### PR TITLE
ci: build & test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: build & test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the same Zig 0.16 the flake pins, so CI matches local dev exactly.
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Build
+        run: nix develop --command zig build
+
+      - name: Test
+        run: nix develop --command zig build test --summary all


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and tests zrk on every push to `main` and on pull requests.

- Runs `zig build` and `zig build test --summary all`
- Matrix: `ubuntu-latest` + `macos-latest`
- Uses `nix develop` so CI runs the exact Zig 0.16 pinned by `flake.nix` (matches local dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)