### PR TITLE
ci: automated release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Cut a release by pushing a version tag:
+#   git tag v0.1.0 && git push origin v0.1.0
+# or run manually from the Actions tab, supplying the tag.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. v0.1.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: build binaries & publish release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Zig cross-compiles every target from this one Linux runner, using the
+      # exact Zig 0.16 the flake pins.
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Resolve version
+        id: ver
+        run: |
+          ref="${{ github.event.inputs.tag || github.ref_name }}"
+          echo "tag=$ref" >> "$GITHUB_OUTPUT"
+          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and package all targets
+        run: |
+          set -euo pipefail
+          version="${{ steps.ver.outputs.version }}"
+          mkdir -p dist
+
+          # zig-target : release-archive-label
+          targets="
+            x86_64-linux-musl:x86_64-linux
+            aarch64-linux-musl:aarch64-linux
+            x86_64-macos:x86_64-macos
+            aarch64-macos:aarch64-macos
+            x86_64-windows-gnu:x86_64-windows
+            aarch64-windows-gnu:aarch64-windows
+          "
+          for pair in $targets; do
+            zig_t="${pair%%:*}"
+            label="${pair##*:}"
+            echo "::group::$label ($zig_t)"
+            nix develop --command zig build \
+              -Dtarget="$zig_t" -Doptimize=ReleaseFast --prefix "out/$label"
+            case "$zig_t" in
+              *windows*)
+                zip -j "dist/zrk-$version-$label.zip" "out/$label/bin/zrk.exe"
+                ;;
+              *)
+                tar czf "dist/zrk-$version-$label.tar.gz" -C "out/$label/bin" zrk
+                ;;
+            esac
+            echo "::endgroup::"
+          done
+
+          ( cd dist && sha256sum * > SHA256SUMS.txt )
+          ls -la dist
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          files: dist/*
+          generate_release_notes: true


### PR DESCRIPTION
Adds `.github/workflows/release.yml` to publish prebuilt binaries automatically.

**Trigger:** push a version tag (`git tag v0.1.0 && git push origin v0.1.0`), or run manually from the Actions tab.

**What it does (single `ubuntu-latest` runner, via Zig cross-compilation):**
- Builds `ReleaseFast` binaries for: `x86_64-linux`, `aarch64-linux` (static musl), `x86_64-macos`, `aarch64-macos`, `x86_64-windows`, `aarch64-windows`
- Packages each as `.tar.gz` (unix) / `.zip` (windows), plus `SHA256SUMS.txt`
- Publishes a GitHub Release with auto-generated notes

All six targets were verified to cross-compile cleanly against the flake-pinned Zig 0.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)