### PR TITLE
feat: read the request body from a file or stdin (-b @FILE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ zrk [options] <url>
                             linearly from A to B over the run (default 1000)
   -H, --header  <K: V>      Add a request header (repeatable)
   -m, --method      <M>     HTTP method                    (default GET)
-  -b, --body        <S>     Request body
+  -b, --body     <S|@FILE>  Request body; @FILE reads it from a file
+                            (@- = stdin, @@x = a literal "@x")
       --timeout     <T>     Per-request timeout            (default 2s)
       --interval    <T>     Dashboard refresh interval     (default 1s)
       --latency             Print full latency spectrum in the final report
@@ -84,6 +85,10 @@ zrk -c20 -d1m -R500 --latency https://api.example.com/health
 
 # POST with a body and custom headers
 zrk -c10 -R100 -m POST -b '{"ping":1}' \
+    -H 'Content-Type: application/json' http://127.0.0.1:8080/echo
+
+# POST a body read from a file (@- reads stdin instead)
+zrk -c10 -R100 -m POST -b @payload.json \
     -H 'Content-Type: application/json' http://127.0.0.1:8080/echo
 
 # CI-friendly, no redrawing dashboard

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -51,6 +51,10 @@ pub const Config = struct {
 
     method: []const u8 = "GET",
     body: []const u8 = "",
+    /// When set (from `-b @FILE`), the caller reads the request body from this
+    /// path and fills in `body`. `"-"` means stdin. Parsing stays pure — the
+    /// file is not read here.
+    body_path: ?[]const u8 = null,
     headers: []const Header = &.{},
 
     /// Print the full latency percentile spectrum in the final report.
@@ -119,7 +123,8 @@ pub const usage =
     \\                            linearly from A to B over the run (default 1000)
     \\  -H, --header  <K: V>      Add a request header (repeatable)
     \\  -m, --method      <M>     HTTP method                    (default GET)
-    \\  -b, --body        <S>     Request body
+    \\  -b, --body     <S|@FILE>  Request body; @FILE reads it from a file
+    \\                            (@- = stdin, @@x = a literal "@x")
     \\      --timeout     <T>     Per-request timeout            (default 2s)
     \\      --interval    <T>     Dashboard refresh interval     (default 1s)
     \\      --latency             Print full latency spectrum in the final report
@@ -217,7 +222,19 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
         } else if (eq(arg, "-m") or eq(arg, "--method")) {
             cfg.method = try nextValue(tokens, &i);
         } else if (eq(arg, "-b") or eq(arg, "--body")) {
-            cfg.body = try nextValue(tokens, &i);
+            const v = try nextValue(tokens, &i);
+            // curl/vegeta convention: a leading '@' reads the body from a file
+            // (`@-` = stdin), and `@@` escapes a body that literally starts '@'.
+            if (v.len >= 2 and v[0] == '@' and v[1] == '@') {
+                cfg.body = v[1..];
+                cfg.body_path = null;
+            } else if (v.len >= 1 and v[0] == '@') {
+                cfg.body_path = v[1..];
+                cfg.body = "";
+            } else {
+                cfg.body = v;
+                cfg.body_path = null;
+            }
         } else if (eq(arg, "-H") or eq(arg, "--header")) {
             try headers.append(arena, try parseHeader(try nextValue(tokens, &i)));
         } else if (arg[0] == '-' and arg.len > 1) {
@@ -473,6 +490,31 @@ test "parse full command line" {
     try testing.expectEqualStrings("application/json", cfg.headers[0].value);
     try testing.expectEqualStrings("127.0.0.1", cfg.url.host);
     try testing.expectEqual(@as(u16, 8080), cfg.url.port);
+}
+
+test "body: inline, @file, @- stdin, and @@ escape" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    // Inline literal is unchanged, with no file reference.
+    const inline_body = (try parse(a, &[_][]const u8{ "-b", "hello", "http://x/" })).config;
+    try testing.expectEqualStrings("hello", inline_body.body);
+    try testing.expectEqual(@as(?[]const u8, null), inline_body.body_path);
+
+    // @FILE records a path and leaves body empty (read happens in the caller).
+    const from_file = (try parse(a, &[_][]const u8{ "-b", "@payload.json", "http://x/" })).config;
+    try testing.expectEqualStrings("payload.json", from_file.body_path.?);
+    try testing.expectEqualStrings("", from_file.body);
+
+    // @- means stdin.
+    const from_stdin = (try parse(a, &[_][]const u8{ "--body", "@-", "http://x/" })).config;
+    try testing.expectEqualStrings("-", from_stdin.body_path.?);
+
+    // @@ escapes to a literal body that starts with '@'.
+    const escaped = (try parse(a, &[_][]const u8{ "-b", "@@handle", "http://x/" })).config;
+    try testing.expectEqualStrings("@handle", escaped.body);
+    try testing.expectEqual(@as(?[]const u8, null), escaped.body_path);
 }
 
 test "parse help flag" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,7 +19,7 @@ pub fn main(init: std.process.Init) !void {
         try printUsageError(io, err);
         std.process.exit(2);
     };
-    const cfg: cli.Config = switch (parsed) {
+    var cfg: cli.Config = switch (parsed) {
         .help => {
             try writeAll(io, .stdout(), cli.usage);
             return;
@@ -30,6 +30,15 @@ pub fn main(init: std.process.Init) !void {
         },
         .config => |c| c,
     };
+
+    // Resolve `-b @FILE` / `-b @-` now that we have I/O; the runner only ever
+    // sees `cfg.body` as raw bytes.
+    if (cfg.body_path) |path| {
+        cfg.body = readBody(arena, io, path) catch |err| {
+            try printBodyError(io, path, err);
+            std.process.exit(2);
+        };
+    }
 
     const json = cfg.format == .json;
 
@@ -113,6 +122,31 @@ fn openOut(io: Io, path: ?[]const u8, close: *bool) !Io.File {
     }
     close.* = false;
     return Io.File.stdout();
+}
+
+/// Upper bound on a request body read from a file/stdin, so a wrong path can't
+/// exhaust memory. 64 MiB is far larger than any realistic load-test payload.
+const max_body_bytes = 64 << 20;
+
+/// Read the request body from `path` (or stdin when `path` is "-"). Returned
+/// bytes live in `arena`.
+fn readBody(arena: std.mem.Allocator, io: Io, path: []const u8) ![]u8 {
+    if (std.mem.eql(u8, path, "-")) {
+        var buf: [4096]u8 = undefined;
+        var fr: Io.File.Reader = .init(.stdin(), io, &buf);
+        var aw: Io.Writer.Allocating = .init(arena);
+        _ = try fr.interface.streamRemaining(&aw.writer);
+        return aw.toOwnedSlice();
+    }
+    return Io.Dir.cwd().readFileAlloc(io, path, arena, .limited(max_body_bytes));
+}
+
+fn printBodyError(io: Io, path: []const u8, err: anyerror) !void {
+    var buf: [512]u8 = undefined;
+    const src = if (std.mem.eql(u8, path, "-")) "stdin" else path;
+    const msg = std.fmt.bufPrint(&buf, "zrk: cannot read body from {s}: {s}\n", .{ src, @errorName(err) }) catch
+        "zrk: cannot read request body\n";
+    try writeAll(io, .stderr(), msg);
 }
 
 fn printSloBreach(io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, slo: report.SloResult) !void {


### PR DESCRIPTION
## Summary

`-b`/`--body` can now read the request body from a file or stdin, following the curl/vegeta `@` convention. Fully backward compatible — inline bodies are unchanged.

| Invocation | Behavior |
|---|---|
| `-b '{"x":1}'` | literal inline body (unchanged) |
| `-b @payload.json` | read body from the file |
| `-b @-` | read body from stdin |
| `-b @@handle` | escape → literal `@handle` |
| `-b @missing.json` | clean error, exit 2 |

## Design

- **`cli.zig`** stays pure: `parse` classifies the `@` prefix into a new `Config.body_path` (`"-"` = stdin) and leaves `body` empty. No I/O in the parser.
- **`main.zig`** resolves `body_path` — reads the file (`readFileAlloc`, 64 MiB cap) or stdin into the arena and fills `cfg.body` before the run; failures exit 2 with a message.
- **`http.buildRequest`** is unchanged: `Content-Length` is derived from the bytes, so binary bodies work for free.

The embeddable `runner.run` still only ever sees `cfg.body` as raw bytes — the `@file` sugar is entirely in the CLI layer, so the library gains no filesystem dependency.

## Testing
- `zig build test` — **110/110 pass**. New pure unit test covers all four `@` forms.
- Smoke-tested end to end against a socket capture: `@file` (Content-Length 28), `@-` stdin (20), `@@` escape (7), and the missing-file error (exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
