### PR TITLE
feat: --timeseries-histogram embeds each interval's HDR blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ zrk [options] <url>
                             distribution (.hgrm) to FILE
       --timeseries  <FILE>  Stream per-interval NDJSON (throughput +
                             latency percentiles) to FILE
+      --timeseries-histogram  Add each interval's full latency histogram
+                            (HdrHistogram base64) to every --timeseries row
       --no-record-timeouts  Drop timed-out requests from the latency histogram
                             (default: record them, so the tail isn't truncated)
 
@@ -161,6 +163,13 @@ This is the artifact a **ramp** (`-R A:B`) exists to produce: a curve of latency
 against offered load, so you can find the rate at which the server's tail breaks
 down. (The final summary's aggregate percentiles blend the whole ramp together,
 so they're less useful for a ramp than the time series is.)
+
+Add `--timeseries-histogram` to append each interval's **full** latency
+distribution as an HdrHistogram V2 base64 blob (`latency_histogram`) to every
+row. Each blob decodes losslessly, so a harness can re-percentile a single
+interval or merge any subset of them — e.g. just the windows above a target
+rate. Merging every row reproduces the run's summary histogram exactly, since
+the intervals partition the run. (Rows get noticeably larger, so it is opt-in.)
 
 Timed-out requests are recorded into the latency histogram by default (as a
 coordinated-omission-corrected sample) so the tail isn't silently truncated;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -74,6 +74,9 @@ pub const Config = struct {
     /// If set, stream one NDJSON object per `--interval` with that window's
     /// throughput and latency percentiles (a time series, ideal for ramps).
     timeseries_path: ?[]const u8 = null,
+    /// Augment each `--timeseries` row with that interval's full latency
+    /// distribution as an HdrHistogram V2 base64 blob (lossless, mergeable).
+    timeseries_histogram: bool = false,
 
     /// Record a (coordinated-omission-corrected) latency sample for requests
     /// that hit `--timeout`, so the tail isn't silently truncated. On by
@@ -138,6 +141,8 @@ pub const usage =
     \\                            distribution (.hgrm) to FILE
     \\      --timeseries  <FILE>  Stream per-interval NDJSON (throughput +
     \\                            latency percentiles) to FILE
+    \\      --timeseries-histogram  Add each interval's full latency histogram
+    \\                            (HdrHistogram base64) to every --timeseries row
     \\      --no-record-timeouts  Drop timed-out requests from the latency
     \\                            histogram (default: record them)
     \\
@@ -201,6 +206,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.hdr_path = try nextValue(tokens, &i);
         } else if (eq(arg, "--timeseries")) {
             cfg.timeseries_path = try nextValue(tokens, &i);
+        } else if (eq(arg, "--timeseries-histogram")) {
+            cfg.timeseries_histogram = true;
         } else if (eq(arg, "--slo-p99")) {
             cfg.slo_p99_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--max-error-rate")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,7 +61,10 @@ pub fn main(init: std.process.Init) !void {
         ts_obj = try report.TimeSeries.init(arena, &ts_fw.interface, &cfg);
         ts_ptr = &ts_obj;
     }
-    defer if (cfg.timeseries_path != null) ts_file.close(io);
+    defer if (cfg.timeseries_path != null) {
+        ts_obj.deinit();
+        ts_file.close(io);
+    };
 
     var progress: Progress = .{ .dash = if (json) null else &dash, .ts = ts_ptr };
     const active = progress.dash != null or progress.ts != null;

--- a/src/report.zig
+++ b/src/report.zig
@@ -136,6 +136,10 @@ pub const TimeSeries = struct {
     prev_cum: hdr.Histogram,
     /// Scratch histogram holding the current interval's delta.
     delta: hdr.Histogram,
+    /// Reset (retaining capacity) after each row's base64 encoding, so the
+    /// transient encode buffers never accumulate in the caller's arena when
+    /// `--timeseries-histogram` is on. Backed by the page allocator.
+    scratch: std.heap.ArenaAllocator,
     prev_completed: u64 = 0,
     prev_errors: u64 = 0,
     prev_elapsed_s: f64 = 0,
@@ -146,7 +150,14 @@ pub const TimeSeries = struct {
             .cfg = cfg,
             .prev_cum = try stats.newHistogram(arena),
             .delta = try stats.newHistogram(arena),
+            .scratch = .init(std.heap.page_allocator),
         };
+    }
+
+    pub fn deinit(self: *TimeSeries) void {
+        self.prev_cum.deinit();
+        self.delta.deinit();
+        self.scratch.deinit();
     }
 
     /// Offered *total* target rate (req/s) at elapsed `t_s`, honoring a ramp.
@@ -173,7 +184,7 @@ pub const TimeSeries = struct {
 
         try self.w.print(
             "{{\"t\":{d:.3},\"target_rate\":{d:.1},\"achieved_rate\":{d:.1},\"requests\":{d},\"errors\":{d}," ++
-                "\"latency_us\":{{\"p50\":{d},\"p90\":{d},\"p99\":{d},\"p99_9\":{d},\"max\":{d}}}}}\n",
+                "\"latency_us\":{{\"p50\":{d},\"p90\":{d},\"p99\":{d},\"p99_9\":{d},\"max\":{d}}}",
             .{
                 elapsed_s,                 self.targetRate(elapsed_s),
                 achieved,                  d_completed,
@@ -182,8 +193,19 @@ pub const TimeSeries = struct {
                 h.valueAtPercentile(99.9), h.max(),
             },
         );
+
+        // Optional: the interval's full distribution, losslessly mergeable.
+        // Encoded into the scratch arena, which we reset once the bytes have
+        // been copied into the writer by `print`.
+        if (self.cfg.timeseries_histogram) {
+            const b64 = try h.encodeBase64(self.scratch.allocator());
+            try self.w.print(",\"latency_histogram\":\"{s}\"", .{b64});
+            _ = self.scratch.reset(.retain_capacity);
+        }
+
         // Flush every line so the series is durable even if a later SLO gate
         // exits the process (which skips deferred cleanup).
+        try self.w.writeAll("}\n");
         try self.w.flush();
 
         snap.hist.copyInto(&self.prev_cum);
@@ -269,6 +291,57 @@ test "writeJson emits parseable, well-formed summary" {
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_us\"") != null);
     // The embedded HdrHistogram blob is present and decodes back to 100 samples.
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_histogram\": \"HIST") != null);
+}
+
+test "time series row carries the interval HDR blob when enabled" {
+    var cfg = testConfig();
+    cfg.timeseries_histogram = true;
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var ts = try TimeSeries.init(testing.allocator, &alloc.writer, &cfg);
+    defer ts.deinit();
+
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+    var i: u64 = 0;
+    while (i < 50) : (i += 1) snap.hist.record(1000 + i);
+    snap.counters.completed = 50;
+
+    try ts.record(&snap, 1.0);
+    const out = alloc.written();
+    try testing.expect(std.mem.indexOf(u8, out, "\"latency_us\":{") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"latency_histogram\":\"HIST") != null);
+    try testing.expect(std.mem.endsWith(u8, out, "}\n"));
+
+    // The blob decodes back to this interval's 50 samples.
+    const start = std.mem.indexOf(u8, out, "HIST").?;
+    const end = std.mem.indexOfScalarPos(u8, out, start, '"').?;
+    var decoded = try hdr.decodeBase64(testing.allocator, out[start..end]);
+    defer decoded.deinit();
+    try testing.expectEqual(@as(u64, 50), decoded.count());
+}
+
+test "time series omits the HDR blob by default" {
+    const cfg = testConfig(); // timeseries_histogram defaults false
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var ts = try TimeSeries.init(testing.allocator, &alloc.writer, &cfg);
+    defer ts.deinit();
+
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+    snap.hist.record(1234);
+    snap.counters.completed = 1;
+
+    try ts.record(&snap, 1.0);
+    try testing.expect(std.mem.indexOf(u8, alloc.written(), "latency_histogram") == null);
 }
 
 test "errorRate and checkSlo gates" {


### PR DESCRIPTION
## Summary

Adds `--timeseries-histogram`: each `--timeseries` NDJSON row gains a `latency_histogram` field carrying that interval's **full** latency distribution as an HdrHistogram V2 compressed base64 blob, alongside the existing percentile summary.

```json
{"t":2.002,...,"latency_us":{"p50":102,...},"latency_histogram":"HISTFAAAAIp4nC1M0RGC..."}
```

Each blob decodes losslessly (`hdr.decodeBase64`), so a harness can re-percentile a single interval or **merge any subset** of them (e.g. only windows above a target rate). Merging every row reproduces the run's summary histogram exactly, since the intervals partition the run.

## Why it's small

`TimeSeries.record` already computed the per-interval delta histogram (`setToDifference`) just to pull five percentiles from it — this encodes that same histogram. Two design points:

- **Opt-in**, because a blob adds a few hundred bytes to a few KB per row; the default rows stay lean.
- **Bounded memory**: encoding uses a page-allocator-backed scratch `ArenaAllocator` inside `TimeSeries`, reset (retaining capacity) after each row — so the transient encode buffers never accumulate in the caller's never-freeing process arena over a long run.

## Testing
- `zig build test` — **114/114 pass**. New tests: a row with the blob present that **decodes back to the interval's sample count**, and a default row that omits the field.
- Smoke-tested a 3s run: every row carries a blob; the first blob's framing verified byte-exact (`1c 84 93 14` compressed cookie + `78 9c` zlib header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
