### PR TITLE
fix: HEAD and 304 responses carry no body — keep the connection framed

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -86,6 +86,8 @@ pub const Params = struct {
     address: net.IpAddress,
     host: []const u8,
     request: []const u8,
+    /// True when the request method is HEAD, whose responses have no body.
+    is_head: bool = false,
     is_tls: bool,
     insecure: bool,
     /// Send schedule for THIS connection (constant spacing or a linear ramp).
@@ -315,7 +317,7 @@ fn performWork(p: *Params, app_reader: *Io.Reader, app_writer: *Io.Writer) WorkR
     // For TLS the app writer only encrypts into the socket writer's buffer; the
     // underlying stream writer must be flushed to actually send the ciphertext.
     if (p.is_tls) p.tls_state.?.swriter.interface.flush() catch return .write_failed;
-    const resp = httpmod.parseResponse(app_reader) catch return .read_failed;
+    const resp = httpmod.parseResponse(app_reader, p.is_head) catch return .read_failed;
     return .{ .ok = resp };
 }
 
@@ -452,6 +454,77 @@ test "run drives keep-alive requests against a local server" {
     try testing.expectEqual(counters.completed, histogram.count());
     // Every response is fully consumed and counted (headers + body).
     try testing.expectEqual(counters.completed * response_len, counters.bytes);
+}
+
+/// Serves HEAD-style responses: headers advertising a Content-Length that has
+/// no body following it, as RFC 9112 §6.3 prescribes for HEAD.
+fn headServe(io: Io, server: *net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    var rbuf: [4096]u8 = undefined;
+    var wbuf: [4096]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    const response = "HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n";
+    while (true) {
+        while (true) {
+            const line = r.interface.takeDelimiterInclusive('\n') catch return;
+            if (line.len <= 2) break;
+        }
+        w.interface.writeAll(response) catch return;
+        w.interface.flush() catch return;
+    }
+}
+
+test "run keeps HEAD responses framed despite Content-Length" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    group.async(io, headServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(200));
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "HEAD / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        .is_head = true,
+        .is_tls = false,
+        .insecure = false,
+        .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } },
+        // Short response timeout so a framing regression fails fast (as
+        // timeouts) instead of hanging the test on a body that never comes.
+        .timeout_ns = 100 * std.time.ns_per_ms,
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Without HEAD awareness the parser would wait for 1234 body bytes that
+    // never arrive: zero completions, all timeouts. With it, the keep-alive
+    // connection serves many requests.
+    try testing.expect(counters.completed > 1);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    try testing.expectEqual(@as(u64, 0), counters.read_errors);
 }
 
 /// Accepts one connection, reads the request, then holds the connection open

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -385,19 +385,24 @@ fn testServe(io: Io, server: *net.Server) void {
     stream.close(io);
 }
 
+/// Consume one request's header lines through the terminating blank line (the
+/// test client sends no bodies). Errors when the peer closes the connection.
+fn discardRequestHead(r: *Io.Reader) !void {
+    while (true) {
+        const line = try r.takeDelimiterInclusive('\n');
+        if (line.len <= 2) return; // "\r\n" or "\n": end of headers
+    }
+}
+
 fn serveConn(io: Io, stream: *net.Stream) void {
     var rbuf: [4096]u8 = undefined;
     var wbuf: [4096]u8 = undefined;
     var r = stream.reader(io, &rbuf);
     var w = stream.writer(io, &wbuf);
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+    // One response per request until the client closes the connection.
     while (true) {
-        // Consume one request (headers up to the blank line); the client sends
-        // no body.
-        while (true) {
-            const line = r.interface.takeDelimiterInclusive('\n') catch return;
-            if (line.len <= 2) break; // "\r\n" or "\n": end of headers
-        }
+        discardRequestHead(&r.interface) catch return;
         w.interface.writeAll(response) catch return;
         w.interface.flush() catch return;
     }
@@ -466,11 +471,9 @@ fn headServe(io: Io, server: *net.Server) void {
     var r = stream.reader(io, &rbuf);
     var w = stream.writer(io, &wbuf);
     const response = "HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n";
+    // One response per request until the client closes the connection.
     while (true) {
-        while (true) {
-            const line = r.interface.takeDelimiterInclusive('\n') catch return;
-            if (line.len <= 2) break;
-        }
+        discardRequestHead(&r.interface) catch return;
         w.interface.writeAll(response) catch return;
         w.interface.flush() catch return;
     }
@@ -534,10 +537,7 @@ fn stallServe(io: Io, server: *net.Server) void {
     defer stream.close(io);
     var rbuf: [4096]u8 = undefined;
     var r = stream.reader(io, &rbuf);
-    while (true) {
-        const line = r.interface.takeDelimiterInclusive('\n') catch return;
-        if (line.len <= 2) break;
-    }
+    discardRequestHead(&r.interface) catch return;
     io.sleep(Io.Duration.fromSeconds(30), .awake) catch {};
 }
 

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -86,8 +86,9 @@ pub const Params = struct {
     address: net.IpAddress,
     host: []const u8,
     request: []const u8,
-    /// True when the request method is HEAD, whose responses have no body.
-    is_head: bool = false,
+    /// Framing classification of the request method (HEAD responses have no
+    /// body); see `http.RequestMethod`.
+    method: httpmod.RequestMethod = .other,
     is_tls: bool,
     insecure: bool,
     /// Send schedule for THIS connection (constant spacing or a linear ramp).
@@ -317,7 +318,7 @@ fn performWork(p: *Params, app_reader: *Io.Reader, app_writer: *Io.Writer) WorkR
     // For TLS the app writer only encrypts into the socket writer's buffer; the
     // underlying stream writer must be flushed to actually send the ciphertext.
     if (p.is_tls) p.tls_state.?.swriter.interface.flush() catch return .write_failed;
-    const resp = httpmod.parseResponse(app_reader, p.is_head) catch return .read_failed;
+    const resp = httpmod.parseResponse(app_reader, p.method) catch return .read_failed;
     return .{ .ok = resp };
 }
 
@@ -505,7 +506,7 @@ test "run keeps HEAD responses framed despite Content-Length" {
         .address = server_addr,
         .host = "127.0.0.1",
         .request = "HEAD / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
-        .is_head = true,
+        .method = .head,
         .is_tls = false,
         .insecure = false,
         .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } },

--- a/src/http.zig
+++ b/src/http.zig
@@ -83,9 +83,11 @@ pub const ParseError = error{
 };
 
 /// Parse one HTTP/1.1 response from `r`, consuming its full body so the reader
-/// is positioned at the start of the next response. `r`'s buffer capacity must
-/// be large enough to hold the longest single header line.
-pub fn parseResponse(r: *Io.Reader) ParseError!Response {
+/// is positioned at the start of the next response. `head` must be true when
+/// the request was HEAD: those responses carry framing headers describing the
+/// body they *would* have, but never the body itself (RFC 9112 §6.3). `r`'s
+/// buffer capacity must be large enough to hold the longest single header line.
+pub fn parseResponse(r: *Io.Reader, head: bool) ParseError!Response {
     var bytes: u64 = 0;
 
     // Status line: "HTTP/1.1 200 OK\r\n"
@@ -119,17 +121,20 @@ pub fn parseResponse(r: *Io.Reader) ParseError!Response {
         }
     }
 
-    // Body.
-    if (chunked) {
+    // Body. HEAD responses and 1xx/204/304 statuses never carry one, whatever
+    // Content-Length or Transfer-Encoding claim (RFC 9112 §6.3) — consuming a
+    // body there would eat into the next response and break framing.
+    const bodyless = head or status == 204 or status == 304 or status / 100 == 1;
+    if (bodyless) {
+        // Nothing to consume.
+    } else if (chunked) {
         try consumeChunkedBody(r, &bytes);
     } else if (content_length) |len| {
         discard(r, len, &bytes) catch return error.UnexpectedEof;
     } else {
-        // No framing info. For 1xx/204/304 there is no body; otherwise the body
-        // runs to connection close, which precludes keep-alive.
-        if (status != 204 and status != 304 and status / 100 != 1) {
-            keep_alive = false;
-        }
+        // No framing info: the body runs to connection close, which precludes
+        // keep-alive.
+        keep_alive = false;
     }
 
     return .{ .status = status, .bytes = bytes, .keep_alive = keep_alive };
@@ -229,7 +234,7 @@ test "buildRequest with non-default port, method, body, headers" {
 test "parseResponse content-length" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Type: text/plain\r\n\r\nhello";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r);
+    const resp = try parseResponse(&r, false);
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expect(resp.keep_alive);
     try testing.expectEqual(@as(u64, raw.len), resp.bytes);
@@ -240,9 +245,9 @@ test "parseResponse two pipelined responses stay framed" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi" ++
         "HTTP/1.1 404 Not Found\r\nContent-Length: 3\r\n\r\nno!";
     var r = Io.Reader.fixed(raw);
-    const first = try parseResponse(&r);
+    const first = try parseResponse(&r, false);
     try testing.expectEqual(@as(u16, 200), first.status);
-    const second = try parseResponse(&r);
+    const second = try parseResponse(&r, false);
     try testing.expectEqual(@as(u16, 404), second.status);
     try testing.expectEqual(StatusClass.client_error, StatusClass.of(second.status));
 }
@@ -251,7 +256,7 @@ test "parseResponse chunked" {
     const raw = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" ++
         "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r);
+    const resp = try parseResponse(&r, false);
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expect(resp.keep_alive);
     try testing.expectEqual(@as(u64, raw.len), resp.bytes);
@@ -260,21 +265,57 @@ test "parseResponse chunked" {
 test "parseResponse connection close disables keep-alive" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r);
+    const resp = try parseResponse(&r, false);
     try testing.expect(!resp.keep_alive);
 }
 
 test "parseResponse http/1.0 defaults to no keep-alive" {
     const raw = "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r);
+    const resp = try parseResponse(&r, false);
     try testing.expect(!resp.keep_alive);
+}
+
+test "parseResponse HEAD ignores Content-Length and stays framed" {
+    // HEAD responses advertise the entity's Content-Length but carry no body;
+    // two back-to-back responses must parse cleanly without consuming "body"
+    // bytes that don't exist.
+    const one = "HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n";
+    const raw = one ++ "HTTP/1.1 404 Not Found\r\nContent-Length: 99\r\n\r\n";
+    var r = Io.Reader.fixed(raw);
+    const first = try parseResponse(&r, true);
+    try testing.expectEqual(@as(u16, 200), first.status);
+    try testing.expect(first.keep_alive);
+    try testing.expectEqual(@as(u64, one.len), first.bytes);
+    const second = try parseResponse(&r, true);
+    try testing.expectEqual(@as(u16, 404), second.status);
+}
+
+test "parseResponse HEAD ignores chunked transfer-encoding" {
+    const raw = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
+    var r = Io.Reader.fixed(raw);
+    const resp = try parseResponse(&r, true);
+    try testing.expectEqual(@as(u16, 200), resp.status);
+    try testing.expect(resp.keep_alive);
+    try testing.expectEqual(@as(u64, raw.len), resp.bytes);
+}
+
+test "parseResponse 304 with Content-Length has no body" {
+    const one = "HTTP/1.1 304 Not Modified\r\nContent-Length: 5678\r\n\r\n";
+    const raw = one ++ "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+    var r = Io.Reader.fixed(raw);
+    const first = try parseResponse(&r, false);
+    try testing.expectEqual(@as(u16, 304), first.status);
+    try testing.expect(first.keep_alive);
+    try testing.expectEqual(@as(u64, one.len), first.bytes);
+    const second = try parseResponse(&r, false);
+    try testing.expectEqual(@as(u16, 200), second.status);
 }
 
 test "parseResponse 204 no body" {
     const raw = "HTTP/1.1 204 No Content\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r);
+    const resp = try parseResponse(&r, false);
     try testing.expectEqual(@as(u16, 204), resp.status);
     try testing.expect(resp.keep_alive);
 }

--- a/src/http.zig
+++ b/src/http.zig
@@ -82,12 +82,26 @@ pub const ParseError = error{
     ReadFailed,
 };
 
+/// The one method distinction response parsing needs: responses to HEAD carry
+/// framing headers describing the body a GET would have returned, but never
+/// the body itself (RFC 9112 §6.3). Every other method — including arbitrary
+/// `-m` strings zrk passes through verbatim — frames normally.
+pub const RequestMethod = enum {
+    other,
+    head,
+
+    /// Classify a raw method string (methods are case-sensitive per RFC 9110,
+    /// but we accept any casing of HEAD rather than misframe the response).
+    pub fn of(method: []const u8) RequestMethod {
+        return if (std.ascii.eqlIgnoreCase(method, "HEAD")) .head else .other;
+    }
+};
+
 /// Parse one HTTP/1.1 response from `r`, consuming its full body so the reader
-/// is positioned at the start of the next response. `head` must be true when
-/// the request was HEAD: those responses carry framing headers describing the
-/// body they *would* have, but never the body itself (RFC 9112 §6.3). `r`'s
-/// buffer capacity must be large enough to hold the longest single header line.
-pub fn parseResponse(r: *Io.Reader, head: bool) ParseError!Response {
+/// is positioned at the start of the next response. `method` is the request's
+/// framing classification (see `RequestMethod`). `r`'s buffer capacity must be
+/// large enough to hold the longest single header line.
+pub fn parseResponse(r: *Io.Reader, method: RequestMethod) ParseError!Response {
     var bytes: u64 = 0;
 
     // Status line: "HTTP/1.1 200 OK\r\n"
@@ -124,7 +138,7 @@ pub fn parseResponse(r: *Io.Reader, head: bool) ParseError!Response {
     // Body. HEAD responses and 1xx/204/304 statuses never carry one, whatever
     // Content-Length or Transfer-Encoding claim (RFC 9112 §6.3) — consuming a
     // body there would eat into the next response and break framing.
-    const bodyless = head or status == 204 or status == 304 or status / 100 == 1;
+    const bodyless = method == .head or status == 204 or status == 304 or status / 100 == 1;
     if (bodyless) {
         // Nothing to consume.
     } else if (chunked) {
@@ -234,7 +248,7 @@ test "buildRequest with non-default port, method, body, headers" {
 test "parseResponse content-length" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Type: text/plain\r\n\r\nhello";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, false);
+    const resp = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expect(resp.keep_alive);
     try testing.expectEqual(@as(u64, raw.len), resp.bytes);
@@ -245,9 +259,9 @@ test "parseResponse two pipelined responses stay framed" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi" ++
         "HTTP/1.1 404 Not Found\r\nContent-Length: 3\r\n\r\nno!";
     var r = Io.Reader.fixed(raw);
-    const first = try parseResponse(&r, false);
+    const first = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 200), first.status);
-    const second = try parseResponse(&r, false);
+    const second = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 404), second.status);
     try testing.expectEqual(StatusClass.client_error, StatusClass.of(second.status));
 }
@@ -256,7 +270,7 @@ test "parseResponse chunked" {
     const raw = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" ++
         "4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, false);
+    const resp = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expect(resp.keep_alive);
     try testing.expectEqual(@as(u64, raw.len), resp.bytes);
@@ -265,15 +279,22 @@ test "parseResponse chunked" {
 test "parseResponse connection close disables keep-alive" {
     const raw = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, false);
+    const resp = try parseResponse(&r, .other);
     try testing.expect(!resp.keep_alive);
 }
 
 test "parseResponse http/1.0 defaults to no keep-alive" {
     const raw = "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, false);
+    const resp = try parseResponse(&r, .other);
     try testing.expect(!resp.keep_alive);
+}
+
+test "RequestMethod.of classifies HEAD case-insensitively" {
+    try testing.expectEqual(RequestMethod.head, RequestMethod.of("HEAD"));
+    try testing.expectEqual(RequestMethod.head, RequestMethod.of("head"));
+    try testing.expectEqual(RequestMethod.other, RequestMethod.of("GET"));
+    try testing.expectEqual(RequestMethod.other, RequestMethod.of("PROPPATCH"));
 }
 
 test "parseResponse HEAD ignores Content-Length and stays framed" {
@@ -283,18 +304,18 @@ test "parseResponse HEAD ignores Content-Length and stays framed" {
     const one = "HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n";
     const raw = one ++ "HTTP/1.1 404 Not Found\r\nContent-Length: 99\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const first = try parseResponse(&r, true);
+    const first = try parseResponse(&r, .head);
     try testing.expectEqual(@as(u16, 200), first.status);
     try testing.expect(first.keep_alive);
     try testing.expectEqual(@as(u64, one.len), first.bytes);
-    const second = try parseResponse(&r, true);
+    const second = try parseResponse(&r, .head);
     try testing.expectEqual(@as(u16, 404), second.status);
 }
 
 test "parseResponse HEAD ignores chunked transfer-encoding" {
     const raw = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, true);
+    const resp = try parseResponse(&r, .head);
     try testing.expectEqual(@as(u16, 200), resp.status);
     try testing.expect(resp.keep_alive);
     try testing.expectEqual(@as(u64, raw.len), resp.bytes);
@@ -304,18 +325,18 @@ test "parseResponse 304 with Content-Length has no body" {
     const one = "HTTP/1.1 304 Not Modified\r\nContent-Length: 5678\r\n\r\n";
     const raw = one ++ "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
     var r = Io.Reader.fixed(raw);
-    const first = try parseResponse(&r, false);
+    const first = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 304), first.status);
     try testing.expect(first.keep_alive);
     try testing.expectEqual(@as(u64, one.len), first.bytes);
-    const second = try parseResponse(&r, false);
+    const second = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 200), second.status);
 }
 
 test "parseResponse 204 no body" {
     const raw = "HTTP/1.1 204 No Content\r\n\r\n";
     var r = Io.Reader.fixed(raw);
-    const resp = try parseResponse(&r, false);
+    const resp = try parseResponse(&r, .other);
     try testing.expectEqual(@as(u16, 204), resp.status);
     try testing.expect(resp.keep_alive);
 }

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -75,6 +75,7 @@ pub fn run(
         .address = address,
         .host = cfg.url.host,
         .request = request,
+        .is_head = std.ascii.eqlIgnoreCase(cfg.method, "HEAD"),
         .is_tls = cfg.url.isTls(),
         .insecure = cfg.insecure,
         .schedule = schedule,

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -75,7 +75,7 @@ pub fn run(
         .address = address,
         .host = cfg.url.host,
         .request = request,
-        .is_head = std.ascii.eqlIgnoreCase(cfg.method, "HEAD"),
+        .method = .of(cfg.method),
         .is_tls = cfg.url.isTls(),
         .insecure = cfg.insecure,
         .schedule = schedule,


### PR DESCRIPTION
## Problem

`parseResponse` consumed a body whenever `Content-Length` or `Transfer-Encoding` said so. But per RFC 9112 §6.3, responses to **HEAD** requests and **304** responses advertise the entity's framing headers *without* carrying the body — servers normally include `Content-Length` on HEAD responses describing the body a GET would have returned.

The parser would block waiting for body bytes that never arrive, so:

- `zrk -m HEAD <url>` stalled on every request until the watchdog shut the connection down → the benchmark reported ~100% timeouts against a perfectly healthy server.
- Any 304 that included `Content-Length` desynced the keep-alive framing the same way (the existing 204/304 exemption only lived in the *no-framing-info* branch).

## Fix

- `parseResponse` now takes `http.RequestMethod` (`enum { other, head }` — the one bit of method semantics framing needs; a full method enum would fight zrk's free-form `-m` pass-through) and treats HEAD / 1xx / 204 / 304 responses as bodyless regardless of `Content-Length` / `Transfer-Encoding`.
- `RequestMethod.of` classifies the raw method string case-insensitively, keeping the RFC knowledge in `http.zig`.
- `connection.Params` gains `method`; the runner derives it once per run from `cfg.method`.

## Tests

- Two pipelined HEAD responses with `Content-Length` parse cleanly and stay framed (bytes = headers only, keep-alive preserved).
- HEAD with `Transfer-Encoding: chunked` is not consumed as a chunked body.
- 304 with `Content-Length` followed by a normal 200 stays framed.
- `RequestMethod.of` classification (case-insensitive HEAD, custom methods → `.other`).
- End-to-end `connection.run` test against a local HEAD-style server: completions > 1, zero timeouts/read errors. (Uses a short watchdog timeout so a framing regression fails fast instead of hanging the test.)

123/123 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg