### PR TITLE
fix: honor -o/--output in text mode

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -79,6 +79,10 @@ pub fn main(init: std.process.Init) !void {
 
     if (json) {
         try writeJsonReport(arena, io, &cfg, &snapshot, result.elapsed_s, result.launched);
+    } else if (cfg.output_path) |path| {
+        // Text report redirected to --output; leave a breadcrumb on stdout.
+        try writeTextReport(io, &dash, path, &snapshot, result.elapsed_s);
+        try dash.finalRedirected(path);
     } else {
         try dash.final(&snapshot, result.elapsed_s);
     }
@@ -94,6 +98,16 @@ pub fn main(init: std.process.Init) !void {
         try printSloBreach(io, &cfg, &snapshot, slo);
         std.process.exit(3);
     }
+}
+
+/// Write the wrk2-style text report to `--output` (text mode with -o set).
+fn writeTextReport(io: Io, dash: *tui.Dashboard, path: []const u8, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+    const file = try Io.Dir.cwd().createFile(io, path, .{});
+    defer file.close(io);
+    var buf: [8192]u8 = undefined;
+    var fw: Io.File.Writer = .init(file, io, &buf);
+    try dash.writeReport(&fw.interface, snap, elapsed_s);
+    try fw.interface.flush();
 }
 
 /// Write the JSON summary to `--output` (or stdout when unset).

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -139,12 +139,26 @@ pub const Dashboard = struct {
         }
     }
 
-    /// Print the wrk2-style final report. Aggregates should come from
-    /// `Fleet.readFinal` (post-join).
+    /// Print the wrk2-style final report to stdout. Aggregates should come
+    /// from `Fleet.readFinal` (post-join).
     pub fn final(self: *Dashboard, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+        if (self.tui) try self.writer().writeAll("\x1b[H\x1b[2J");
+        try self.writeReport(self.writer(), snap, elapsed_s);
+        try self.fw.interface.flush();
+    }
+
+    /// Settle the terminal when the final report went to `--output` instead of
+    /// stdout: clear the live TUI (if any) and leave a pointer to the file.
+    pub fn finalRedirected(self: *Dashboard, path: []const u8) !void {
         const w = self.writer();
         if (self.tui) try w.writeAll("\x1b[H\x1b[2J");
+        try w.print("Report written to {s}\n", .{path});
+        try self.fw.interface.flush();
+    }
 
+    /// Render the wrk2-style final report to any writer (stdout, or the
+    /// `--output` file in text mode). Does not flush.
+    pub fn writeReport(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, elapsed_s: f64) !void {
         const c = snap.counters;
         const rps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.completed)) / elapsed_s else 0;
         const bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
@@ -178,8 +192,6 @@ pub const Dashboard = struct {
         try w.writeAll("Transfer/sec: ");
         try writeBytes(w, bps);
         try w.writeAll("\n");
-
-        try self.fw.interface.flush();
     }
 
     /// The `--latency` detailed percentile spectrum.
@@ -230,4 +242,36 @@ fn writeBytes(w: *Io.Writer, bytes: f64) !void {
     } else {
         try w.print("{d:.2}{s}", .{ v, units[i] });
     }
+}
+
+// --- tests -------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "writeReport renders the wrk2-style summary to any writer" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const cfg = cli.Config{ .url = try cli.parseUrl("http://127.0.0.1:8080/") };
+    var dash_buf: [1024]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, &dash_buf);
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 100;
+    snap.counters.bytes = 5000;
+    snap.counters.recordStatus(200);
+
+    var out = Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    try dash.writeReport(&out.writer, &snap, 2.0);
+    const text = out.written();
+
+    try testing.expect(std.mem.indexOf(u8, text, "Latency (corrected for coordinated omission)") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "100 requests in 2.00s") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Requests/sec: 50.00") != null);
+    // No terminal control sequences in the redirectable report.
+    try testing.expect(std.mem.indexOf(u8, text, "\x1b") == null);
 }


### PR DESCRIPTION
Finding #4 from the code-review series.

## Problem

Usage/README promise `-o, --output <FILE>  Write the final report to FILE (default stdout)` unconditionally, but only the JSON path honored it. In text mode the flag was silently ignored — the final report always went to stdout through the Dashboard's writer.

## Fix

Redirect semantics (matching the documented behavior): with `--format text -o FILE`,

- the live dashboard still runs on stdout during the test (TUI or `--plain` lines as usual),
- the final wrk2-style report is written to FILE,
- the terminal gets a one-line `Report written to FILE` breadcrumb at the end (clearing the TUI first, as `final` did).

Mechanically, the report rendering moved out of `Dashboard.final` into `Dashboard.writeReport(w, ...)`, which targets any writer and never emits terminal escape sequences; `final` (stdout) and the new `writeTextReport` (file) both call it.

## Tests / verification

- New unit test: `writeReport` renders the summary into an in-memory writer (latency section, request count, `Requests/sec`) with no `\x1b` control bytes.
- Verified end-to-end against a local server: 50/50 requests completed, report file contains the full summary, stdout shows the dashboard lines plus the breadcrumb, exit 0.

130/130 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg