### PR TITLE
feat!: remove the -t/--threads flag — it never did anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ zig build test            # run the unit + integration tests
 ```
 zrk [options] <url>
 
-  -t, --threads     <N>     Number of worker threads       (default 2)
   -c, --connections <N>     Total connections to keep open (default 10)
   -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
   -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
@@ -70,13 +69,16 @@ zrk [options] <url>
 ```
 
 Durations accept `us`, `ms`, `s`, `m`, `h` (a bare number is seconds).
-Short options may be attached (`-t4`, `-c100`) or separated (`-t 4`).
+Short options may be attached (`-c100`) or separated (`-c 100`).
+
+Unlike wrk2 there is no `-t/--threads`: each connection runs on its own
+worker, so `-c` alone controls concurrency.
 
 ### Examples
 
 ```sh
 # 2000 req/s for 30s over 100 connections
-zrk -t2 -c100 -d30s -R2000 http://127.0.0.1:8080/
+zrk -c100 -d30s -R2000 http://127.0.0.1:8080/
 
 # Ramp linearly from 100 to 5000 req/s over 60s, capturing the latency-vs-load
 # curve as a per-interval NDJSON time series (find the knee where latency breaks)
@@ -117,7 +119,7 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
 {
   "zrk_version": "0.1.0",
   "target": { "url": "http://127.0.0.1:8080/", "method": "GET" },
-  "config": { "connections": 50, "threads": 2, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "record_timeouts": true },
+  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "record_timeouts": true },
   "duration_s": 20.002,
   "requests": 19998,
   "bytes": 1239876,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -34,7 +34,6 @@ pub const Header = struct {
 };
 
 pub const Config = struct {
-    threads: u32 = 2,
     connections: u32 = 10,
     /// Total test duration.
     duration_ns: u64 = 10 * std.time.ns_per_s,
@@ -101,7 +100,6 @@ pub const ParseError = error{
     InvalidHeader,
     InvalidFormat,
     ZeroConnections,
-    ZeroThreads,
     ZeroRate,
     OutOfMemory,
 };
@@ -119,7 +117,6 @@ pub const usage =
     \\Usage: zrk [options] <url>
     \\
     \\Options:
-    \\  -t, --threads     <N>     Number of worker threads       (default 2)
     \\  -c, --connections <N>     Total connections to keep open (default 10)
     \\  -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
     \\  -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
@@ -155,8 +152,8 @@ pub const usage =
     \\
 ;
 
-/// Short options that take a value, so `-t2` can be split into `-t 2`.
-const value_short_opts = "tcdRHmbo";
+/// Short options that take a value, so `-c100` can be split into `-c 100`.
+const value_short_opts = "cdRHmbo";
 
 /// Parse argv (excluding the program name). Header slices and the header array
 /// are allocated from `arena`; string values point into `args` (borrowed).
@@ -212,8 +209,6 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.slo_p99_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--max-error-rate")) {
             cfg.max_error_rate = try parseErrorRate(try nextValue(tokens, &i));
-        } else if (eq(arg, "-t") or eq(arg, "--threads")) {
-            cfg.threads = try parseU32(try nextValue(tokens, &i));
         } else if (eq(arg, "-c") or eq(arg, "--connections")) {
             cfg.connections = try parseU32(try nextValue(tokens, &i));
         } else if (eq(arg, "-d") or eq(arg, "--duration")) {
@@ -252,13 +247,10 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
         }
     }
 
-    if (cfg.threads == 0) return error.ZeroThreads;
     if (cfg.connections == 0) return error.ZeroConnections;
     if (cfg.rate == 0) return error.ZeroRate;
     // A ramp toward 0 req/s has no well-defined schedule; require a positive end.
     if (cfg.rate_end) |e| if (e == 0) return error.ZeroRate;
-    // Never run more worker threads than connections.
-    if (cfg.threads > cfg.connections) cfg.threads = cfg.connections;
 
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
@@ -477,7 +469,6 @@ test "parse full command line" {
     const arena = arena_state.allocator();
 
     const args = [_][]const u8{
-        "-t",         "4",
         "-c",         "100",
         "-d",         "30s",
         "-R",         "2000",
@@ -487,7 +478,6 @@ test "parse full command line" {
     };
     const parsed = try parse(arena, &args);
     const cfg = parsed.config;
-    try testing.expectEqual(@as(u32, 4), cfg.threads);
     try testing.expectEqual(@as(u32, 100), cfg.connections);
     try testing.expectEqual(@as(u64, 30 * std.time.ns_per_s), cfg.duration_ns);
     try testing.expectEqual(@as(u64, 2000), cfg.rate);
@@ -579,7 +569,7 @@ test "invalid format and out-of-range error rate are rejected" {
 test "parse missing url errors" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
-    try testing.expectError(error.MissingUrl, parse(arena_state.allocator(), &[_][]const u8{ "-t", "2" }));
+    try testing.expectError(error.MissingUrl, parse(arena_state.allocator(), &[_][]const u8{ "-c", "2" }));
 }
 
 test "rate parses scalar and ramp forms" {
@@ -602,10 +592,10 @@ test "rate parses scalar and ramp forms" {
     try testing.expectError(error.ZeroRate, parse(a, &[_][]const u8{ "-R", "100:0", "http://x/" }));
 }
 
-test "threads clamped to connections" {
+test "removed threads flag is rejected as unknown" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
-    const args = [_][]const u8{ "-t", "8", "-c", "4", "http://x.com/" };
-    const parsed = try parse(arena_state.allocator(), &args);
-    try testing.expectEqual(@as(u32, 4), parsed.config.threads);
+    const a = arena_state.allocator();
+    try testing.expectError(error.UnknownFlag, parse(a, &[_][]const u8{ "-t", "8", "http://x.com/" }));
+    try testing.expectError(error.UnknownFlag, parse(a, &[_][]const u8{ "--threads", "8", "http://x.com/" }));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -236,7 +236,6 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.InvalidHeader => "zrk: invalid header (expected 'Name: Value')\n\n",
         error.InvalidFormat => "zrk: invalid --format (expected 'text' or 'json')\n\n",
         error.ZeroConnections => "zrk: connections (-c) must be greater than 0\n\n",
-        error.ZeroThreads => "zrk: threads (-t) must be greater than 0\n\n",
         error.ZeroRate => "zrk: rate (-R) must be greater than 0\n\n",
         error.OutOfMemory => "zrk: out of memory\n\n",
     };

--- a/src/report.zig
+++ b/src/report.zig
@@ -78,11 +78,13 @@ pub fn writeJson(
 
     try w.writeAll("  \"config\": {");
     try w.print(
-        " \"connections\": {d}, \"threads\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"record_timeouts\": {} }},\n",
+        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"record_timeouts\": {} }},\n",
         .{
-            cfg.connections,                                          cfg.threads,
-            launched,                                                 @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s,
-            cfg.rate,                                                 cfg.timeout_ns / std.time.ns_per_ms,
+            cfg.connections,
+            launched,
+            @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s,
+            cfg.rate,
+            cfg.timeout_ns / std.time.ns_per_ms,
             cfg.record_timeouts,
         },
     );
@@ -254,7 +256,6 @@ const testing = std.testing;
 fn testConfig() cli.Config {
     return .{
         .connections = 4,
-        .threads = 2,
         .rate = 1000,
         .url = cli.parseUrl("http://127.0.0.1:8080/health") catch unreachable,
     };

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -211,7 +211,6 @@ test "run's elapsed time tracks the duration, not the interval grid" {
 
     var cfg: cli.Config = .{
         .connections = 1,
-        .threads = 1,
         .rate = 200,
         // 300ms run with a 1s snapshot interval: the old loop always slept a
         // full interval before checking `end`, reporting ~1s elapsed for a


### PR DESCRIPTION
Finding #1 from the code-review series, per review decision: remove rather than implement.

## Problem

`cfg.threads` was parsed, validated (`ZeroThreads`), clamped to `connections`, documented in usage/README as "Number of worker threads (default 2)", and echoed into the JSON report — but the runner never read it. Concurrency has always been one worker per connection via `group.concurrent`; `-t 4 -c 1000` silently launched 1000 workers.

## Change (breaking)

- `-t` / `--threads` is **removed**, not ignored: passing it is now an unknown-flag error (exit 2 + usage). A silent no-op is exactly the bug being removed, so scripts migrating from wrk2 get a loud failure instead of false knobs.
- `Config.threads`, the `ZeroThreads` error, and the clamp are gone; `t` dropped from the attachable short options.
- The JSON report's `config` object no longer carries `"threads"` (consumers should use `"connections"` / `"launched"`).
- README documents the difference from wrk2 explicitly: each connection runs on its own worker, `-c` alone controls concurrency.

## Tests

- New test: `-t` and `--threads` are rejected as unknown flags.
- Updated the full-command-line, missing-URL, and JSON-report tests; removed the clamp test.
- Verified against the built binary: `zrk -t2 <url>` → `zrk: unknown flag` + usage, exit 2.

130/130 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg