### PR TITLE
fix: stop and join workers if run() errors after launching them

### DIFF
--- a/src/runner.zig
+++ b/src/runner.zig
@@ -93,6 +93,14 @@ pub fn run(
     // Launch each connection on its own thread. `concurrent` (unlike
     // `async`) guarantees real parallelism on the Threaded backend.
     var group: Io.Group = .init;
+    // If anything below fails, the workers must be stopped and joined before
+    // this frame unwinds: they hold pointers to `stop` (this stack) and to
+    // fleet state that the deferred `fleet.deinit` (declared earlier, so it
+    // runs after this) is about to free.
+    errdefer {
+        stop.store(true, .monotonic);
+        group.cancel(io);
+    }
     var launched: u32 = 0;
     for (params) |*p| {
         group.concurrent(io, connection.run, .{p}) catch break;


### PR DESCRIPTION
Finding #6 from the code-review series.

## Problem

`runner.run` spawns the connection workers, *then* allocates the snapshot histogram:

```zig
group.concurrent(io, connection.run, .{p}) ...   // workers hold &stop, fleet state
...
var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(arena), ... };  // can fail
```

If that `try` (or anything else after launch) fails, `run` returns the error without stopping the group. The worker threads keep dereferencing `stop` (a local in the unwound frame) and the fleet's histograms/params — which the earlier-declared `defer fleet.deinit()` frees during the same unwind. Use-after-free on the error path. OOM-only in practice, but the unwind order was plainly wrong.

## Fix

An `errdefer` declared right after the group — so it runs *before* `fleet.deinit` during unwind — signals `stop` and cancels (joins) the group. For the `NoConnectionsLaunched` path the group is empty and the cancel is a no-op.

## Testing

No new test: exercising this requires allocation-failure injection, and `run`'s allocator contract is arena-style (callees never free), so `std.testing.checkAllAllocationFailures` would report false leaks. The existing runner/connection e2e tests cover the success and teardown paths; 130/130 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg