### PR TITLE
Harden untrusted-input decoding and init failure paths

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -101,6 +101,7 @@ pub const ParseError = error{
     InvalidFormat,
     ZeroConnections,
     ZeroRate,
+    ZeroInterval,
     OutOfMemory,
 };
 
@@ -251,6 +252,9 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
     if (cfg.rate == 0) return error.ZeroRate;
     // A ramp toward 0 req/s has no well-defined schedule; require a positive end.
     if (cfg.rate_end) |e| if (e == 0) return error.ZeroRate;
+    // A zero interval would busy-loop the snapshot thread and take the publish
+    // lock on every request.
+    if (cfg.interval_ns == 0) return error.ZeroInterval;
 
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
@@ -350,7 +354,11 @@ pub fn parseDuration(s: []const u8) ParseError!u64 {
     else
         return error.InvalidDuration;
 
-    return @intFromFloat(value * multiplier);
+    // Reject durations the i64-nanosecond timestamp math downstream cannot
+    // represent (~292 years) instead of tripping checked-@intFromFloat UB.
+    const scaled = value * multiplier;
+    if (scaled >= @as(f64, @floatFromInt(std.math.maxInt(i64)))) return error.InvalidDuration;
+    return @intFromFloat(scaled);
 }
 
 /// Parse an absolute http(s) URL into scheme/host/port/target.
@@ -418,6 +426,23 @@ test "parseDuration units" {
     try testing.expectError(error.InvalidDuration, parseDuration(""));
     try testing.expectError(error.InvalidDuration, parseDuration("abc"));
     try testing.expectError(error.InvalidDuration, parseDuration("10x"));
+}
+
+test "durations beyond the timestamp range are rejected, not UB" {
+    try testing.expectError(error.InvalidDuration, parseDuration("99999999999999999999"));
+    try testing.expectError(error.InvalidDuration, parseDuration("9999999999999h"));
+    // Large-but-representable spans still parse.
+    try testing.expect(try parseDuration("100000h") > 0);
+}
+
+test "zero interval is rejected" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    try testing.expectError(error.ZeroInterval, parse(a, &[_][]const u8{ "--interval", "0", "http://x/" }));
+    // Zero timeout stays valid: it means "no response timeout".
+    const cfg = (try parse(a, &[_][]const u8{ "--timeout", "0", "http://x/" })).config;
+    try testing.expectEqual(@as(u64, 0), cfg.timeout_ns);
 }
 
 test "parseUrl http default port and path" {

--- a/src/hdr.zig
+++ b/src/hdr.zig
@@ -70,6 +70,9 @@ pub const Histogram = struct {
     ) InitError!Histogram {
         if (lowest_discernible < 1) return error.InvalidArguments;
         if (sig_figs < 1 or sig_figs > 5) return error.InvalidArguments;
+        // The doubling below must not overflow (decoded headers can carry
+        // arbitrary values here).
+        if (lowest_discernible > std.math.maxInt(u64) / 2) return error.InvalidArguments;
         if (highest_trackable < 2 * lowest_discernible) return error.InvalidArguments;
 
         // largest_value_with_single_unit_resolution = 2 * 10^sig_figs
@@ -467,7 +470,9 @@ pub fn decodeBase64(gpa: Allocator, str: []const u8) !Histogram {
     const enc_cookie = std.mem.readInt(u32, encoded[0..][0..4], .big);
     if ((enc_cookie & cookie_base_mask) != v2_encoding_base) return error.InvalidCookie;
     const payload_len = std.mem.readInt(u32, encoded[4..][0..4], .big);
-    const sig_figs: u8 = @intCast(std.mem.readInt(u32, encoded[12..][0..4], .big));
+    const sig_figs_raw = std.mem.readInt(u32, encoded[12..][0..4], .big);
+    if (sig_figs_raw < 1 or sig_figs_raw > 5) return error.InvalidHistogram;
+    const sig_figs: u8 = @intCast(sig_figs_raw);
     const lowest = std.mem.readInt(u64, encoded[16..][0..8], .big);
     const highest = std.mem.readInt(u64, encoded[24..][0..8], .big);
     if (40 + @as(usize, payload_len) > encoded.len) return error.InvalidHistogram;
@@ -475,16 +480,18 @@ pub fn decodeBase64(gpa: Allocator, str: []const u8) !Histogram {
     var hist = try Histogram.init(gpa, lowest, highest, sig_figs);
     errdefer hist.deinit();
 
-    // Expand the ZigZag/RLE payload back into the counts array.
+    // Expand the ZigZag/RLE payload back into the counts array. The payload is
+    // untrusted: truncated varints error, and a hostile zero-run length only
+    // saturates the (u64) index, ending the loop, rather than overflowing.
     const payload = encoded[40 .. 40 + payload_len];
-    var idx: u32 = 0;
+    var idx: u64 = 0;
     var pos: usize = 0;
     while (pos < payload.len and idx < hist.counts_len) {
-        const v = readZigZag(payload, &pos);
+        const v = readZigZag(payload, &pos) catch return error.InvalidHistogram;
         if (v < 0) {
-            idx += @intCast(-v); // run of zeros
+            idx +|= @intCast(-@as(i128, v)); // run of zeros
         } else {
-            hist.counts[idx] = @intCast(v);
+            hist.counts[@intCast(idx)] = @intCast(v);
             idx += 1;
         }
     }
@@ -520,12 +527,14 @@ fn appendZigZag(list: *std.ArrayList(u8), gpa: Allocator, v: i64) !void {
     try list.append(gpa, @intCast(value & 0xff)); // 9th byte: full 8 bits
 }
 
-/// Inverse of `appendZigZag`, advancing `pos` past the consumed bytes.
-fn readZigZag(bytes: []const u8, pos: *usize) i64 {
+/// Inverse of `appendZigZag`, advancing `pos` past the consumed bytes. Errors
+/// instead of reading past the end of a truncated buffer.
+fn readZigZag(bytes: []const u8, pos: *usize) error{Truncated}!i64 {
     var value: u64 = 0;
     var shift: u6 = 0;
     var i: usize = 0;
     while (true) : (i += 1) {
+        if (pos.* >= bytes.len) return error.Truncated;
         const b = bytes[pos.*];
         pos.* += 1;
         if (i == 8) {
@@ -708,8 +717,12 @@ test "zigzag varint: explicit encodings and round-trip" {
     defer enc.deinit(testing.allocator);
     for (vals) |v| try appendZigZag(&enc, testing.allocator, v);
     var pos: usize = 0;
-    for (vals) |v| try testing.expectEqual(v, readZigZag(enc.items, &pos));
+    for (vals) |v| try testing.expectEqual(v, try readZigZag(enc.items, &pos));
     try testing.expectEqual(enc.items.len, pos);
+
+    // A truncated buffer (continuation bit on the final byte) errors.
+    pos = 0;
+    try testing.expectError(error.Truncated, readZigZag(&.{0x80}, &pos));
 }
 
 test "encodeBase64/decodeBase64 round-trip preserves the distribution" {
@@ -750,6 +763,79 @@ test "empty histogram encodes and decodes" {
 test "decodeBase64 rejects a bad cookie" {
     // Valid base64 (12 zero bytes), but the leading cookie is wrong.
     try testing.expectError(error.InvalidCookie, decodeBase64(testing.allocator, "AAAAAAAAAAAAAAAA"));
+}
+
+/// Build a structurally valid compressed V2 base64 blob from raw header
+/// fields and payload bytes, for exercising the decoder against inputs the
+/// encoder would never produce. Caller owns the result.
+fn buildTestBlob(
+    gpa: Allocator,
+    sig_figs: u32,
+    lowest: u64,
+    highest: u64,
+    payload: []const u8,
+) ![]u8 {
+    const encoded = try gpa.alloc(u8, 40 + payload.len);
+    defer gpa.free(encoded);
+    std.mem.writeInt(u32, encoded[0..][0..4], encoding_cookie, .big);
+    std.mem.writeInt(u32, encoded[4..][0..4], @intCast(payload.len), .big);
+    std.mem.writeInt(u32, encoded[8..][0..4], 0, .big);
+    std.mem.writeInt(u32, encoded[12..][0..4], sig_figs, .big);
+    std.mem.writeInt(u64, encoded[16..][0..8], lowest, .big);
+    std.mem.writeInt(u64, encoded[24..][0..8], highest, .big);
+    std.mem.writeInt(u64, encoded[32..][0..8], @bitCast(@as(f64, 1.0)), .big);
+    @memcpy(encoded[40..], payload);
+
+    const zbytes = try zlibCompress(gpa, encoded);
+    defer gpa.free(zbytes);
+    const framed = try gpa.alloc(u8, 8 + zbytes.len);
+    defer gpa.free(framed);
+    std.mem.writeInt(u32, framed[0..][0..4], compressed_cookie, .big);
+    std.mem.writeInt(u32, framed[4..][0..4], @intCast(zbytes.len), .big);
+    @memcpy(framed[8..], zbytes);
+
+    const enc = std.base64.standard.Encoder;
+    const out = try gpa.alloc(u8, enc.calcSize(framed.len));
+    _ = enc.encode(out, framed);
+    return out;
+}
+
+test "decodeBase64 errors (never panics) on malformed blobs" {
+    const gpa = testing.allocator;
+
+    // Truncated varint payload: continuation bit set on the final byte.
+    {
+        const b64 = try buildTestBlob(gpa, 3, 1, 1000, &.{0x80});
+        defer gpa.free(b64);
+        try testing.expectError(error.InvalidHistogram, decodeBase64(gpa, b64));
+    }
+    // Out-of-range significant figures in the header.
+    {
+        const b64 = try buildTestBlob(gpa, 9, 1, 1000, &.{});
+        defer gpa.free(b64);
+        try testing.expectError(error.InvalidHistogram, decodeBase64(gpa, b64));
+    }
+    // A lowest/highest pair whose validation math would overflow.
+    {
+        const b64 = try buildTestBlob(gpa, 3, std.math.maxInt(u64), std.math.maxInt(u64), &.{});
+        defer gpa.free(b64);
+        try testing.expectError(error.InvalidArguments, decodeBase64(gpa, b64));
+    }
+}
+
+test "decodeBase64 tolerates an absurd zero-run length" {
+    const gpa = testing.allocator;
+    // Encode a zero-run of 2^62 — vastly beyond counts_len. The index
+    // saturates and the loop ends; the result is simply an empty histogram.
+    var payload: std.ArrayList(u8) = .empty;
+    defer payload.deinit(gpa);
+    try appendZigZag(&payload, gpa, -(@as(i64, 1) << 62));
+    const b64 = try buildTestBlob(gpa, 3, 1, 3_600_000_000, payload.items);
+    defer gpa.free(b64);
+
+    var d = try decodeBase64(gpa, b64);
+    defer d.deinit();
+    try testing.expectEqual(@as(u64, 0), d.count());
 }
 
 test "copyInto snapshot" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -237,6 +237,7 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.InvalidFormat => "zrk: invalid --format (expected 'text' or 'json')\n\n",
         error.ZeroConnections => "zrk: connections (-c) must be greater than 0\n\n",
         error.ZeroRate => "zrk: rate (-R) must be greater than 0\n\n",
+        error.ZeroInterval => "zrk: --interval must be greater than 0\n\n",
         error.OutOfMemory => "zrk: out of memory\n\n",
     };
     try writeAll(io, .stderr(), msg);

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -46,14 +46,30 @@ pub const Fleet = struct {
 
     pub fn init(allocator: Allocator, n: u32, publish_interval_ns: u64, enable_tls: bool) !Fleet {
         const live_hist = try allocator.alloc(hdr.Histogram, n);
+        errdefer allocator.free(live_hist);
         const live_counters = try allocator.alloc(connection.Counters, n);
+        errdefer allocator.free(live_counters);
         const snap_hist = try allocator.alloc(hdr.Histogram, n);
+        errdefer allocator.free(snap_hist);
         const publish = try allocator.alloc(connection.Publish, n);
+        errdefer allocator.free(publish);
         const params = try allocator.alloc(connection.Params, n);
+        errdefer allocator.free(params);
         const tls_state: ?[]tlsmod.State = if (enable_tls) try allocator.alloc(tlsmod.State, n) else null;
+        errdefer if (tls_state) |ts| allocator.free(ts);
 
-        for (live_hist) |*h| h.* = try newHistogram(allocator);
-        for (snap_hist) |*h| h.* = try newHistogram(allocator);
+        var live_inited: usize = 0;
+        errdefer for (live_hist[0..live_inited]) |*h| h.deinit();
+        for (live_hist) |*h| {
+            h.* = try newHistogram(allocator);
+            live_inited += 1;
+        }
+        var snap_inited: usize = 0;
+        errdefer for (snap_hist[0..snap_inited]) |*h| h.deinit();
+        for (snap_hist) |*h| {
+            h.* = try newHistogram(allocator);
+            snap_inited += 1;
+        }
         @memset(live_counters, .{});
         for (publish, snap_hist) |*p, *sh| {
             p.* = .{ .hist = sh, .interval_ns = publish_interval_ns };
@@ -144,6 +160,15 @@ test "fleet aggregates live counters and histograms" {
     try testing.expectEqual(@as(u64, 30), snap.counters.completed);
     try testing.expectEqual(@as(u64, 300), snap.counters.bytes);
     try testing.expectEqual(@as(u64, 3), snap.hist.count());
+}
+
+test "Fleet.init leaks nothing when any allocation fails" {
+    try testing.checkAllAllocationFailures(testing.allocator, struct {
+        fn initAndDeinit(allocator: Allocator) !void {
+            var fleet = try Fleet.init(allocator, 3, std.time.ns_per_s, true);
+            fleet.deinit();
+        }
+    }.initAndDeinit, .{});
 }
 
 test "readSnapshot reflects published state" {


### PR DESCRIPTION
Findings #7, #8, #9 from the code-review series — the robustness batch, one commit each.

## 1. `decodeBase64` errors instead of panicking on malformed blobs (#7)

The decoder exists to ingest externally produced histogram blobs, but crafted input could trip safety panics:

- `readZigZag` indexed past the end of a truncated payload (continuation bit on the final byte) → now `error{Truncated}`, surfaced as `InvalidHistogram`.
- A hostile zero-run length panicked on the `u32` index cast → the index is now `u64` with a saturating add; an absurd run simply ends the loop (empty histogram), matching "ignore trailing zeros" semantics.
- Header `sig_figs > 255` overflowed a `u8` cast → validated (1–5) before casting.
- A huge `lowest_discernible` overflowed `Histogram.init`'s `2 * lowest` validation itself → guarded.

Tests build structurally valid blobs with hostile contents via a test-only builder and assert errors (or a clean empty decode), plus a truncated-varint unit test.

## 2. Reject out-of-range durations and a zero `--interval` (#8)

- `parseDuration`'s `@intFromFloat` was checked UB past the representable range: `-d 9999999999999h` panicked. Parsed durations are now capped below `maxInt(i64)` ns (~292 years) — which also keeps the runner's `Io.Duration` casts and the watchdog's i64 deadline math in range.
- `--interval 0` was accepted and would busy-loop the snapshot thread while taking every connection's publish lock per request → now `error.ZeroInterval` with a usage message. `--timeout 0` ("no response timeout") stays valid, with a test pinning that.

## 3. `Fleet.init` frees everything on partial allocation failure (#9)

Six sequential allocations plus two histogram-init loops had no `errdefer`s. Masked by the arena in the runner, but the type takes any allocator. Now exhaustively verified with `std.testing.checkAllAllocationFailures` (every failure point injected, leaks checked).

140/140 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg