### PR TITLE
Nits sweep: watchdog race, HTTP edges, naming and scaffold cleanup

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,156 +1,51 @@
 const std = @import("std");
 
-// Although this function looks imperative, it does not perform the build
-// directly and instead it mutates the build graph (`b`) that will be then
-// executed by an external runner. The functions in `std.Build` implement a DSL
-// for defining build steps and express dependencies between them, allowing the
-// build runner to parallelize the build automatically (and the cache system to
-// know when a step doesn't need to be re-run).
 pub fn build(b: *std.Build) void {
-    // Standard target options allow the person running `zig build` to choose
-    // what target to build for. Here we do not override the defaults, which
-    // means any target is allowed, and the default is native. Other options
-    // for restricting supported target set are available.
     const target = b.standardTargetOptions(.{});
-    // Standard optimization options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
-    // set a preferred release mode, allowing the user to decide how to optimize.
     const optimize = b.standardOptimizeOption(.{});
-    // It's also possible to define more custom flags to toggle optional features
-    // of this build script using `b.option()`. All defined flags (including
-    // target and optimize options) will be listed when running `zig build --help`
-    // in this directory.
 
-    // This creates a module, which represents a collection of source files alongside
-    // some compilation options, such as optimization mode and linked system libraries.
-    // Zig modules are the preferred way of making Zig code available to consumers.
-    // addModule defines a module that we intend to make available for importing
-    // to our consumers. We must give it a name because a Zig package can expose
-    // multiple modules and consumers will need to be able to specify which
-    // module they want to access.
+    // The reusable library module: embedders `@import("zrk")` this.
     const mod = b.addModule("zrk", .{
-        // The root source file is the "entry point" of this module. Users of
-        // this module will only be able to access public declarations contained
-        // in this file, which means that if you have declarations that you
-        // intend to expose to consumers that were defined in other files part
-        // of this module, you will have to make sure to re-export them from
-        // the root file.
         .root_source_file = b.path("src/root.zig"),
-        // Later on we'll use this module as the root module of a test executable
-        // which requires us to specify a target.
         .target = target,
     });
 
-    // Here we define an executable. An executable needs to have a root module
-    // which needs to expose a `main` function. While we could add a main function
-    // to the module defined above, it's sometimes preferable to split business
-    // logic and the CLI into two separate modules.
-    //
-    // If your goal is to create a Zig library for others to use, consider if
-    // it might benefit from also exposing a CLI tool. A parser library for a
-    // data serialization format could also bundle a CLI syntax checker, for example.
-    //
-    // If instead your goal is to create an executable, consider if users might
-    // be interested in also being able to embed the core functionality of your
-    // program in their own executable in order to avoid the overhead involved in
-    // subprocessing your CLI tool.
-    //
-    // If neither case applies to you, feel free to delete the declaration you
-    // don't need and to put everything under a single module.
+    // The CLI executable.
     const exe = b.addExecutable(.{
         .name = "zrk",
         .root_module = b.createModule(.{
-            // b.createModule defines a new module just like b.addModule but,
-            // unlike b.addModule, it does not expose the module to consumers of
-            // this package, which is why in this case we don't have to give it a name.
             .root_source_file = b.path("src/main.zig"),
-            // Target and optimization levels must be explicitly wired in when
-            // defining an executable or library (in the root module), and you
-            // can also hardcode a specific target for an executable or library
-            // definition if desireable (e.g. firmware for embedded devices).
             .target = target,
             .optimize = optimize,
-            // List of modules available for import in source files part of the
-            // root module.
             .imports = &.{
-                // Here "zrk" is the name you will use in your source code to
-                // import this module (e.g. `@import("zrk")`). The name is
-                // repeated because you are allowed to rename your imports, which
-                // can be extremely useful in case of collisions (which can happen
-                // importing modules from different packages).
                 .{ .name = "zrk", .module = mod },
             },
         }),
     });
-
-    // This declares intent for the executable to be installed into the
-    // install prefix when running `zig build` (i.e. when executing the default
-    // step). By default the install prefix is `zig-out/` but can be overridden
-    // by passing `--prefix` or `-p`.
     b.installArtifact(exe);
 
-    // This creates a top level step. Top level steps have a name and can be
-    // invoked by name when running `zig build` (e.g. `zig build run`).
-    // This will evaluate the `run` step rather than the default step.
-    // For a top level step to actually do something, it must depend on other
-    // steps (e.g. a Run step, as we will see in a moment).
+    // `zig build run -- <args>` runs the installed binary.
     const run_step = b.step("run", "Run the app");
-
-    // This creates a RunArtifact step in the build graph. A RunArtifact step
-    // invokes an executable compiled by Zig. Steps will only be executed by the
-    // runner if invoked directly by the user (in the case of top level steps)
-    // or if another step depends on it, so it's up to you to define when and
-    // how this Run step will be executed. In our case we want to run it when
-    // the user runs `zig build run`, so we create a dependency link.
     const run_cmd = b.addRunArtifact(exe);
     run_step.dependOn(&run_cmd.step);
-
-    // By making the run step depend on the default step, it will be run from the
-    // installation directory rather than directly from within the cache directory.
     run_cmd.step.dependOn(b.getInstallStep());
-
-    // This allows the user to pass arguments to the application in the build
-    // command itself, like this: `zig build run -- arg1 arg2 etc`
     if (b.args) |args| {
         run_cmd.addArgs(args);
     }
 
-    // Creates an executable that will run `test` blocks from the provided module.
-    // Here `mod` needs to define a target, which is why earlier we made sure to
-    // set the releative field.
+    // `zig build test`: a test binary per module (a test executable covers
+    // exactly one module, hence two of them).
     const mod_tests = b.addTest(.{
         .root_module = mod,
     });
-
-    // A run step that will run the test executable.
     const run_mod_tests = b.addRunArtifact(mod_tests);
 
-    // Creates an executable that will run `test` blocks from the executable's
-    // root module. Note that test executables only test one module at a time,
-    // hence why we have to create two separate ones.
     const exe_tests = b.addTest(.{
         .root_module = exe.root_module,
     });
-
-    // A run step that will run the second test executable.
     const run_exe_tests = b.addRunArtifact(exe_tests);
 
-    // A top level step for running all tests. dependOn can be called multiple
-    // times and since the two run steps do not depend on one another, this will
-    // make the two of them run in parallel.
     const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_mod_tests.step);
     test_step.dependOn(&run_exe_tests.step);
-
-    // Just like flags, top level steps are also listed in the `--help` menu.
-    //
-    // The Zig build system is entirely implemented in userland, which means
-    // that it cannot hook into private compiler APIs. All compilation work
-    // orchestrated by the build system will result in other Zig compiler
-    // subcommands being invoked with the right flags defined. You can observe
-    // these invocations when one fails (or you pass a flag to increase
-    // verbosity) to validate assumptions and diagnose problems.
-    //
-    // Lastly, the Zig build system is relatively simple and self-contained,
-    // and reading its source code will allow you to master it.
 }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -297,9 +297,17 @@ const Watchdog = struct {
             const deadline = w.deadline_ns.load(.acquire);
             const t = std.math.lossyCast(i64, now(io).nanoseconds);
             if (deadline != 0 and t >= deadline) {
-                w.fired.store(true, .release);
-                w.stream.shutdown(io, .both) catch {};
-                return;
+                // Fire only if this exact deadline is still armed: the request
+                // may have completed (disarm, possibly followed by the next
+                // arm) since the load above, and shutting the socket down then
+                // would misclassify the *next* request as a timeout. Deadlines
+                // strictly increase, so there is no ABA to worry about.
+                if (w.deadline_ns.cmpxchgStrong(deadline, 0, .acq_rel, .acquire) == null) {
+                    w.fired.store(true, .release);
+                    w.stream.shutdown(io, .both) catch {};
+                    return;
+                }
+                continue; // Deadline moved: re-evaluate against the new one.
             }
             const sleep_ns: i64 = if (deadline != 0)
                 deadline - t

--- a/src/hdr.zig
+++ b/src/hdr.zig
@@ -294,14 +294,14 @@ pub const Histogram = struct {
     pub fn stdDev(self: *const Histogram) f64 {
         if (self.total_count == 0) return 0;
         const m = self.mean();
-        var geometric_sum: f64 = 0;
+        var sum_sq_dev: f64 = 0;
         for (self.counts, 0..) |c, i| {
             if (c == 0) continue;
             const v: f64 = @floatFromInt(self.medianEquivalentValue(self.valueFromIndex(@intCast(i))));
             const dev = v - m;
-            geometric_sum += (dev * dev) * @as(f64, @floatFromInt(c));
+            sum_sq_dev += (dev * dev) * @as(f64, @floatFromInt(c));
         }
-        return @sqrt(geometric_sum / @as(f64, @floatFromInt(self.total_count)));
+        return @sqrt(sum_sq_dev / @as(f64, @floatFromInt(self.total_count)));
     }
 
     /// Value at the given percentile (0..100). Returns the midpoint of the

--- a/src/http.zig
+++ b/src/http.zig
@@ -26,25 +26,41 @@ pub fn buildRequest(allocator: std.mem.Allocator, cfg: *const cli.Config) ![]u8 
         try w.print("Host: {s}:{d}\r\n", .{ cfg.url.host, cfg.url.port });
     }
 
-    // Sensible defaults; a user -H of the same name is additionally sent, which
-    // mirrors wrk's behavior of not de-duplicating headers.
+    // Sensible defaults, each skipped when the user supplies the same header
+    // via -H (other duplicate -H headers pass through, mirroring wrk).
     var has_ua = false;
     var has_conn = false;
+    var has_cl = false;
     for (cfg.headers) |h| {
         if (std.ascii.eqlIgnoreCase(h.name, "user-agent")) has_ua = true;
         if (std.ascii.eqlIgnoreCase(h.name, "connection")) has_conn = true;
+        if (std.ascii.eqlIgnoreCase(h.name, "content-length")) has_cl = true;
         try w.print("{s}: {s}\r\n", .{ h.name, h.value });
     }
     if (!has_ua) try w.writeAll("User-Agent: zrk\r\n");
     if (!has_conn) try w.writeAll("Connection: keep-alive\r\n");
 
-    if (cfg.body.len > 0) {
-        try w.print("Content-Length: {d}\r\n", .{cfg.body.len});
+    if (!has_cl) {
+        if (cfg.body.len > 0) {
+            try w.print("Content-Length: {d}\r\n", .{cfg.body.len});
+        } else if (methodAnticipatesBody(cfg.method)) {
+            // An empty body on a body-bearing method still needs an explicit
+            // length: many servers answer 411 otherwise.
+            try w.writeAll("Content-Length: 0\r\n");
+        }
     }
     try w.writeAll("\r\n");
     try w.writeAll(cfg.body);
 
     return alloc_writer.toOwnedSlice();
+}
+
+/// Methods whose semantics anticipate request content (RFC 9110 §9.3), for
+/// which an empty body still gets an explicit `Content-Length: 0`.
+fn methodAnticipatesBody(method: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(method, "POST") or
+        std.ascii.eqlIgnoreCase(method, "PUT") or
+        std.ascii.eqlIgnoreCase(method, "PATCH");
 }
 
 pub const StatusClass = enum {
@@ -174,7 +190,11 @@ fn parseStatus(status_line: []const u8) !u16 {
     const first_space = std.mem.indexOfScalar(u8, status_line, ' ') orelse return error.MalformedStatusLine;
     const after = status_line[first_space + 1 ..];
     const code_end = std.mem.indexOfScalar(u8, after, ' ') orelse after.len;
-    return std.fmt.parseInt(u16, after[0..code_end], 10) catch error.MalformedStatusLine;
+    const code = std.fmt.parseInt(u16, after[0..code_end], 10) catch return error.MalformedStatusLine;
+    // Status codes are exactly three digits (RFC 9112 §4). Enforcing that here
+    // keeps every counted status inside the 1xx..5xx+ class buckets.
+    if (code < 100 or code > 999) return error.MalformedStatusLine;
+    return code;
 }
 
 fn consumeChunkedBody(r: *Io.Reader, bytes: *u64) ParseError!void {
@@ -288,6 +308,37 @@ test "parseResponse http/1.0 defaults to no keep-alive" {
     var r = Io.Reader.fixed(raw);
     const resp = try parseResponse(&r, .other);
     try testing.expect(!resp.keep_alive);
+}
+
+test "buildRequest Content-Length: bodyless methods, empty POST, user override" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // GET with no body: no Content-Length at all.
+    const get = try buildRequest(a, &.{ .url = try cli.parseUrl("http://x/") });
+    try testing.expect(std.mem.indexOf(u8, get, "Content-Length") == null);
+
+    // POST with an empty body still declares an explicit zero length.
+    const post = try buildRequest(a, &.{ .method = "POST", .url = try cli.parseUrl("http://x/") });
+    try testing.expect(std.mem.indexOf(u8, post, "Content-Length: 0\r\n") != null);
+
+    // A user-supplied Content-Length suppresses the automatic one.
+    const headers = [_]cli.Header{.{ .name = "Content-Length", .value = "5" }};
+    const custom = try buildRequest(a, &.{
+        .method = "POST",
+        .body = "hello",
+        .headers = &headers,
+        .url = try cli.parseUrl("http://x/"),
+    });
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, custom, "Content-Length"));
+}
+
+test "parseResponse rejects non-3-digit status codes" {
+    var short = Io.Reader.fixed("HTTP/1.1 42 Weird\r\n\r\n");
+    try testing.expectError(error.MalformedStatusLine, parseResponse(&short, .other));
+    var long = Io.Reader.fixed("HTTP/1.1 12345 Weird\r\n\r\n");
+    try testing.expectError(error.MalformedStatusLine, parseResponse(&long, .other));
 }
 
 test "RequestMethod.of classifies HEAD case-insensitively" {

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -51,12 +51,16 @@ pub const Dashboard = struct {
     pub fn frame(self: *Dashboard, snap: *const stats.Snapshot, now_ns: i128, elapsed_s: f64, total_s: f64) !void {
         const w = self.writer();
 
-        // Interval request rate from the delta since the previous frame.
+        // Interval request rate from the delta since the previous frame; the
+        // first frame's "interval" is the whole run so far (otherwise a run
+        // with a single frame reports 0 req/s despite completed requests).
         var rate: f64 = 0;
         if (self.have_prev and now_ns > self.prev_ns) {
             const d_req: f64 = @floatFromInt(snap.counters.completed -| self.prev_completed);
             const d_s: f64 = @as(f64, @floatFromInt(now_ns - self.prev_ns)) / std.time.ns_per_s;
             if (d_s > 0) rate = d_req / d_s;
+        } else if (!self.have_prev and elapsed_s > 0) {
+            rate = @as(f64, @floatFromInt(snap.counters.completed)) / elapsed_s;
         }
         self.have_prev = true;
         self.prev_completed = snap.counters.completed;


### PR DESCRIPTION
The nits pile from the code-review series, one commit each.

## 1. Watchdog fires only if its deadline is still armed

Rare cross-request race: the watchdog loads a nonzero deadline, the response completes and disarms (possibly the next request re-arms) before it shuts the socket down — the *next* request then fails and gets misclassified as a timeout with a bogus near-zero latency sample. The fire condition is now a CAS of the loaded deadline to 0: if the deadline moved, the watchdog lost the race and re-evaluates instead of firing. Deadlines strictly increase, so there's no ABA. Arm/disarm stay single atomic stores — no hot-path cost.

## 2. HTTP request/response edges

- Empty-body **POST/PUT/PATCH** now send `Content-Length: 0` (many servers answer 411 without it); GET and friends remain header-free per RFC 9110 §9.3's "SHOULD NOT". A user-supplied `-H "Content-Length: …"` suppresses the automatic one, same rule as User-Agent/Connection.
- Status codes are exactly three digits (RFC 9112 §4): `parseStatus` now rejects codes below 100 or above 999 as malformed instead of silently bucketing them into the never-reported `status_class[0]`.

## 3. Cosmetics

- `hdr.stdDev`'s accumulator renamed `geometric_sum` → `sum_sq_dev` (it's a sum of squared deviations).
- The dashboard's first frame rated `0 req/s` regardless of traffic (no previous frame to delta against); it now rates the whole run so far — visible on runs short enough to produce a single frame.
- `build.zig` shed its `zig init` tutorial prose (−100 lines, no functional change).

144/144 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg