### PR TITLE
docs: add CI badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # zrk
 
+[![CI](https://github.com/zoxy-io/zrk/actions/workflows/ci.yml/badge.svg)](https://github.com/zoxy-io/zrk/actions/workflows/ci.yml)
+
 A constant-throughput HTTP load generator — a Zig 0.16 rewrite of
 [wrk2](https://github.com/giltene/wrk2), with a **live in-terminal dashboard**
 of test progress.


### PR DESCRIPTION
Adds the CI workflow status badge under the README title, linking to the workflow's Actions page. Badge URL verified to resolve (`200`, `image/svg+xml`); it reflects the workflow's status on the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg