### PR TITLE
feat: interval transfer rate on the dashboard and in --timeseries rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,12 @@ distribution (values in milliseconds), directly loadable by the
 and format-compatible with wrk2's `--latency` output.
 
 `--timeseries <file>` streams one NDJSON object per `--interval`, each carrying
-that window's offered `target_rate`, `achieved_rate`, request/error counts, and
-a delta-histogram latency percentile set:
+that window's offered `target_rate`, `achieved_rate`, request/error counts,
+transfer (`bytes`, `bytes_per_sec`), and a delta-histogram latency percentile
+set:
 
 ```
-{"t":1.006,"target_rate":480.0,"achieved_rate":476.2,"requests":476,"errors":0,"latency_us":{"p50":245,"p90":669,"p99":1745,"p99_9":2401,"max":2401}}
+{"t":1.006,"target_rate":480.0,"achieved_rate":476.2,"requests":476,"errors":0,"bytes":58852,"bytes_per_sec":58501.0,"latency_us":{"p50":245,"p90":669,"p99":1745,"p99_9":2401,"max":2401}}
 ```
 
 This is the artifact a **ramp** (`-R A:B`) exists to produce: a curve of latency

--- a/src/report.zig
+++ b/src/report.zig
@@ -143,6 +143,7 @@ pub const TimeSeries = struct {
     /// `--timeseries-histogram` is on. Backed by the page allocator.
     scratch: std.heap.ArenaAllocator,
     prev_completed: u64 = 0,
+    prev_bytes: u64 = 0,
     prev_errors: u64 = 0,
     prev_elapsed_s: f64 = 0,
 
@@ -180,17 +181,21 @@ pub const TimeSeries = struct {
 
         const interval_s = elapsed_s - self.prev_elapsed_s;
         const d_completed = snap.counters.completed -| self.prev_completed;
+        const d_bytes = snap.counters.bytes -| self.prev_bytes;
         const cur_errors = snap.counters.status_errors + snap.counters.socketErrors();
         const d_errors = cur_errors -| self.prev_errors;
         const achieved: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_completed)) / interval_s else 0;
+        const bps: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_bytes)) / interval_s else 0;
 
         try self.w.print(
             "{{\"t\":{d:.3},\"target_rate\":{d:.1},\"achieved_rate\":{d:.1},\"requests\":{d},\"errors\":{d}," ++
+                "\"bytes\":{d},\"bytes_per_sec\":{d:.1}," ++
                 "\"latency_us\":{{\"p50\":{d},\"p90\":{d},\"p99\":{d},\"p99_9\":{d},\"max\":{d}}}",
             .{
                 elapsed_s,                 self.targetRate(elapsed_s),
                 achieved,                  d_completed,
-                d_errors,                  h.valueAtPercentile(50),
+                d_errors,                  d_bytes,
+                bps,                       h.valueAtPercentile(50),
                 h.valueAtPercentile(90),   h.valueAtPercentile(99),
                 h.valueAtPercentile(99.9), h.max(),
             },
@@ -212,6 +217,7 @@ pub const TimeSeries = struct {
 
         snap.hist.copyInto(&self.prev_cum);
         self.prev_completed = snap.counters.completed;
+        self.prev_bytes = snap.counters.bytes;
         self.prev_errors = cur_errors;
         self.prev_elapsed_s = elapsed_s;
     }
@@ -311,11 +317,14 @@ test "time series row carries the interval HDR blob when enabled" {
     var i: u64 = 0;
     while (i < 50) : (i += 1) snap.hist.record(1000 + i);
     snap.counters.completed = 50;
+    snap.counters.bytes = 4200;
 
     try ts.record(&snap, 1.0);
     const out = alloc.written();
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_us\":{") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_histogram\":\"HIST") != null);
+    // The interval's transfer: byte delta and rate over the 1s window.
+    try testing.expect(std.mem.indexOf(u8, out, "\"bytes\":4200,\"bytes_per_sec\":4200.0") != null);
     try testing.expect(std.mem.endsWith(u8, out, "}\n"));
 
     // The blob decodes back to this interval's 50 samples.

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -25,6 +25,7 @@ pub const Dashboard = struct {
     // Rate tracking between frames.
     have_prev: bool = false,
     prev_completed: u64 = 0,
+    prev_bytes: u64 = 0,
     prev_ns: i128 = 0,
 
     // p99 history (microseconds) for the sparkline.
@@ -51,19 +52,26 @@ pub const Dashboard = struct {
     pub fn frame(self: *Dashboard, snap: *const stats.Snapshot, now_ns: i128, elapsed_s: f64, total_s: f64) !void {
         const w = self.writer();
 
-        // Interval request rate from the delta since the previous frame; the
-        // first frame's "interval" is the whole run so far (otherwise a run
-        // with a single frame reports 0 req/s despite completed requests).
+        // Interval request/transfer rates from the delta since the previous
+        // frame; the first frame's "interval" is the whole run so far
+        // (otherwise a run with a single frame reports 0 despite traffic).
         var rate: f64 = 0;
+        var bps: f64 = 0;
         if (self.have_prev and now_ns > self.prev_ns) {
             const d_req: f64 = @floatFromInt(snap.counters.completed -| self.prev_completed);
+            const d_bytes: f64 = @floatFromInt(snap.counters.bytes -| self.prev_bytes);
             const d_s: f64 = @as(f64, @floatFromInt(now_ns - self.prev_ns)) / std.time.ns_per_s;
-            if (d_s > 0) rate = d_req / d_s;
+            if (d_s > 0) {
+                rate = d_req / d_s;
+                bps = d_bytes / d_s;
+            }
         } else if (!self.have_prev and elapsed_s > 0) {
             rate = @as(f64, @floatFromInt(snap.counters.completed)) / elapsed_s;
+            bps = @as(f64, @floatFromInt(snap.counters.bytes)) / elapsed_s;
         }
         self.have_prev = true;
         self.prev_completed = snap.counters.completed;
+        self.prev_bytes = snap.counters.bytes;
         self.prev_ns = now_ns;
 
         const p99 = snap.hist.valueAtPercentile(99);
@@ -72,10 +80,11 @@ pub const Dashboard = struct {
 
         if (self.tui) {
             try w.writeAll("\x1b[H\x1b[2J"); // home + clear
-            try self.drawPanel(w, snap, rate, elapsed_s, total_s, p99);
+            try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, p99);
         } else {
-            try w.print("[{d:6.1}s] {d:8.0} req/s  p50={f} p99={f} p99.9={f} max={f}  errs={d}\n", .{
+            try w.print("[{d:6.1}s] {d:8.0} req/s {f}/s  p50={f} p99={f} p99.9={f} max={f}  errs={d}\n", .{
                 elapsed_s,             rate,
+                Bytes.of(bps),
                 Dur.of(snap.hist.valueAtPercentile(50)), Dur.of(p99),
                 Dur.of(snap.hist.valueAtPercentile(99.9)), Dur.of(snap.hist.max()),
                 snap.counters.socketErrors() + snap.counters.status_errors,
@@ -84,7 +93,7 @@ pub const Dashboard = struct {
         try self.fw.interface.flush();
     }
 
-    fn drawPanel(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, rate: f64, elapsed_s: f64, total_s: f64, p99: u64) !void {
+    fn drawPanel(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, rate: f64, bps: f64, elapsed_s: f64, total_s: f64, p99: u64) !void {
         const c = snap.counters;
         try w.print("  zrk  →  {s}://{s}:{d}{s}\n", .{
             @tagName(self.cfg.url.scheme), self.cfg.url.host, self.cfg.url.port, self.cfg.url.target,
@@ -93,9 +102,9 @@ pub const Dashboard = struct {
             elapsed_s, total_s, self.cfg.connections, self.cfg.rate,
         });
 
-        try w.print("  requests {d}      rate {d:.0} req/s      transfer ", .{ c.completed, rate });
-        try writeBytes(w, @floatFromInt(c.bytes));
-        try w.writeAll("\n");
+        try w.print("  requests {d}      rate {d:.0} req/s      transfer {f} ({f}/s)\n", .{
+            c.completed, rate, Bytes.of(@floatFromInt(c.bytes)), Bytes.of(bps),
+        });
 
         const errs = c.socketErrors();
         if (errs > 0 or c.status_errors > 0) {
@@ -233,6 +242,19 @@ const Dur = struct {
 
     pub fn format(self: Dur, w: *Io.Writer) Io.Writer.Error!void {
         try write(w, @floatFromInt(self.micros));
+    }
+};
+
+/// Byte-quantity formatting helper (binary units), usable via `{f}`.
+const Bytes = struct {
+    v: f64,
+
+    fn of(v: f64) Bytes {
+        return .{ .v = v };
+    }
+
+    pub fn format(self: Bytes, w: *Io.Writer) Io.Writer.Error!void {
+        try writeBytes(w, self.v);
     }
 };
 


### PR DESCRIPTION
Adds throughput-as-a-rate to the two surfaces that lacked it (the final text report and JSON summary already have `Transfer/sec` / `bytes_per_sec`):

## Dashboard

- TUI panel: `transfer 17.29KiB (5.76KiB/s)` — cumulative plus interval rate.
- `--plain` lines: `[   1.0s]      100 req/s 5.76KiB/s  p50=…`.

Uses the same frame-delta tracking as the request rate (including the first-frame whole-run fallback). `writeBytes` gains a `Bytes` wrapper struct so byte quantities compose into `print` format strings via `{f}`, like `Dur`.

## `--timeseries` rows

Each NDJSON row now carries the interval's `"bytes"` and `"bytes_per_sec"`, alongside `achieved_rate`. Rationale: on ramps, bytes/s vs offered load is how you catch response-size anomalies — error pages shrinking payloads keep req/s looking healthy while real throughput collapses. Pairs well with the just-landed publish-on-every-completion fix (9f0a62d), which unquantizes exactly these per-interval deltas.

No hot-path changes — both consume `counters.bytes` already aggregated in the snapshots.

## Verification

- Unit test pins `"bytes":4200,"bytes_per_sec":4200.0` in a recorded row; 150/150 tests pass.
- Live run against a local server with 59-byte responses at 100 req/s: plain lines show `5.76KiB/s`, rows show `"bytes":5900,"bytes_per_sec":5893.3`, final report `Transfer/sec: 5.76KiB` — all mutually consistent.
- README timeseries description and sample row updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRHfiHkDoLGgo8s2HASMrg