### PR TITLE
tui: refresh latency bar values at --refresh, not --interval

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -67,7 +67,9 @@ pub const Counters = struct {
 /// A double-buffer for exposing a connection's live latency/counters to the
 /// dashboard thread without racing the hot path. The connection thread copies
 /// its live state here at most once per publish interval, under `mutex`; the
-/// dashboard reads it under the same lock. Cheap because it happens ~once/sec.
+/// dashboard reads it under the same lock. The publish interval follows the
+/// fastest consumer — the dashboard's `--refresh` when a live TUI is attached,
+/// else the `--interval` stats window.
 pub const Publish = struct {
     mutex: Io.Mutex = .init,
     /// Snapshot histogram (must share the live histogram's layout).

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -69,7 +69,14 @@ pub fn run(
     }
     const ca_ptr: ?*tlsmod.CaStore = if (ca_store) |*c| c else null;
 
-    var fleet = try stats.Fleet.init(arena, cfg.connections, cfg.interval_ns, cfg.url.isTls());
+    // Publish the (expensive) live-histogram copy as often as the fastest
+    // consumer wakes: the dashboard's `--refresh` when a live TUI is attached,
+    // else the `--interval` stats window. This is what lets the latency bars
+    // step with each redraw instead of only once per stats window — the panel
+    // repaints every frame but the numbers behind it are only as fresh as the
+    // last publish.
+    const publish_ns = if (frame_interval_ns > 0) @min(frame_interval_ns, cfg.interval_ns) else cfg.interval_ns;
+    var fleet = try stats.Fleet.init(arena, cfg.connections, publish_ns, cfg.url.isTls());
     defer fleet.deinit();
 
     var stop = std.atomic.Value(bool).init(false);


### PR DESCRIPTION
## Problem

The latency spectrum bars repaint every frame (`--refresh`, default 80ms), but the histogram behind them was only copied out of each connection into its publish buffer once per `--interval` (default 1s). So the panel redrew fast while the bar *values* stepped only once a second — the bars looked bound to `--interval` rather than `--refresh`.

## Fix

Publish the histogram at the fastest attached consumer's cadence:

```zig
const publish_ns = if (frame_interval_ns > 0) @min(frame_interval_ns, cfg.interval_ns) else cfg.interval_ns;
```

- **Live interactive TUI** → publishes every `--refresh` → bars step with each redraw.
- **`--plain` / `--format json` / piped / timeseries-only** → `frame_interval_ns` is 0, so `publish_ns` falls back to `--interval`. Output is byte-for-byte unchanged.

## Why it's safe

The published histogram is cumulative over the whole run (never reset per window), so `publish_ns` controls *staleness*, not *content* — a fresher publish only reduces lag, it never changes what a percentile means. It cannot affect plain, timeseries, or the final report.

## Tradeoff

The histogram copy (~184 KiB/connection) now runs up to 12.5× more often when a TUI is attached. Negligible at typical connection counts; at very high `-c`, raising `--refresh` bounds it (that flag now governs both repaint and data freshness).

## Verification

- `zig build` and `zig build test` pass
- Smoke-tested `--plain` and the live TUI (under a pty) against a local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)