### PR TITLE
ci: bump actions to Node-24-native versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Use the same Zig 0.16 the flake pins, so CI matches local dev exactly.
       - uses: cachix/install-nix-action@v30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     name: build binaries & publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Zig cross-compiles every target from this one Linux runner, using the
       # exact Zig 0.16 the flake pins.
@@ -72,7 +72,7 @@ jobs:
           ls -la dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           files: dist/*


### PR DESCRIPTION
## What

Bumps the GitHub Actions flagged by the Node 20 deprecation warning during the v0.3.3 release:

- `actions/checkout@v4` → `@v5` (in `ci.yml` and `release.yml`)
- `softprops/action-gh-release@v2` → `@v3` (in `release.yml`)

Both target Node 24 natively, silencing:

> Node.js 20 is deprecated. The following actions … are being forced to run on Node.js 24: actions/checkout@v4, softprops/action-gh-release@v2.

## Notes

- `cachix/install-nix-action@v30` was **not** flagged (already Node-24-compatible), so it's left unchanged.
- Chose `checkout@v5` (first Node-24 major, widely deployed) over the newer v6/v7 to keep the bump minimal and low-risk; a plain checkout has no behavior dependence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)