### PR TITLE
hdr: limit add/copyInto to the occupied index span

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,23 @@ pub fn build(b: *std.Build) void {
         run_cmd.addArgs(args);
     }
 
+    // `zig build bench`: the histogram publish/aggregate microbenchmark.
+    // Always ReleaseFast so the numbers mean something.
+    const bench_exe = b.addExecutable(.{
+        .name = "zrk-bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/bench.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+            .imports = &.{
+                .{ .name = "zrk", .module = mod },
+            },
+        }),
+    });
+    const bench_step = b.step("bench", "Run the histogram publish/aggregate benchmark");
+    const run_bench = b.addRunArtifact(bench_exe);
+    bench_step.dependOn(&run_bench.step);
+
     // `zig build test`: a test binary per module (a test executable covers
     // exactly one module, hence two of them).
     const mod_tests = b.addTest(.{

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -1,0 +1,120 @@
+//! Microbenchmark for the histogram publish/aggregate path.
+//!
+//! These two operations are the dashboard's per-frame cost (see tui/runner):
+//!   - `copyInto`  — a connection publishes its live histogram once per publish
+//!                   interval (now the `--refresh` cadence with a live TUI).
+//!   - reset + N×`add` — `stats.readSnapshot` merges every connection's snapshot
+//!                   into one aggregate, once per frame.
+//!
+//! Build/run:  zig build bench
+//! Both run over a realistic latency distribution so the touched index range
+//! reflects real use (which is what the range-limited variant exploits).
+
+const std = @import("std");
+const Io = std.Io;
+const zrk = @import("zrk");
+const hdr = zrk.hdr;
+
+fn nowNs(io: Io) i128 {
+    return Io.Timestamp.now(io, .awake).nanoseconds;
+}
+
+// Production histogram parameters (mirror stats.zig: 1µs .. 1h, 3 sig figs).
+const lowest: u64 = 1;
+const highest: u64 = 3_600_000_000;
+const sig_figs: u8 = 3;
+
+/// Fill `h` with a log-normal-ish latency spread (median ~3ms, tail to ~80ms,
+/// a sub-ms floor) plus a few outliers, so min/max span a realistic band.
+fn recordRealistic(h: *hdr.Histogram, rng: std.Random, n: usize) void {
+    var i: usize = 0;
+    while (i < n) : (i += 1) {
+        // exp(normal) around ln(3000µs); clamp to a sane floor.
+        const z = rng.floatNorm(f64);
+        const us = @exp(@log(3000.0) + 0.6 * z);
+        const v: u64 = @intFromFloat(@max(us, 200.0));
+        h.record(v);
+    }
+    // A handful of tail outliers (slow requests / GC pauses).
+    var k: usize = 0;
+    while (k < n / 500 + 1) : (k += 1) {
+        h.record(20_000 + rng.uintLessThan(u64, 60_000));
+    }
+}
+
+const print = std.debug.print;
+
+pub fn main() !void {
+    const a = std.heap.page_allocator;
+
+    var threaded = Io.Threaded.init(a, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    var prng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const rng = prng.random();
+
+    // One representative source histogram.
+    var src = try hdr.Histogram.init(a, lowest, highest, sig_figs);
+    defer src.deinit();
+    recordRealistic(&src, rng, 200_000);
+
+    var dst = try hdr.Histogram.init(a, lowest, highest, sig_figs);
+    defer dst.deinit();
+
+    const counts_len = src.counts_len;
+    const bytes = @as(usize, counts_len) * 8;
+
+    // Touched span: first..last nonzero index, the ceiling a range-limited
+    // copy/add could hit. Predicts the achievable speedup.
+    var lo: usize = counts_len;
+    var hi: usize = 0;
+    for (src.counts, 0..) |c, i| {
+        if (c != 0) {
+            if (i < lo) lo = i;
+            if (i > hi) hi = i;
+        }
+    }
+    const span = if (hi >= lo) hi - lo + 1 else 0;
+
+    
+    print("histogram: counts_len={d}  ({d:.1} KiB)\n", .{ counts_len, @as(f64, @floatFromInt(bytes)) / 1024.0 });
+    print("recorded:  n=200000  min={d}us max={d}us\n", .{ src.min_value, src.max_value });
+    print("touched:   [{d}..{d}]  span={d}  ({d:.1}% of array)\n\n", .{
+        lo, hi, span, 100.0 * @as(f64, @floatFromInt(span)) / @as(f64, @floatFromInt(counts_len)),
+    });
+
+    // --- copyInto (per publish) --------------------------------------------
+    const K = 20_000;
+    const ci_start = nowNs(io);
+    {
+        var i: usize = 0;
+        while (i < K) : (i += 1) {
+            src.copyInto(&dst);
+            std.mem.doNotOptimizeAway(dst.counts[hi]);
+        }
+    }
+    const ci_ns: u64 = @intCast(@divTrunc(nowNs(io) - ci_start, K));
+    print("copyInto:            {d:>7} ns/op   ({d:.1} GB/s)\n", .{
+        ci_ns, @as(f64, @floatFromInt(bytes)) / @as(f64, @floatFromInt(ci_ns)),
+    });
+
+    // --- reset + N×add (per readSnapshot frame) ----------------------------
+    for ([_]usize{ 10, 100, 1000 }) |nconns| {
+        const iters = 2000;
+        const start = nowNs(io);
+        var it: usize = 0;
+        while (it < iters) : (it += 1) {
+            dst.reset();
+            var c: usize = 0;
+            while (c < nconns) : (c += 1) dst.add(&src);
+            std.mem.doNotOptimizeAway(dst.counts[hi]);
+        }
+        const per_frame: u64 = @intCast(@divTrunc(nowNs(io) - start, iters));
+        // Live TUI redraws at --refresh (80ms) => 12.5 frames/s.
+        const per_sec_us = @as(f64, @floatFromInt(per_frame)) * 12.5 / 1000.0;
+        print("readSnapshot N={d:>4}:  {d:>9} ns/frame   ({d:.2} ms/s of runner CPU @12.5fps)\n", .{
+            nconns, per_frame, per_sec_us / 1000.0,
+        });
+    }
+}

--- a/src/hdr.zig
+++ b/src/hdr.zig
@@ -224,21 +224,49 @@ pub const Histogram = struct {
 
     // --- merging / snapshotting ---------------------------------------------
 
+    /// Inclusive counts-index span covering every nonzero bucket, or null when
+    /// empty. Counts indices increase monotonically with value, so every value
+    /// ever recorded — and thus every nonzero bucket — lies within
+    /// [index(min_value), index(max_value)]. Lets `add`/`copyInto` touch only
+    /// the occupied region instead of the whole (mostly-zero) array, which for
+    /// a clustered latency distribution is a fraction of `counts_len`.
+    const IndexSpan = struct { lo: u32, hi: u32 };
+    fn touchedSpan(self: *const Histogram) ?IndexSpan {
+        if (self.total_count == 0) return null;
+        return .{ .lo = self.countsIndexFor(self.min_value), .hi = self.countsIndexFor(self.max_value) };
+    }
+
     /// Add every count from `other` into `self`. Both histograms must have been
-    /// created with identical parameters (same counts layout).
+    /// created with identical parameters (same counts layout). Only `other`'s
+    /// occupied span is walked — adding its zero region is a no-op, so this is
+    /// exact regardless of `self`'s contents.
     pub fn add(self: *Histogram, other: *const Histogram) void {
         assert(self.counts_len == other.counts_len);
-        for (self.counts, other.counts) |*dst, src| dst.* += src;
+        const s = other.touchedSpan() orelse return;
+        for (self.counts[s.lo .. s.hi + 1], other.counts[s.lo .. s.hi + 1]) |*dst, src| dst.* += src;
         self.total_count += other.total_count;
         if (other.min_value < self.min_value) self.min_value = other.min_value;
         if (other.max_value > self.max_value) self.max_value = other.max_value;
     }
 
     /// Copy this histogram's contents into `dst` (which must share the layout).
-    /// Used to publish a snapshot without allocating.
+    /// Used to publish a snapshot without allocating. Copies only the occupied
+    /// span; any region `dst` still holds outside it is zeroed first, so the
+    /// result equals `self` even when `dst` was previously wider. (For the
+    /// monotonic cumulative snapshots this serves, the range only grows and the
+    /// zeroing is a no-op.)
     pub fn copyInto(self: *const Histogram, dst: *Histogram) void {
         assert(self.counts_len == dst.counts_len);
-        @memcpy(dst.counts, self.counts);
+        const src = self.touchedSpan();
+        if (dst.touchedSpan()) |d| {
+            if (src) |s| {
+                if (d.lo < s.lo) @memset(dst.counts[d.lo..s.lo], 0);
+                if (d.hi > s.hi) @memset(dst.counts[s.hi + 1 .. d.hi + 1], 0);
+            } else {
+                @memset(dst.counts[d.lo .. d.hi + 1], 0);
+            }
+        }
+        if (src) |s| @memcpy(dst.counts[s.lo .. s.hi + 1], self.counts[s.lo .. s.hi + 1]);
         dst.total_count = self.total_count;
         dst.min_value = self.min_value;
         dst.max_value = self.max_value;
@@ -699,6 +727,42 @@ test "setToDifference yields the interval between two cumulative snapshots" {
     // The interval contains only the new (9ms) samples.
     try testing.expect(delta.valuesAreEquivalent(delta.valueAtPercentile(50), 9000));
     try testing.expect(delta.valuesAreEquivalent(delta.min(), 9000));
+}
+
+test "copyInto onto a previously-wider dst drops the stale tail" {
+    // Guards the range-limited copyInto: when dst already holds a wider
+    // distribution than the source, the region the source doesn't cover must
+    // be zeroed, or a stale tail would survive and corrupt percentiles.
+    var wide = try newDefault();
+    defer wide.deinit();
+    var narrow = try newDefault();
+    defer narrow.deinit();
+    var dst = try newDefault();
+    defer dst.deinit();
+
+    wide.record(1000);
+    wide.record(500_000); // far tail → high counts index
+    wide.copyInto(&dst);
+    try testing.expectEqual(@as(u64, 2), dst.count());
+
+    narrow.record(1000); // narrower: never reaches the old tail
+    narrow.copyInto(&dst);
+
+    try testing.expectEqual(@as(u64, 1), dst.count());
+    try testing.expect(dst.valuesAreEquivalent(dst.max(), 1000));
+    try testing.expect(dst.valueAtPercentile(100) < 2000); // old 500ms tail is gone
+}
+
+test "copyInto from an empty source clears dst" {
+    var empty = try newDefault();
+    defer empty.deinit();
+    var dst = try newDefault();
+    defer dst.deinit();
+
+    dst.record(1234);
+    empty.copyInto(&dst);
+    try testing.expectEqual(@as(u64, 0), dst.count());
+    try testing.expectEqual(@as(u64, 0), dst.max());
 }
 
 test "zigzag varint: explicit encodings and round-trip" {


### PR DESCRIPTION
## What

The live dashboard's per-frame cost is dominated by histogram publish and aggregation:

- each connection `copyInto`s its **184 KiB** counts array once per publish (now the `--refresh` cadence with a TUI attached), and
- `readSnapshot` `add`s all N connections' snapshots into one aggregate **every frame**.

Both walked the full **23,552-bucket** array even though a real latency distribution occupies only a fraction of it.

This limits both to `[index(min_value), index(max_value)]` — the span that provably bounds every nonzero bucket, since HDR counts indices increase monotonically with value. **No new state** (min/max are already tracked) and **no precision loss**.

## Correctness

- `add` — exact unconditionally: the skipped region is all zeros and `+0` is identity.
- `copyInto` — zeroes any region `dst` still holds outside the source span before copying, so it's correct even if `dst` was previously wider (a no-op for the monotonic cumulative snapshots it actually serves). Two new tests cover the wider-`dst` and empty-source cases.

## Measured (ReleaseFast, distribution touching ~30% of the array)

| op | before | after | speedup |
|---|---|---|---|
| `copyInto` (per publish) | 4604 ns | 1484 ns | 3.1× |
| `readSnapshot` N=100 | 701 µs/frame | 200 µs | 3.5× |
| `readSnapshot` N=1000 | 6.95 ms/frame | 1.99 ms | 3.5× |

At `-c 1000` with a live TUI, per-frame aggregation drops from ~87 to ~25 ms/s of runner CPU. The win tracks the touched-span fraction, so it scales with how clustered the distribution is (real ones are clustered). This also buys back most of the cost the earlier `--refresh` change added (#22).

## Harness

Adds `src/bench.zig` + `zig build bench` (the harness these numbers came from). Not wired into `zig build test`; it's a standalone ReleaseFast executable.

## Verification

- `zig build test` passes, incl. the two new `copyInto` correctness tests.
- End-to-end run confirms live-aggregate and final-report percentiles match and the tail `max` is preserved identically across the `readSnapshot` and `readFinal` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)