### PR TITLE
Add --deadline mode to bound the CO latency tail under overload (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ zrk [options] <url>
   -m, --method      <M>     HTTP method                    (default GET)
   -b, --body     <S|@FILE>  Request body; @FILE reads it from a file
                             (@- = stdin, @@x = a literal "@x")
-      --timeout     <T>     Per-request timeout            (default 2s)
+      --timeout     <T>     Wire timeout per attempt, from the actual
+                            send (default 2s); does not bound CO latency
+      --deadline    <T>     Max coordinated-omission latency, from the
+                            scheduled send: a request past T is failed as
+                            a `deadline` error, not recorded (0 = off)
       --interval    <T>     Stats window: --timeseries rows and --plain
                             lines                          (default 1s)
       --refresh     <T>     Live dashboard redraw rate     (default 80ms)
@@ -61,8 +65,9 @@ zrk [options] <url>
                             latency percentiles) to FILE
       --timeseries-histogram  Add each interval's full latency histogram
                             (HdrHistogram base64) to every --timeseries row
-      --no-record-timeouts  Drop timed-out requests from the latency histogram
-                            (default: record them, so the tail isn't truncated)
+      --no-record-timeouts  Drop wire-timed-out requests from the latency
+                            histogram (default: record them, so the tail isn't
+                            truncated). --deadline misses are never recorded.
 
   CI gates (exit code 3 on breach):
       --slo-p99     <T>     Fail if final p99 latency exceeds T
@@ -123,7 +128,7 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
 {
   "zrk_version": "0.1.0",
   "target": { "url": "http://127.0.0.1:8080/", "method": "GET" },
-  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "record_timeouts": true },
+  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "record_timeouts": true },
   "duration_s": 20.002,
   "requests": 19998,
   "bytes": 1239876,
@@ -132,10 +137,11 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
   "rate_ratio": 0.9998,
   "bytes_per_sec": 61987.30,
   "error_rate": 0.000000,
+  "max_schedule_lag_us": 84,
   "latency_us": { "min": 106, "mean": 422.0, "stdev": 1222.9, "max": 13991,
                   "p50": 251, "p75": 337, "p90": 471, "p99": 1913, "p99_9": 13364, "p99_99": 13988 },
   "status_codes": { "1xx": 0, "2xx": 19998, "3xx": 0, "4xx": 0, "5xx": 0 },
-  "errors": { "connect": 0, "read": 0, "write": 0, "timeout": 0, "non_2xx_3xx": 0 },
+  "errors": { "connect": 0, "read": 0, "write": 0, "timeout": 0, "deadline": 0, "non_2xx_3xx": 0 },
   "latency_histogram": "HISTFAAAAUJ4nC1P..."
 }
 ```
@@ -182,6 +188,39 @@ Timed-out requests are recorded into the latency histogram by default (as a
 coordinated-omission-corrected sample) so the tail isn't silently truncated;
 `--no-record-timeouts` restores wrk2's drop-on-timeout behavior.
 
+### `--timeout` vs `--deadline` (bounding the tail under overload)
+
+These knobs sound similar but measure from **different clocks**, and the
+difference only shows up under overload:
+
+- **`--timeout`** is a **wire** timeout, measured from the *actual* send. It
+  bounds one attempt on the wire (`done − actual_send`) and catches a hung
+  socket or a dead server. It does **not** bound coordinated-omission latency:
+  when a connection falls behind its schedule, each attempt still goes out and
+  comes back quickly, so the timeout never trips even though the *recorded* CO
+  latency (measured from the request's **scheduled** time) balloons into the
+  tens of seconds. A tight `--timeout 1s` will happily sit next to a 30 s `p50`.
+- **`--deadline`** is what actually bounds that tail. It is measured from each
+  request's **scheduled** send time and bounds `done − scheduled`. A request
+  whose CO latency would exceed the deadline is **failed as a `deadline`
+  error** rather than recorded — shed before it is even sent if it is already
+  too stale, or shut down in flight at `scheduled + deadline`. This is the
+  usual benchmark intent ("past X ms it's a failed request, per our SLA").
+
+With `--deadline` set, the latency histogram becomes the distribution of
+requests **served within the deadline** (so its tail is bounded by the
+deadline), and sustained overload shows up as a rising `deadline` error count
+instead of an unbounded latency tail. That makes both CI gates meaningful at
+once under overload: `--slo-p99` stays a p99 of *met* latency, while
+`--max-error-rate` catches the deadline-miss rate. Deadline misses are **never**
+recorded into the histogram (unlike wire timeouts), so `--no-record-timeouts`
+does not affect them.
+
+`max_schedule_lag_us` (JSON) / "Peak schedule lag" (text report) is the backlog
+gauge: the peak `now − scheduled` the fleet ever reached. It is populated even
+without `--deadline`, so it is an early warning that the client is falling
+behind the offered schedule — a companion to `rate_ratio` / `achieved_rate`.
+
 ## How it works
 
 - **One request in flight per connection** (like wrk/wrk2). Throughput comes
@@ -220,9 +259,11 @@ coordinated-omission-corrected sample) so the tail isn't silently truncated;
   (e.g. 2000 req/s at 5 ms ⇒ ≥ 10 connections). Below that the client, not the
   server, is the bottleneck; watch `rate_ratio` / `achieved_rate` in the JSON
   report to confirm the offered load was actually delivered.
-- `--timeout` bounds the **response** (a request whose response doesn't arrive
-  in time is abandoned and counted as `Socket errors: ... timeout N`, matching
-  wrk2). The *connect* itself still uses the OS default, since
+- `--timeout` bounds the **wire attempt** from the actual send (a response that
+  doesn't arrive in time is abandoned and counted as `Socket errors: ... timeout
+  N`, matching wrk2). It does **not** bound coordinated-omission latency under
+  overload — use `--deadline` for that (see "`--timeout` vs `--deadline`"
+  above). The *connect* itself still uses the OS default, since
   connect-with-timeout is unimplemented in the std backend and panics.
 - `-k` skips certificate verification; with the std TLS client this also omits
   SNI, so name-based virtual hosts may respond differently under `-k`.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -44,8 +44,15 @@ pub const Config = struct {
     /// End rate for a linear ramp (null = constant `rate`). When set, the total
     /// target rate ramps linearly from `rate` to `rate_end` over the duration.
     rate_end: ?u64 = null,
-    /// Per-request timeout.
+    /// Per-request wire timeout: bounds the attempt on the wire, measured from
+    /// the actual send (catches a hung socket / dead server). Does *not* bound
+    /// coordinated-omission latency under overload — see `deadline_ns`.
     timeout_ns: u64 = 2 * std.time.ns_per_s,
+    /// Coordinated-omission deadline (0 = off): a request whose CO-corrected
+    /// latency (measured from its *scheduled* send time) would exceed this is
+    /// failed as a `deadline` error rather than recorded, bounding the latency
+    /// tail and surfacing sustained overload through the error path.
+    deadline_ns: u64 = 0,
     /// Stats window: per-connection publish period, `--timeseries` row cadence,
     /// and the line rate of `--plain` output.
     interval_ns: u64 = 1 * std.time.ns_per_s,
@@ -133,7 +140,11 @@ pub const usage =
     \\  -m, --method      <M>     HTTP method                    (default GET)
     \\  -b, --body     <S|@FILE>  Request body; @FILE reads it from a file
     \\                            (@- = stdin, @@x = a literal "@x")
-    \\      --timeout     <T>     Per-request timeout            (default 2s)
+    \\      --timeout     <T>     Wire timeout per attempt, from the actual
+    \\                            send (default 2s); does not bound CO latency
+    \\      --deadline    <T>     Max coordinated-omission latency, from the
+    \\                            scheduled send: a request past T is failed as
+    \\                            a `deadline` error, not recorded (0 = off)
     \\      --interval    <T>     Stats window: --timeseries rows and --plain
     \\                            lines                          (default 1s)
     \\      --refresh     <T>     Live dashboard redraw rate     (default 80ms)
@@ -150,8 +161,9 @@ pub const usage =
     \\                            latency percentiles) to FILE
     \\      --timeseries-histogram  Add each interval's full latency histogram
     \\                            (HdrHistogram base64) to every --timeseries row
-    \\      --no-record-timeouts  Drop timed-out requests from the latency
-    \\                            histogram (default: record them)
+    \\      --no-record-timeouts  Drop wire-timed-out requests from the latency
+    \\                            histogram (default: record them). Independent
+    \\                            of --deadline misses, which are never recorded.
     \\
     \\CI gates (exit code 3 on breach):
     \\      --slo-p99     <T>     Fail if final p99 latency exceeds T
@@ -229,6 +241,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.rate_end = spec.end;
         } else if (eq(arg, "--timeout")) {
             cfg.timeout_ns = try parseDuration(try nextValue(tokens, &i));
+        } else if (eq(arg, "--deadline")) {
+            cfg.deadline_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--interval")) {
             cfg.interval_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--refresh")) {
@@ -458,6 +472,17 @@ test "zero interval is rejected" {
     try testing.expectEqual(@as(u64, 0), cfg.timeout_ns);
 }
 
+test "deadline flag parses; defaults off" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+    // Off by default (0 = no deadline), independent of --timeout's own default.
+    const default = (try parse(a, &[_][]const u8{"http://x/"})).config;
+    try testing.expectEqual(@as(u64, 0), default.deadline_ns);
+    const cfg = (try parse(a, &[_][]const u8{ "--deadline", "250ms", "http://x/" })).config;
+    try testing.expectEqual(@as(u64, 250 * std.time.ns_per_ms), cfg.deadline_ns);
+}
+
 test "refresh flag parses and zero is rejected" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -516,12 +541,12 @@ test "parse full command line" {
     const arena = arena_state.allocator();
 
     const args = [_][]const u8{
-        "-c",         "100",
-        "-d",         "30s",
-        "-R",         "2000",
-        "-H",         "Accept: application/json",
-        "-H",         "X-Test: 1",
-        "--latency",  "http://127.0.0.1:8080/index.html",
+        "-c",        "100",
+        "-d",        "30s",
+        "-R",        "2000",
+        "-H",        "Accept: application/json",
+        "-H",        "X-Test: 1",
+        "--latency", "http://127.0.0.1:8080/index.html",
     };
     const parsed = try parse(arena, &args);
     const cfg = parsed.config;
@@ -579,13 +604,12 @@ test "parse reporting and CI-gate flags" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
     const args = [_][]const u8{
-        "--format",         "json",
-        "-o",               "out.json",
-        "--hdr",            "lat.hgrm",
-        "--slo-p99",        "250ms",
-        "--max-error-rate", "1%",
-        "--no-record-timeouts",
-        "http://127.0.0.1:8080/",
+        "--format",             "json",
+        "-o",                   "out.json",
+        "--hdr",                "lat.hgrm",
+        "--slo-p99",            "250ms",
+        "--max-error-rate",     "1%",
+        "--no-record-timeouts", "http://127.0.0.1:8080/",
     };
     const cfg = (try parse(arena_state.allocator(), &args)).config;
     try testing.expectEqual(Format.json, cfg.format);

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -31,8 +31,19 @@ pub const Counters = struct {
     write_errors: u64 = 0,
     /// Failures while reading/parsing a response.
     read_errors: u64 = 0,
-    /// Requests abandoned because the response exceeded `--timeout`.
+    /// Requests abandoned because the response exceeded the wire `--timeout`.
     timeouts: u64 = 0,
+    /// Requests that missed their coordinated-omission `--deadline`: either shed
+    /// before sending (already staler than the deadline) or shut down in flight
+    /// once `scheduled + deadline` passed. Distinct from wire `timeouts`, and —
+    /// unlike a timeout — never recorded as a latency sample, so the histogram
+    /// stays the distribution of requests served *within* the deadline.
+    deadline_errors: u64 = 0,
+    /// Peak observed schedule lag (`now − scheduled`) in nanoseconds: how far
+    /// behind its intended send time this connection ever fell. A backlog gauge
+    /// — nonzero means the client could not keep up with the offered schedule
+    /// (see `--deadline`). Aggregated as a max, not a sum.
+    max_behind_ns: u64 = 0,
     /// Completed responses bucketed by status class, indexed by status/100
     /// (so [1]=1xx .. [5]=5xx; index 0 is unused). Sums to `completed`.
     status_class: [6]u64 = [_]u64{0} ** 6,
@@ -45,7 +56,14 @@ pub const Counters = struct {
         self.write_errors += other.write_errors;
         self.read_errors += other.read_errors;
         self.timeouts += other.timeouts;
+        self.deadline_errors += other.deadline_errors;
+        self.max_behind_ns = @max(self.max_behind_ns, other.max_behind_ns);
         for (&self.status_class, other.status_class) |*d, s| d.* += s;
+    }
+
+    /// Update the peak schedule-lag gauge with one send's observed lag (ns).
+    pub fn noteBehind(self: *Counters, behind_ns: u64) void {
+        if (behind_ns > self.max_behind_ns) self.max_behind_ns = behind_ns;
     }
 
     /// Record a completed response's status: bump its class bucket and, for
@@ -100,10 +118,22 @@ pub const Params = struct {
     /// sends spread uniformly instead of firing in N-connection lockstep
     /// waves (which quantize per-interval throughput to multiples of N).
     phase: f64 = 0,
-    /// Per-request response timeout (0 = no timeout).
+    /// Per-request wire timeout, measured from the actual send (0 = none).
+    /// Bounds `done − actual_send` — the attempt on the wire — so it catches a
+    /// hung socket or a dead server, but does *not* bound the coordinated-
+    /// omission latency (which also includes time spent behind schedule). See
+    /// `deadline_ns` for that.
     timeout_ns: u64,
+    /// Coordinated-omission deadline, measured from each request's *scheduled*
+    /// send time (0 = none). Bounds `done − scheduled`: a request whose CO
+    /// latency would exceed this is failed as a `deadline` error — shed before
+    /// sending if already too stale, or shut down in flight at `scheduled +
+    /// deadline` — instead of being recorded, which bounds the latency tail and
+    /// makes sustained overload surface through the error path.
+    deadline_ns: u64 = 0,
     /// Record a coordinated-omission-corrected latency sample when a request
-    /// times out, instead of dropping it (which would truncate the tail).
+    /// times out on the wire, instead of dropping it (which would truncate the
+    /// tail). Does not apply to `deadline` misses, which are never recorded.
     record_timeouts: bool = true,
     /// Monotonic timestamp at which the connection should stop sending.
     end: Io.Timestamp,
@@ -178,10 +208,18 @@ pub fn run(p: *Params) void {
         // backend that per-request spawn/cancel pair costs milliseconds
         // (macOS especially), capping every connection near 500 req/s no
         // matter how fast the target answers.
-        var watchdog: Watchdog = .{ .io = io, .stream = &stream, .timeout_ns = p.timeout_ns };
+        var watchdog: Watchdog = .{
+            .io = io,
+            .stream = &stream,
+            .timeout_ns = p.timeout_ns,
+            .deadline_ns = p.deadline_ns,
+            // Idle tick cadence: the tighter of the two bounds, so an
+            // armed request is caught at most ~1.5x that bound late.
+            .tick_ns = tighter(p.timeout_ns, p.deadline_ns),
+        };
         var watchdog_group: Io.Group = .init;
         var watchdog_active = false;
-        if (p.timeout_ns != 0) {
+        if (p.timeout_ns != 0 or p.deadline_ns != 0) {
             if (watchdog_group.concurrent(io, Watchdog.watch, .{&watchdog})) |_| {
                 watchdog_active = true;
             } else |_| {
@@ -208,6 +246,23 @@ pub fn run(p: *Params) void {
             const offset = p.schedule.offsetNs(send_index, p.phase);
             const scheduled = anchor.?.addDuration(Io.Duration.fromNanoseconds(@intCast(offset)));
 
+            // Schedule lag: how late this send already is. Positive only under
+            // load (when ahead we pace below); feeds the backlog gauge and the
+            // deadline check. Both clocks are monotonic, so `behind` fits u64.
+            const behind_ns: i128 = t.nanoseconds - scheduled.nanoseconds;
+            if (behind_ns > 0) p.counters.noteBehind(@intCast(behind_ns));
+
+            // Deadline shedding: a request already staler than the deadline can
+            // never meet it, so fail it now — without touching the wire — and
+            // move on. This lets the connection shed accumulated backlog and
+            // keep measuring near-live latency instead of serializing through an
+            // ever-staler queue; the misses surface as `deadline` errors.
+            if (p.deadline_ns != 0 and behind_ns > p.deadline_ns) {
+                noteDeadline(p);
+                send_index += 1;
+                continue;
+            }
+
             // Pace: if we're ahead of schedule, wait; if behind, fire immediately.
             if (scheduled.nanoseconds > t.nanoseconds) {
                 const wait = Io.Duration.fromNanoseconds(scheduled.nanoseconds - t.nanoseconds);
@@ -215,21 +270,27 @@ pub fn run(p: *Params) void {
             }
             send_index += 1;
 
-            // Send the request and read its response inline on this thread;
-            // the watchdog turns a stalled read into a socket shutdown, which
-            // surfaces here as a read failure that `fired` reclassifies.
-            if (watchdog_active) watchdog.arm(now(io));
+            // Send the request and read its response inline on this thread; the
+            // watchdog turns a stalled read into a socket shutdown, which
+            // surfaces here as a read failure that `fired` reclassifies. Arm
+            // against both bounds: the wire timeout from the actual send, and
+            // the CO deadline from the scheduled time (whichever is earlier).
+            if (watchdog_active) watchdog.arm(scheduled, now(io));
             const work = performWork(p, app_reader, app_writer);
             if (watchdog_active) watchdog.disarm();
             const timed_out = watchdog_active and watchdog.fired.load(.acquire);
+            // A fired watchdog is a deadline miss when the CO bound was the one
+            // that expired, else a wire timeout. `fired_reason` is set at arm
+            // time and only ever touched by this (the request) thread.
+            const deadline_hit = timed_out and watchdog.fired_reason == .deadline;
 
             switch (work) {
                 .write_failed => {
-                    if (timed_out) noteTimeout(p, io, scheduled) else noteError(p, .write);
+                    if (deadline_hit) noteDeadline(p) else if (timed_out) noteTimeout(p, io, scheduled) else noteError(p, .write);
                     conn_open = false;
                 },
                 .read_failed => {
-                    if (timed_out) noteTimeout(p, io, scheduled) else noteError(p, .read);
+                    if (deadline_hit) noteDeadline(p) else if (timed_out) noteTimeout(p, io, scheduled) else noteError(p, .read);
                     conn_open = false;
                 },
                 .ok => |resp| {
@@ -266,60 +327,96 @@ const WorkResult = union(enum) {
     read_failed,
 };
 
-/// One per connection: watches the in-flight request's deadline and, on
+/// The tighter (smaller nonzero) of two bounds, or 0 if both are 0. Used to
+/// pick the watchdog's idle tick cadence from the wire timeout and deadline.
+fn tighter(a: u64, b: u64) u64 {
+    if (a == 0) return b;
+    if (b == 0) return a;
+    return @min(a, b);
+}
+
+/// One per connection: watches the in-flight request's expiry and, on
 /// expiry, shuts the stream down so the blocked read unblocks with an error
-/// the request loop reclassifies as a timeout (the wrk approach, adapted to
-/// blocking threads). Arming costs one atomic store on the request path —
-/// no per-request task spawns.
+/// the request loop reclassifies as a timeout or deadline miss (the wrk
+/// approach, adapted to blocking threads). Arming costs one atomic store on
+/// the request path — no per-request task spawns.
+///
+/// The expiry is the earlier of two bounds: the wire timeout from the actual
+/// send (`sent + timeout_ns`) and the CO deadline from the scheduled send
+/// (`scheduled + deadline_ns`); either is omitted when its config is 0.
 const Watchdog = struct {
     io: Io,
     stream: *net.Stream,
+    /// Wire timeout (0 = none): bounds the attempt from the actual send.
     timeout_ns: u64,
-    /// Monotonic-ns deadline of the in-flight request; 0 = idle. i64 (not
+    /// CO deadline (0 = none): bounds latency from the scheduled send.
+    deadline_ns: u64,
+    /// Idle tick cadence base: the tighter of the two bounds.
+    tick_ns: u64,
+    /// Monotonic-ns expiry of the in-flight request; 0 = idle. i64 (not
     /// the timestamp's native i128) because 128-bit atomics don't exist on
     /// x86_64; saturating i64 nanoseconds still spans ~292 years of uptime.
-    deadline_ns: std.atomic.Value(i64) = .init(0),
+    expiry_ns: std.atomic.Value(i64) = .init(0),
     /// True once the stream has been shut down; read by the request loop
-    /// to tell a timeout from a genuine transport failure.
+    /// to tell an expiry from a genuine transport failure.
     fired: std.atomic.Value(bool) = .init(false),
+    /// Which bound the current arm expires on, so the request loop can tell a
+    /// deadline miss from a wire timeout. Written by the request thread at arm
+    /// time and read by it after disarm; the watchdog thread never touches it.
+    fired_reason: Reason = .wire,
 
-    fn arm(w: *Watchdog, t: Io.Timestamp) void {
-        const deadline = std.math.lossyCast(i64, t.nanoseconds + @as(i128, w.timeout_ns));
-        w.deadline_ns.store(deadline, .release);
+    const Reason = enum { wire, deadline };
+
+    fn arm(w: *Watchdog, scheduled: Io.Timestamp, sent: Io.Timestamp) void {
+        var expiry: i128 = std.math.maxInt(i64);
+        var reason: Reason = .wire;
+        if (w.timeout_ns != 0) {
+            expiry = sent.nanoseconds + @as(i128, w.timeout_ns);
+            reason = .wire;
+        }
+        if (w.deadline_ns != 0) {
+            const co = scheduled.nanoseconds + @as(i128, w.deadline_ns);
+            if (co < expiry) {
+                expiry = co;
+                reason = .deadline;
+            }
+        }
+        w.fired_reason = reason;
+        w.expiry_ns.store(std.math.lossyCast(i64, expiry), .release);
     }
 
     fn disarm(w: *Watchdog) void {
-        w.deadline_ns.store(0, .release);
+        w.expiry_ns.store(0, .release);
     }
 
     /// Runs until it fires or is canceled at connection teardown. While a
-    /// request is in flight it sleeps exactly to that deadline (successive
-    /// deadlines only move forward, so it can never oversleep a later one);
-    /// while idle it ticks at half the timeout, so a request armed mid-tick
-    /// is caught at most 1.5x the timeout late. Deliberate slack: this
+    /// request is in flight it sleeps exactly to that expiry (successive
+    /// expiries only move forward, so it can never oversleep a later one);
+    /// while idle it ticks at half the tighter bound, so a request armed
+    /// mid-tick is caught at most 1.5x that bound late. Deliberate slack: this
     /// guards against stalls, it is not a precision timer.
     fn watch(w: *Watchdog) void {
         const io = w.io;
         while (true) {
-            const deadline = w.deadline_ns.load(.acquire);
+            const expiry = w.expiry_ns.load(.acquire);
             const t = std.math.lossyCast(i64, now(io).nanoseconds);
-            if (deadline != 0 and t >= deadline) {
-                // Fire only if this exact deadline is still armed: the request
+            if (expiry != 0 and t >= expiry) {
+                // Fire only if this exact expiry is still armed: the request
                 // may have completed (disarm, possibly followed by the next
                 // arm) since the load above, and shutting the socket down then
-                // would misclassify the *next* request as a timeout. Deadlines
-                // strictly increase, so there is no ABA to worry about.
-                if (w.deadline_ns.cmpxchgStrong(deadline, 0, .acq_rel, .acquire) == null) {
+                // would misclassify the *next* request. Expiries strictly
+                // increase, so there is no ABA to worry about.
+                if (w.expiry_ns.cmpxchgStrong(expiry, 0, .acq_rel, .acquire) == null) {
                     w.fired.store(true, .release);
                     w.stream.shutdown(io, .both) catch {};
                     return;
                 }
-                continue; // Deadline moved: re-evaluate against the new one.
+                continue; // Expiry moved: re-evaluate against the new one.
             }
-            const sleep_ns: i64 = if (deadline != 0)
-                deadline - t
+            const sleep_ns: i64 = if (expiry != 0)
+                expiry - t
             else
-                @intCast(@max(w.timeout_ns / 2, std.time.ns_per_ms));
+                @intCast(@max(w.tick_ns / 2, std.time.ns_per_ms));
             io.sleep(Io.Duration.fromNanoseconds(@intCast(sleep_ns)), .awake) catch return;
         }
     }
@@ -371,6 +468,19 @@ fn noteTimeout(p: *Params, io: Io, scheduled: Io.Timestamp) void {
     }
     // Publish so a fully stalled target still surfaces on the dashboard.
     maybePublish(p, done.nanoseconds);
+}
+
+/// A request that missed its coordinated-omission `--deadline`: shed before
+/// sending (already too stale) or shut down in flight at `scheduled + deadline`.
+/// Counted as an error so sustained overload surfaces through `--max-error-rate`
+/// instead of an unbounded latency tail, but deliberately *not* recorded as a
+/// latency sample — the histogram stays the distribution of requests served
+/// within the deadline. Skipped during shutdown, where it would be a teardown
+/// artifact rather than a real miss.
+fn noteDeadline(p: *Params) void {
+    if (p.stop.load(.monotonic)) return;
+    p.counters.deadline_errors += 1;
+    maybePublish(p, now(p.io).nanoseconds);
 }
 
 /// Publish this connection's live state for the dashboard. Counters are
@@ -716,4 +826,169 @@ test "run with record_timeouts disabled drops timed-out samples" {
 
     try testing.expect(counters.timeouts > 0);
     try testing.expectEqual(@as(u64, 0), histogram.count());
+}
+
+test "deadline mode fails stale requests without recording them" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    try group.concurrent(io, stallServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(500));
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        .is_tls = false,
+        .insecure = false,
+        .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } }, // ~500 req/s
+        // No wire timeout: the deadline alone must catch the stall in flight,
+        // shutting each blocked request down at `scheduled + deadline`.
+        .timeout_ns = 0,
+        .deadline_ns = 50 * std.time.ns_per_ms,
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    group.cancel(io);
+    server.deinit(io);
+
+    // The server never responds, so nothing completes; every request misses the
+    // deadline and is counted as such — never as a wire timeout.
+    try testing.expectEqual(@as(u64, 0), counters.completed);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    try testing.expect(counters.deadline_errors > 0);
+    // Deadline misses are failures, not latencies: the histogram stays empty
+    // (contrast the timeout test above, where record_timeouts fills the tail).
+    try testing.expectEqual(@as(u64, 0), histogram.count());
+    // The stall drives the connection a full deadline behind its schedule, so
+    // the backlog gauge registers substantial lag (equilibrium sits near the
+    // 50ms deadline; assert well above jitter).
+    try testing.expect(counters.max_behind_ns > 20 * std.time.ns_per_ms);
+}
+
+test "deadline mode sheds backlog under overload and bounds the recorded tail" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    // A fast keep-alive server: responses are instant, so the *only* thing that
+    // can make the connection fall behind is an unservably high offered rate.
+    var group: Io.Group = .init;
+    group.async(io, testServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(300));
+    const deadline_ns = 20 * std.time.ns_per_ms;
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        .is_tls = false,
+        .insecure = false,
+        // 500k req/s on one blocking connection is unachievable on loopback, so
+        // the connection falls behind and — once past the deadline — sheds.
+        .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_us } },
+        .timeout_ns = 0,
+        .deadline_ns = deadline_ns,
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Some requests are served (the connection keeps probing near-live latency)
+    // and some are shed as the backlog outruns the deadline.
+    try testing.expect(counters.completed > 0);
+    try testing.expect(counters.deadline_errors > 0);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    // Only served requests are recorded; shed ones are not.
+    try testing.expectEqual(counters.completed, histogram.count());
+    // The recorded tail is bounded by the deadline: shedding keeps sends within
+    // one deadline of schedule, so every recorded latency stays near/under it
+    // (vs. the tens-of-seconds tail this mode exists to prevent).
+    try testing.expect(histogram.max() <= 2 * deadline_ns / std.time.ns_per_us);
+}
+
+test "a generous deadline never fires against a healthy server" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    group.async(io, testServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(200));
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        .is_tls = false,
+        .insecure = false,
+        .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } }, // ~500 req/s
+        .timeout_ns = 0,
+        .deadline_ns = 1 * std.time.ns_per_s, // far above loopback latency
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // A connection that keeps up never sheds and never expires in flight: every
+    // request completes and is recorded, and the deadline path stays untouched.
+    try testing.expect(counters.completed > 0);
+    try testing.expectEqual(@as(u64, 0), counters.deadline_errors);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    try testing.expectEqual(counters.completed, histogram.count());
 }

--- a/src/report.zig
+++ b/src/report.zig
@@ -11,11 +11,15 @@ const stats = @import("stats.zig");
 const hdr = @import("hdr.zig");
 const connection = @import("connection.zig");
 
-/// Fraction of outcomes that were failures: non-2xx/3xx responses plus socket
-/// errors (connect/read/write/timeout), over all attempts. 0 when idle.
+/// Fraction of outcomes that were failures: non-2xx/3xx responses, socket
+/// errors (connect/read/write/timeout), and `--deadline` misses, over all
+/// attempts. Deadline misses count as both a failure and an attempt, so under
+/// overload the rate reflects the fraction of the offered schedule that could
+/// not be served within the deadline. 0 when idle.
 pub fn errorRate(c: connection.Counters) f64 {
-    const errs = c.status_errors + c.socketErrors();
-    const total = c.completed + c.socketErrors();
+    const failures = c.socketErrors() + c.deadline_errors;
+    const errs = c.status_errors + failures;
+    const total = c.completed + failures;
     if (total == 0) return 0;
     return @as(f64, @floatFromInt(errs)) / @as(f64, @floatFromInt(total));
 }
@@ -78,13 +82,14 @@ pub fn writeJson(
 
     try w.writeAll("  \"config\": {");
     try w.print(
-        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"record_timeouts\": {} }},\n",
+        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"record_timeouts\": {} }},\n",
         .{
             cfg.connections,
             launched,
             @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s,
             cfg.rate,
             cfg.timeout_ns / std.time.ns_per_ms,
+            cfg.deadline_ns / std.time.ns_per_ms,
             cfg.record_timeouts,
         },
     );
@@ -98,13 +103,17 @@ pub fn writeJson(
     try w.print("  \"rate_ratio\": {d:.4},\n", .{if (avg_target > 0) achieved / avg_target else 0});
     try w.print("  \"bytes_per_sec\": {d:.2},\n", .{bps});
     try w.print("  \"error_rate\": {d:.6},\n", .{errorRate(c)});
+    // Peak schedule lag (µs): how far behind its intended send the fleet ever
+    // fell — the backlog gauge. Large values mean the client couldn't sustain
+    // the offered schedule (see also achieved_rate / rate_ratio).
+    try w.print("  \"max_schedule_lag_us\": {d},\n", .{c.max_behind_ns / std.time.ns_per_us});
 
     try w.writeAll("  \"latency_us\": {\n");
     try w.print("    \"min\": {d}, \"mean\": {d:.1}, \"stdev\": {d:.1}, \"max\": {d},\n", .{
         h.min(), h.mean(), h.stdDev(), h.max(),
     });
     try w.print("    \"p50\": {d}, \"p75\": {d}, \"p90\": {d}, \"p99\": {d}, \"p99_9\": {d}, \"p99_99\": {d}\n", .{
-        h.valueAtPercentile(50), h.valueAtPercentile(75),  h.valueAtPercentile(90),
+        h.valueAtPercentile(50), h.valueAtPercentile(75),   h.valueAtPercentile(90),
         h.valueAtPercentile(99), h.valueAtPercentile(99.9), h.valueAtPercentile(99.99),
     });
     try w.writeAll("  },\n");
@@ -115,8 +124,8 @@ pub fn writeJson(
     });
 
     try w.writeAll("  \"errors\": {");
-    try w.print(" \"connect\": {d}, \"read\": {d}, \"write\": {d}, \"timeout\": {d}, \"non_2xx_3xx\": {d} }},\n", .{
-        c.connect_errors, c.read_errors, c.write_errors, c.timeouts, c.status_errors,
+    try w.print(" \"connect\": {d}, \"read\": {d}, \"write\": {d}, \"timeout\": {d}, \"deadline\": {d}, \"non_2xx_3xx\": {d} }},\n", .{
+        c.connect_errors, c.read_errors, c.write_errors, c.timeouts, c.deadline_errors, c.status_errors,
     });
 
     // Full distribution, losslessly re-decodable by any HdrHistogram library.
@@ -182,7 +191,7 @@ pub const TimeSeries = struct {
         const interval_s = elapsed_s - self.prev_elapsed_s;
         const d_completed = snap.counters.completed -| self.prev_completed;
         const d_bytes = snap.counters.bytes -| self.prev_bytes;
-        const cur_errors = snap.counters.status_errors + snap.counters.socketErrors();
+        const cur_errors = snap.counters.status_errors + snap.counters.socketErrors() + snap.counters.deadline_errors;
         const d_errors = cur_errors -| self.prev_errors;
         const achieved: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_completed)) / interval_s else 0;
         const bps: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_bytes)) / interval_s else 0;
@@ -280,10 +289,13 @@ test "writeJson emits parseable, well-formed summary" {
     snap.counters.bytes = 4200;
     snap.counters.recordStatus(200);
     snap.counters.recordStatus(500);
+    snap.counters.deadline_errors = 7;
+    snap.counters.max_behind_ns = 12_000; // 12ms peak lag
 
     var alloc = Io.Writer.Allocating.init(testing.allocator);
     defer alloc.deinit();
-    const cfg = testConfig();
+    var cfg = testConfig();
+    cfg.deadline_ns = 250 * std.time.ns_per_ms;
     try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, 1.0, 4);
     const out = alloc.written();
 
@@ -296,6 +308,10 @@ test "writeJson emits parseable, well-formed summary" {
     try testing.expect(std.mem.indexOf(u8, out, "\"target_rate\": 1000") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"5xx\": 1") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_us\"") != null);
+    // Deadline mode surfaces in config, the errors object, and the backlog gauge.
+    try testing.expect(std.mem.indexOf(u8, out, "\"deadline_ms\": 250") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"deadline\": 7") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"max_schedule_lag_us\": 12") != null);
     // The embedded HdrHistogram blob is present and decodes back to 100 samples.
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_histogram\": \"HIST") != null);
 }
@@ -362,6 +378,12 @@ test "errorRate and checkSlo gates" {
     c.timeouts = 1; // one socket error
     // errors = status_errors(1) + socketErrors(1) = 2; total = completed(98)+socket(1)=99
     try testing.expectApproxEqAbs(@as(f64, 2.0 / 99.0), errorRate(c), 1e-9);
+
+    // Deadline misses count as both a failure and an attempt: adding one moves
+    // the rate to 3/100, so --max-error-rate can see overload-driven misses.
+    c.deadline_errors = 1;
+    try testing.expectApproxEqAbs(@as(f64, 3.0 / 100.0), errorRate(c), 1e-9);
+    c.deadline_errors = 0;
 
     var snap: stats.Snapshot = .{
         .hist = try stats.newHistogram(testing.allocator),

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -102,6 +102,7 @@ pub fn run(
         .insecure = cfg.insecure,
         .schedule = schedule,
         .timeout_ns = cfg.timeout_ns,
+        .deadline_ns = cfg.deadline_ns,
         .record_timeouts = cfg.record_timeouts,
         .end = end,
         .stop = &stop,

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -167,7 +167,7 @@ pub const Dashboard = struct {
                 elapsed_s,               rate,
                 Bytes.of(bps),           Dur.of(snap.hist.valueAtPercentile(50)),
                 Dur.of(p99),             Dur.of(snap.hist.valueAtPercentile(99.9)),
-                Dur.of(snap.hist.max()), snap.counters.socketErrors() + snap.counters.status_errors,
+                Dur.of(snap.hist.max()), snap.counters.socketErrors() + snap.counters.status_errors + snap.counters.deadline_errors,
             });
         }
         try self.fw.interface.flush();
@@ -271,6 +271,16 @@ pub const Dashboard = struct {
         if (errs > 0 or c.status_errors > 0) {
             try w.print("{s}socket errors {d}   non-2xx/3xx {d}{s}\n", .{
                 k.red, errs, c.status_errors, k.reset,
+            });
+            lines += 1;
+        }
+        // Deadline misses and peak schedule lag: the overload signal. The lag
+        // gauge shows even when nothing has missed yet (a ramp approaching the
+        // knee), so it's the earliest warning that the client is falling behind.
+        if (c.deadline_errors > 0 or (self.cfg.deadline_ns != 0 and c.max_behind_ns > 0)) {
+            try w.print("{s}deadline misses {d}{s}   {s}peak lag{s} {f}\n", .{
+                k.red, c.deadline_errors, k.reset,
+                k.dim, k.reset,           Dur.of(c.max_behind_ns / std.time.ns_per_us),
             });
             lines += 1;
         }
@@ -458,6 +468,16 @@ pub const Dashboard = struct {
                 c.connect_errors, c.read_errors, c.write_errors, c.timeouts,
             });
         }
+        if (c.deadline_errors > 0) {
+            try w.print("  Deadline misses: {d} (CO latency exceeded --deadline)\n", .{c.deadline_errors});
+        }
+        // Peak schedule lag is the backlog gauge; sub-millisecond lag is normal
+        // jitter, so only report it once it's large enough to signal overload.
+        if (c.max_behind_ns >= std.time.ns_per_ms) {
+            try w.writeAll("  Peak schedule lag: ");
+            try Dur.write(w, @floatFromInt(c.max_behind_ns / std.time.ns_per_us));
+            try w.writeAll("\n");
+        }
         try w.print("Requests/sec: {d:.2}\n", .{rps});
         try w.writeAll("Transfer/sec: ");
         try writeBytes(w, bps);
@@ -579,4 +599,33 @@ test "writeReport renders the wrk2-style summary to any writer" {
     try testing.expect(std.mem.indexOf(u8, text, "Requests/sec: 50.00") != null);
     // No terminal control sequences in the redirectable report.
     try testing.expect(std.mem.indexOf(u8, text, "\x1b") == null);
+    // No deadline mode here, so neither overload line appears.
+    try testing.expect(std.mem.indexOf(u8, text, "Deadline misses") == null);
+    try testing.expect(std.mem.indexOf(u8, text, "Peak schedule lag") == null);
+}
+
+test "writeReport surfaces deadline misses and peak schedule lag" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const cfg = cli.Config{ .url = try cli.parseUrl("http://127.0.0.1:8080/"), .deadline_ns = 100 * std.time.ns_per_ms };
+    var dash_buf: [1024]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, .empty, &dash_buf);
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 100;
+    snap.counters.recordStatus(200);
+    snap.counters.deadline_errors = 42;
+    snap.counters.max_behind_ns = 250 * std.time.ns_per_ms; // 250ms peak lag
+
+    var out = Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    try dash.writeReport(&out.writer, &snap, 2.0);
+    const text = out.written();
+
+    try testing.expect(std.mem.indexOf(u8, text, "Deadline misses: 42") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "Peak schedule lag: 250.00ms") != null);
 }


### PR DESCRIPTION
Fixes #26.

## The problem

`--timeout` arms the watchdog at the **actual send**, so it only bounds `done − actual_send` — the wire attempt. Under open-loop overload each connection falls behind its own coordinated-omission schedule: every attempt still completes quickly on the wire, so the timeout never trips, while the recorded CO latency (`done − scheduled`) balloons. Hence the issue's `--timeout 1s` next to a **34.7s p50** with **0 timeouts**, and `--no-record-timeouts` having nothing to drop.

The tail lives in the **backlog** term (`actual_send − scheduled`), which a send-anchored wire timeout structurally cannot see.

## What this adds (all three of the issue's proposals)

**1. `--deadline <T>`** — measured from each request's *scheduled* send time, bounding `done − scheduled`:
- **Pre-send shed**: a request already staler than the deadline is failed *without touching the wire*, so the connection sheds accumulated backlog and keeps measuring near-live latency instead of serializing through a stale queue.
- **In-flight**: the watchdog arms at the earlier of `scheduled + deadline` and `sent + timeout`, and classifies a fire as a deadline miss vs. a wire timeout.
- Deadline misses count as `deadline` errors (so `--max-error-rate` sees overload) but are **never recorded** as latency samples — the histogram stays the distribution of requests served *within* the deadline, so `--slo-p99` stays a p99 of *met* latency. Both CI gates become meaningful under overload.

**2. Docs** — clarify `--timeout` (wire) vs `--deadline` (CO) in `--help` + README, and that `--no-record-timeouts` does not apply to deadline misses.

**3. Backlog gauge** — peak `now − scheduled`, tracked *always* (even without `--deadline`): `max_schedule_lag_us` (JSON), "Peak schedule lag" (text report), "peak lag" (live panel). An early warning that the client is falling behind, alongside `rate_ratio`/`achieved_rate`.

## Design notes

- `--timeout` keeps its wrk2-compatible wire semantics; `--deadline` is a new orthogonal knob. They compose via `min()` in the watchdog.
- The decomposition is deliberate: served requests → histogram (tail bounded by the deadline); missed requests → `deadline` error count (rate ≈ offered − served). Under overload `--slo-p99` passes while `--max-error-rate` fails — the correct picture.

## Tests

- `cli`: `--deadline` parses; off by default.
- `connection`: shedding under real overload (served requests recorded & tail bounded, misses shed and not recorded); in-flight expiry against a stalled server (counted, not recorded, no wire timeout); a generous deadline never trips on healthy load; backlog gauge populated.
- `report`: JSON carries `deadline_ms` / `errors.deadline` / `max_schedule_lag_us`; `errorRate` counts deadline misses as both a failure and an attempt.
- `tui`: text report renders "Deadline misses" / "Peak schedule lag" only in deadline mode.

`zig build test` green; `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)