### PR TITLE
Make --deadline shed-before-send only; gate in-flight abort behind --deadline-abort (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ zrk [options] <url>
       --timeout     <T>     Wire timeout per attempt, from the actual
                             send (default 2s); does not bound CO latency
       --deadline    <T>     Max coordinated-omission latency, from the
-                            scheduled send: a request past T is failed as
-                            a `deadline` error, not recorded (0 = off)
+                            scheduled send: a too-stale request is shed
+                            (failed as a `deadline` error, not sent or
+                            recorded) before sending (0 = off)
+      --deadline-abort      Also abort in-flight requests past the deadline.
+                            Resets the connection per miss and churns under
+                            saturation; off by default
       --interval    <T>     Stats window: --timeseries rows and --plain
                             lines                          (default 1s)
       --refresh     <T>     Live dashboard redraw rate     (default 80ms)
@@ -128,7 +132,7 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
 {
   "zrk_version": "0.1.0",
   "target": { "url": "http://127.0.0.1:8080/", "method": "GET" },
-  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "record_timeouts": true },
+  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "deadline_abort": false, "record_timeouts": true },
   "duration_s": 20.002,
   "requests": 19998,
   "bytes": 1239876,
@@ -201,20 +205,31 @@ difference only shows up under overload:
   latency (measured from the request's **scheduled** time) balloons into the
   tens of seconds. A tight `--timeout 1s` will happily sit next to a 30 s `p50`.
 - **`--deadline`** is what actually bounds that tail. It is measured from each
-  request's **scheduled** send time and bounds `done − scheduled`. A request
-  whose CO latency would exceed the deadline is **failed as a `deadline`
-  error** rather than recorded — shed before it is even sent if it is already
-  too stale, or shut down in flight at `scheduled + deadline`. This is the
-  usual benchmark intent ("past X ms it's a failed request, per our SLA").
+  request's **scheduled** send time and targets `done − scheduled`. It is
+  enforced by **shedding before sending**: a request already staler than the
+  deadline is **failed as a `deadline` error** without ever touching the wire,
+  which drains the backlog and keeps the client probing near-live latency. This
+  is the usual benchmark intent ("past X ms it's a failed request, per our SLA").
 
 With `--deadline` set, the latency histogram becomes the distribution of
-requests **served within the deadline** (so its tail is bounded by the
-deadline), and sustained overload shows up as a rising `deadline` error count
-instead of an unbounded latency tail. That makes both CI gates meaningful at
-once under overload: `--slo-p99` stays a p99 of *met* latency, while
-`--max-error-rate` catches the deadline-miss rate. Deadline misses are **never**
-recorded into the histogram (unlike wire timeouts), so `--no-record-timeouts`
-does not affect them.
+requests that were **sent within the deadline** of their schedule, and sustained
+overload shows up as a rising `deadline` error count instead of an unbounded
+latency tail. That makes both CI gates meaningful at once under overload:
+`--slo-p99` stays a p99 of *met* latency, while `--max-error-rate` catches the
+deadline-miss rate. Deadline misses are **never** recorded into the histogram
+(unlike wire timeouts), so `--no-record-timeouts` does not affect them.
+
+Shedding bounds the send time, not the completion, so a request that *is* sent
+still runs to completion on the wire: its recorded CO latency is bounded by
+**deadline + wire time** (and wire time by `--timeout`), not by the deadline
+exactly. zrk deliberately does **not** cut an in-flight request off by default,
+because on HTTP/1.1 keep-alive that means resetting the connection — and under
+saturation, where most in-flight requests exceed the deadline, resetting every
+one storms the target with reconnects and can balloon its memory (an OOM risk
+for the system under test). `--deadline-abort` opts into that in-flight cut-off
+(recorded latency then capped at the deadline exactly), at the cost of a
+connection reset per miss; use it only against a target you know tolerates the
+churn.
 
 `max_schedule_lag_us` (JSON) / "Peak schedule lag" (text report) is the backlog
 gauge: the peak `now − scheduled` the fleet ever reached. It is populated even

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -51,8 +51,14 @@ pub const Config = struct {
     /// Coordinated-omission deadline (0 = off): a request whose CO-corrected
     /// latency (measured from its *scheduled* send time) would exceed this is
     /// failed as a `deadline` error rather than recorded, bounding the latency
-    /// tail and surfacing sustained overload through the error path.
+    /// tail and surfacing sustained overload through the error path. Enforced by
+    /// shedding before sending; in-flight requests are aborted only under
+    /// `deadline_abort`.
     deadline_ns: u64 = 0,
+    /// Opt in to also aborting an in-flight request once `scheduled + deadline`
+    /// passes (`--deadline-abort`). This resets the connection on every miss, so
+    /// it churns under saturation; off by default (shed-before-send suffices).
+    deadline_abort: bool = false,
     /// Stats window: per-connection publish period, `--timeseries` row cadence,
     /// and the line rate of `--plain` output.
     interval_ns: u64 = 1 * std.time.ns_per_s,
@@ -143,8 +149,12 @@ pub const usage =
     \\      --timeout     <T>     Wire timeout per attempt, from the actual
     \\                            send (default 2s); does not bound CO latency
     \\      --deadline    <T>     Max coordinated-omission latency, from the
-    \\                            scheduled send: a request past T is failed as
-    \\                            a `deadline` error, not recorded (0 = off)
+    \\                            scheduled send: a too-stale request is shed
+    \\                            (failed as a `deadline` error, not sent or
+    \\                            recorded) before sending (0 = off)
+    \\      --deadline-abort      Also abort in-flight requests past the
+    \\                            deadline. Resets the connection per miss and
+    \\                            churns under saturation; off by default
     \\      --interval    <T>     Stats window: --timeseries rows and --plain
     \\                            lines                          (default 1s)
     \\      --refresh     <T>     Live dashboard redraw rate     (default 80ms)
@@ -243,6 +253,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.timeout_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--deadline")) {
             cfg.deadline_ns = try parseDuration(try nextValue(tokens, &i));
+        } else if (eq(arg, "--deadline-abort")) {
+            cfg.deadline_abort = true;
         } else if (eq(arg, "--interval")) {
             cfg.interval_ns = try parseDuration(try nextValue(tokens, &i));
         } else if (eq(arg, "--refresh")) {
@@ -481,6 +493,10 @@ test "deadline flag parses; defaults off" {
     try testing.expectEqual(@as(u64, 0), default.deadline_ns);
     const cfg = (try parse(a, &[_][]const u8{ "--deadline", "250ms", "http://x/" })).config;
     try testing.expectEqual(@as(u64, 250 * std.time.ns_per_ms), cfg.deadline_ns);
+    // In-flight abort is opt-in and off unless the flag is present.
+    try testing.expect(!cfg.deadline_abort);
+    const aborting = (try parse(a, &[_][]const u8{ "--deadline", "250ms", "--deadline-abort", "http://x/" })).config;
+    try testing.expect(aborting.deadline_abort);
 }
 
 test "refresh flag parses and zero is rejected" {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -125,12 +125,20 @@ pub const Params = struct {
     /// `deadline_ns` for that.
     timeout_ns: u64,
     /// Coordinated-omission deadline, measured from each request's *scheduled*
-    /// send time (0 = none). Bounds `done − scheduled`: a request whose CO
-    /// latency would exceed this is failed as a `deadline` error — shed before
-    /// sending if already too stale, or shut down in flight at `scheduled +
-    /// deadline` — instead of being recorded, which bounds the latency tail and
-    /// makes sustained overload surface through the error path.
+    /// send time (0 = none). A request already staler than this is shed before
+    /// sending (failed as a `deadline` error without touching the wire), which
+    /// drains the backlog and keeps the recorded tail to roughly deadline + wire
+    /// time while surfacing overload through the error path. In-flight requests
+    /// that pass this age at send time are *not* aborted unless `deadline_abort`
+    /// is set; see it for why.
     deadline_ns: u64 = 0,
+    /// Also abort a request already on the wire once `scheduled + deadline`
+    /// passes, by shutting the connection down (the only way to abandon an
+    /// in-flight HTTP/1.1 request). Off by default: under saturation this resets
+    /// a connection per miss, storming the target with reconnects and inflating
+    /// its memory — while shed-before-send already bounds the tail. Opt in only
+    /// when you need the recorded latency capped at exactly the deadline.
+    deadline_abort: bool = false,
     /// Record a coordinated-omission-corrected latency sample when a request
     /// times out on the wire, instead of dropping it (which would truncate the
     /// tail). Does not apply to `deadline` misses, which are never recorded.
@@ -208,18 +216,28 @@ pub fn run(p: *Params) void {
         // backend that per-request spawn/cancel pair costs milliseconds
         // (macOS especially), capping every connection near 500 req/s no
         // matter how fast the target answers.
+        // The CO deadline is enforced by shedding *before* sending (see the
+        // request loop); the watchdog only arms on it — killing an in-flight
+        // request, which on HTTP/1.1 keep-alive means resetting the whole
+        // connection — when `--deadline-abort` is set. Left off by default: past
+        // a saturated target's knee most in-flight requests would trip the
+        // deadline, and resetting every one storms the target with reconnects
+        // (blowing its working set) while shed-before-send already bounds the
+        // recorded tail to deadline + wire time. So the watchdog's CO bound is
+        // the deadline only under `--deadline-abort`, else disabled (0).
+        const wd_deadline_ns: u64 = if (p.deadline_abort) p.deadline_ns else 0;
         var watchdog: Watchdog = .{
             .io = io,
             .stream = &stream,
             .timeout_ns = p.timeout_ns,
-            .deadline_ns = p.deadline_ns,
-            // Idle tick cadence: the tighter of the two bounds, so an
+            .deadline_ns = wd_deadline_ns,
+            // Idle tick cadence: the tighter of the two active bounds, so an
             // armed request is caught at most ~1.5x that bound late.
-            .tick_ns = tighter(p.timeout_ns, p.deadline_ns),
+            .tick_ns = tighter(p.timeout_ns, wd_deadline_ns),
         };
         var watchdog_group: Io.Group = .init;
         var watchdog_active = false;
-        if (p.timeout_ns != 0 or p.deadline_ns != 0) {
+        if (p.timeout_ns != 0 or wd_deadline_ns != 0) {
             if (watchdog_group.concurrent(io, Watchdog.watch, .{&watchdog})) |_| {
                 watchdog_active = true;
             } else |_| {
@@ -679,6 +697,25 @@ fn stallServe(io: Io, server: *net.Server) void {
     io.sleep(Io.Duration.fromSeconds(30), .awake) catch {};
 }
 
+/// Accepts one keep-alive connection and answers every request with a fixed 200,
+/// but only after a fixed per-response delay — a server slower than the client's
+/// deadline, used to prove the default deadline lets slow requests finish on the
+/// reused connection instead of resetting it.
+fn delayServe(io: Io, server: *net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    var rbuf: [4096]u8 = undefined;
+    var wbuf: [4096]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    while (true) {
+        discardRequestHead(&r.interface) catch return;
+        io.sleep(Io.Duration.fromMilliseconds(60), .awake) catch return;
+        w.interface.writeAll("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi") catch return;
+        w.interface.flush() catch return;
+    }
+}
+
 test "run reports timeouts against a non-responsive server" {
     var threaded = Io.Threaded.init(testing.allocator, .{});
     defer threaded.deinit();
@@ -828,7 +865,7 @@ test "run with record_timeouts disabled drops timed-out samples" {
     try testing.expectEqual(@as(u64, 0), histogram.count());
 }
 
-test "deadline mode fails stale requests without recording them" {
+test "deadline-abort fails stale in-flight requests without recording them" {
     var threaded = Io.Threaded.init(testing.allocator, .{});
     defer threaded.deinit();
     const io = threaded.io();
@@ -857,10 +894,13 @@ test "deadline mode fails stale requests without recording them" {
         .is_tls = false,
         .insecure = false,
         .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } }, // ~500 req/s
-        // No wire timeout: the deadline alone must catch the stall in flight,
-        // shutting each blocked request down at `scheduled + deadline`.
+        // No wire timeout: with --deadline-abort the deadline alone must catch
+        // the stall in flight, shutting each blocked request down at
+        // `scheduled + deadline`. (Without abort a stalled read is not
+        // interrupted at all — that is the separate wire timeout's job.)
         .timeout_ns = 0,
         .deadline_ns = 50 * std.time.ns_per_ms,
+        .deadline_abort = true,
         .end = end,
         .stop = &stop,
         .histogram = &histogram,
@@ -883,6 +923,72 @@ test "deadline mode fails stale requests without recording them" {
     // the backlog gauge registers substantial lag (equilibrium sits near the
     // 50ms deadline; assert well above jitter).
     try testing.expect(counters.max_behind_ns > 20 * std.time.ns_per_ms);
+}
+
+test "default deadline sheds but never resets the connection in flight" {
+    var threaded = Io.Threaded.init(testing.allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    // A single keep-alive connection served by a server that takes 60ms per
+    // response — far longer than the 20ms deadline. With the in-flight abort
+    // OFF (the default), those slow responses must still *complete* on the same
+    // reused connection, never being killed mid-flight.
+    var group: Io.Group = .init;
+    group.async(io, delayServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(400));
+    const deadline_ns = 20 * std.time.ns_per_ms;
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+        .is_tls = false,
+        .insecure = false,
+        // Offer far faster than the server can serve so the backlog outruns the
+        // deadline and the shed path engages.
+        .schedule = .{ .constant = .{ .interval_ns = 1 * std.time.ns_per_ms } }, // ~1000 req/s
+        // No wire timeout and no abort: nothing may interrupt an in-flight
+        // request, so a reset could only come from the deadline — and must not.
+        .timeout_ns = 0,
+        .deadline_ns = deadline_ns,
+        .deadline_abort = false,
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    stop.store(true, .monotonic);
+    group.cancel(io);
+    server.deinit(io);
+
+    // Slow requests complete instead of being aborted, so the connection is
+    // reused (the server accepts exactly one) — no read errors, no reconnect
+    // storm — while the backlog is still drained as shed `deadline` errors.
+    try testing.expect(counters.completed > 0);
+    try testing.expectEqual(@as(u64, 0), counters.read_errors);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    try testing.expect(counters.deadline_errors > 0);
+    try testing.expectEqual(counters.completed, histogram.count());
+    // The tradeoff the default accepts: a completed request's recorded CO
+    // latency can exceed the deadline (it is bounded by deadline + wire time,
+    // not the deadline itself), because we never cut it off.
+    try testing.expect(histogram.max() > deadline_ns / std.time.ns_per_us);
 }
 
 test "deadline mode sheds backlog under overload and bounds the recorded tail" {

--- a/src/report.zig
+++ b/src/report.zig
@@ -82,7 +82,7 @@ pub fn writeJson(
 
     try w.writeAll("  \"config\": {");
     try w.print(
-        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"record_timeouts\": {} }},\n",
+        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"deadline_abort\": {}, \"record_timeouts\": {} }},\n",
         .{
             cfg.connections,
             launched,
@@ -90,6 +90,7 @@ pub fn writeJson(
             cfg.rate,
             cfg.timeout_ns / std.time.ns_per_ms,
             cfg.deadline_ns / std.time.ns_per_ms,
+            cfg.deadline_abort,
             cfg.record_timeouts,
         },
     );
@@ -310,6 +311,7 @@ test "writeJson emits parseable, well-formed summary" {
     try testing.expect(std.mem.indexOf(u8, out, "\"latency_us\"") != null);
     // Deadline mode surfaces in config, the errors object, and the backlog gauge.
     try testing.expect(std.mem.indexOf(u8, out, "\"deadline_ms\": 250") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"deadline_abort\": false") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"deadline\": 7") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"max_schedule_lag_us\": 12") != null);
     // The embedded HdrHistogram blob is present and decodes back to 100 samples.

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -103,6 +103,7 @@ pub fn run(
         .schedule = schedule,
         .timeout_ns = cfg.timeout_ns,
         .deadline_ns = cfg.deadline_ns,
+        .deadline_abort = cfg.deadline_abort,
         .record_timeouts = cfg.record_timeouts,
         .end = end,
         .stop = &stop,


### PR DESCRIPTION
Fixes #28. Follow-up to #26 / #27.

## The bug

`--deadline` (0.4.0) had two enforcement points. **Shed-before-send** is fine. The **in-flight kill** — arming the watchdog on `scheduled + deadline` and shutting the socket down when it passes — is pathological under saturation: on HTTP/1.1 keep-alive that shutdown *is* a connection reset, and past a target's knee its response time exceeds the deadline by definition, so a large fraction of in-flight requests trip it and **each one resets its connection**. With `-c 1024` that's a reconnect storm.

Measured, `--deadline 1s` (0.4.0) vs no deadline (0.3.6), past the knee:

| proxy | peak mem, no deadline | peak mem, `--deadline 1s` | good-put |
|---|---|---|---|
| pingora | 58 MiB | **444 MiB** | collapses to ~0 |
| envoy | 72 MiB | **423 MiB** | collapses to ~0 |
| traefik | 215 MiB | **382 MiB** | collapses to ~0 |

Three of six proxies blow their working set 6–500× and stop serving — the overload region becomes unmeasurable and can OOM-kill the target.

## The fix

**Shed-before-send already bounds the recorded tail without touching the connection.** A request is only sent when it's within the deadline of its schedule, then completes in wire time (bounded by `--timeout`), so recorded CO latency ≤ `deadline + wire time` and the backlog drains as `deadline` errors — with zero resets.

So:
- **Default**: the CO deadline is **shed-only**. The watchdog no longer arms on it (it still arms on the wire `--timeout` to catch genuine hangs).
- **Opt-in**: `--deadline-abort` restores the in-flight cut-off (recorded latency then capped at the deadline exactly), documented as resetting a connection per miss and churning under saturation.

The tradeoff the default accepts: a completed request's recorded latency can exceed the deadline (bounded by `deadline + timeout`), because we never cut it off. That's the right call for a benchmark — good-put stays plateaued at capacity and the target isn't stormed.

## Changes
- `connection.zig`: `Params.deadline_abort`; the watchdog's CO bound is the deadline only when set, else 0 (so the watchdog is inactive when only a shed-only deadline is configured). Pre-send shed unchanged.
- `cli` / `runner` / `report`: `--deadline-abort` flag, plumbed through, surfaced in the JSON `config`.
- `README` + `--help`: shed-only default vs the `--deadline-abort` opt-in, with the reset/OOM rationale.

## Tests
- Converted the stall-server test to `--deadline-abort` (the in-flight kill is now opt-in).
- New `delayServe` test: a 60ms/response server with a 20ms default deadline — slow requests **complete on the reused connection** (`completed > 0`, `read_errors == 0`, no reset storm) while the backlog is still shed (`deadline_errors > 0`), and recorded latency is allowed to exceed the deadline.
- `cli`: `--deadline-abort` parses and defaults off.

`zig build test` green; touched files `zig fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)