### PR TITLE
fix(runner): propagate a canceled run instead of reporting it as complete

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -220,6 +220,10 @@ fn printRunError(io: Io, err: anyerror) !void {
             .{@errorName(err)},
         ) catch "zrk: could not resolve the target host\n",
         error.NoConnectionsLaunched => "zrk: could not launch any connections\n",
+        // The run was cut short, so there is no full-duration sample to report.
+        // Say so and exit nonzero rather than emitting a report that looks
+        // complete but covers a fraction of --duration.
+        error.Canceled => "zrk: run was interrupted before --duration elapsed; no report written\n",
         else => std.fmt.bufPrint(
             &buf,
             "zrk: {s} (try -k to skip TLS verification if this is certificate-related)\n",

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,7 +72,7 @@ pub fn main(init: std.process.Init) !void {
         ts_file.close(io);
     };
 
-    var progress: Progress = .{ .dash = if (json) null else &dash, .ts = ts_ptr };
+    var progress: Progress = .{ .io = io, .dash = if (json) null else &dash, .ts = ts_ptr };
     const active = progress.dash != null or progress.ts != null;
     const ctx: ?*anyopaque = if (active) @ptrCast(&progress) else null;
     const cb: ?runner.ProgressFn = if (active) onProgress else null;
@@ -194,8 +194,14 @@ fn printSloBreach(io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, s
 /// Fan-out target for the runner's progress callback: the live dashboard and/or
 /// the NDJSON time series, whichever are active this run.
 const Progress = struct {
+    io: Io,
     dash: ?*tui.Dashboard,
     ts: ?*report.TimeSeries,
+    /// Set once a sink has reported a failure, so a persistently broken one
+    /// (a full disk, a closed pipe) warns a single time instead of on every
+    /// wake — this callback fires up to 12.5x a second with a live dashboard.
+    dash_failed: bool = false,
+    ts_failed: bool = false,
 };
 
 fn onProgress(
@@ -207,8 +213,35 @@ fn onProgress(
     tick: runner.Tick,
 ) void {
     const p: *Progress = @ptrCast(@alignCast(context.?));
-    if (tick.frame) if (p.dash) |d| d.frame(snapshot, now_ns, elapsed_s, total_s) catch {};
-    if (tick.row) if (p.ts) |t| t.record(snapshot, elapsed_s) catch {};
+    // A failing sink must not abort the run — the measurement is the point, and
+    // this callback cannot propagate anyway (ProgressFn returns void). But
+    // dropping the error silently meant a `--timeseries` file that stopped
+    // accepting writes produced a short file and a report that looked fine, with
+    // nothing said. Report it once and keep measuring.
+    if (tick.frame) if (p.dash) |d| d.frame(snapshot, now_ns, elapsed_s, total_s) catch |err| {
+        if (!p.dash_failed) {
+            p.dash_failed = true;
+            warnSinkFailed(p.io, "dashboard", err);
+        }
+    };
+    if (tick.row) if (p.ts) |t| t.record(snapshot, elapsed_s) catch |err| {
+        if (!p.ts_failed) {
+            p.ts_failed = true;
+            warnSinkFailed(p.io, "--timeseries", err);
+        }
+    };
+}
+
+/// Note a progress sink that stopped working, without derailing the run: this
+/// runs mid-measurement, so a failure to report the failure is itself ignored.
+fn warnSinkFailed(io: Io, sink: []const u8, err: anyerror) void {
+    var buf: [256]u8 = undefined;
+    const msg = std.fmt.bufPrint(
+        &buf,
+        "zrk: {s} output failed ({s}); continuing without it\n",
+        .{ sink, @errorName(err) },
+    ) catch "zrk: progress output failed; continuing without it\n";
+    writeAll(io, .stderr(), msg) catch {};
 }
 
 fn printRunError(io: Io, err: anyerror) !void {

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -161,7 +161,17 @@ pub fn run(
         if (before.nanoseconds >= end.nanoseconds) break;
         const next_wake = @min(@min(next_frame, next_row), end.nanoseconds);
         if (next_wake > before.nanoseconds) {
-            io.sleep(Io.Duration.fromNanoseconds(@intCast(next_wake - before.nanoseconds)), .awake) catch break;
+            // Propagate rather than `catch break`. The only failure here is
+            // cancellation, and breaking would run the normal completion path:
+            // the caller would get a Report that looks like a finished run but
+            // covers a fraction of `--duration`, with nothing marking it short.
+            // A CI gate (`--slo-p99`, `--max-error-rate`) would then pass on a
+            // sample that was never collected. Unreachable from the CLI, which
+            // never cancels this task, but `run` is the embeddable entry point
+            // and an embedder's coroutine can be canceled — and when it is, the
+            // caller asked to stop and should learn the run did not complete.
+            // The errdefer above stops and joins the connections on the way out.
+            try io.sleep(Io.Duration.fromNanoseconds(@intCast(next_wake - before.nanoseconds)), .awake);
         }
 
         const t = Io.Timestamp.now(io, .awake);
@@ -292,6 +302,56 @@ test "run's elapsed time tracks the duration, not the interval grid" {
     // the quantization regression would report >= 1.0s.
     try testing.expect(result.elapsed_s >= 0.29);
     try testing.expect(result.elapsed_s < 0.9);
+}
+
+/// Runs a load test to completion and stores whatever `run` returned, so a
+/// canceled run's outcome can be inspected from outside the coroutine.
+fn runCapturing(io: Io, gpa: std.mem.Allocator, cfg: *const cli.Config, out: *?anyerror!Report) void {
+    out.* = run(gpa, io, cfg, 0, null, null);
+}
+
+test "a canceled run propagates instead of reporting a truncated success" {
+    // `run` is the embeddable entry point, so an embedder can cancel the
+    // coroutine it runs in. Swallowing that (the old `catch break`) returned a
+    // Report covering a fraction of --duration with nothing marking it short,
+    // which a CI gate would then happily evaluate.
+    var rt = try zio.Runtime.init(testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    var serve_group: Io.Group = .init;
+    serve_group.async(io, testServe, .{ io, &server });
+    const port = server.socket.address.getPort();
+
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/", .{port});
+    var cfg: cli.Config = .{
+        .connections = 1,
+        .rate = 100,
+        // Long enough that cancellation lands mid-sleep, well before `end`.
+        .duration_ns = 60 * std.time.ns_per_s,
+        .interval_ns = 1 * std.time.ns_per_s,
+        .url = try cli.parseUrl(url),
+    };
+
+    var outcome: ?anyerror!Report = null;
+    var run_group: Io.Group = .init;
+    try run_group.concurrent(io, runCapturing, .{ io, arena_state.allocator(), &cfg, &outcome });
+
+    // Let it reach the progress loop's sleep, then cancel out from under it.
+    io.sleep(Io.Duration.fromNanoseconds(50 * std.time.ns_per_ms), .awake) catch {};
+    run_group.cancel(io); // waits for the task to unwind
+
+    serve_group.cancel(io);
+    server.deinit(io);
+
+    // Must be the error, not a short-but-successful Report.
+    try testing.expectError(error.Canceled, outcome.?);
 }
 
 test {


### PR DESCRIPTION
The progress loop swallowed `io.sleep` failures with `catch break`
(`runner.zig:164`), which fell straight through to the normal completion path
— stop the connections, `readFinal`, return a `Report`. The caller got
something that looked like a finished run but covered a fraction of
`--duration`, with nothing on the Report marking it short.

In CI that is the bad case: `--slo-p99` and `--max-error-rate` would be
evaluated against a sample that was never collected, and the gate would pass.

## Reachability

Worth being precise, because the two answers differ:

- **From the CLI: not reachable today.** `io.sleep`'s only failure is
  cancellation, which requires the current task to be canceled. That task is
  executor 0's `main_task`; `group.cancel(io)` targets the connection group,
  and there are no signal handlers anywhere in the codebase.
- **For embedders: reachable.** `run` is documented as the programmatic entry
  point ("Embedders — for example zoxy's bench harness — call `run` and get a
  typed `Report` back"). The natural way to embed it is inside a coroutine, and
  a timeout wrapper or group teardown cancels that coroutine. The caller
  explicitly asked to stop and was told the run finished.

## The change

Propagate instead of swallowing. The existing `errdefer` (`runner.zig:132`)
already stops and joins the connections on the way out, and it is declared
after `fleet`/`sweeper`, so unwind order is unchanged. `run` already returned
`!Report`, so the signature does not change.

In the CLI this reaches the existing `catch |err| { printRunError; exit(1) }`
at `main.zig:84`, so it is an error message plus a non-zero exit. Added a
specific case so it reads

```
zrk: run was interrupted before --duration elapsed; no report written
```

instead of falling into the generic `zrk: Canceled (try -k to skip TLS
verification…)` branch, where the TLS hint is nonsense for a cancellation.

## Not changed

`runner.zig:138` (`group.concurrent(...) catch break`) looks similar but is
deliberate and already safe: `launched` counts what started, `launched == 0` is
a hard error, and the count is surfaced as `config.launched` in the JSON, so a
partial launch is visible rather than silent.

## Testing

The new test spawns `run` in a coroutine, cancels it mid-sleep, and asserts the
error propagates. **I verified it against the old code**, where it fails with:

```
expected error.Canceled, found .{ ... .elapsed_s = 0.048750895, .launched = 1 }
```

— a Report for a 60s configured duration, which is exactly the silent
truncation being fixed.

Normal runs are unaffected (verified end-to-end: report printed, exit 0). The
CLI message itself is defensive — since the error is not reachable from the CLI
today, it cannot be triggered from the command line to demonstrate.

Follow-up worth considering separately: zrk installs no SIGINT handler, so
Ctrl-C currently kills a run outright with no report. Graceful interrupt would
be the thing that makes this CLI path actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)