### PR TITLE
feat: stop gracefully on SIGINT and report the partial run

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ zrk [options] <url>
 Durations accept `us`, `ms`, `s`, `m`, `h` (a bare number is seconds).
 Short options may be attached (`-c100`) or separated (`-c 100`).
 
+### Interrupting a run
+
+`Ctrl-C` stops the run and still reports what was measured, rather than
+discarding it — useful when a long run has already shown you what you needed.
+The report covers the elapsed time, not `--duration`: `duration_s` is the real
+figure, `--format json` adds `"interrupted": true`, and the exit code is **130**.
+CI gates are *not* evaluated on an interrupted run, so a partial sample can
+never report a passing `--slo-p99`. A second `Ctrl-C` aborts immediately.
+
+### Exit codes
+
+| code | meaning |
+|------|---------|
+| 0 | run completed; any configured gates passed |
+| 1 | the run failed to start or complete (see the message on stderr) |
+| 2 | bad arguments, or a `--body` file that could not be read |
+| 3 | run completed but a `--slo-p99` / `--max-error-rate` gate was breached |
+| 130 | interrupted with `Ctrl-C`; a partial report was still written |
+
 ### Examples
 
 ```sh

--- a/src/main.zig
+++ b/src/main.zig
@@ -81,14 +81,23 @@ pub fn main(init: std.process.Init) !void {
     // and headless runs stay on the --interval stats window.
     const frame_ns: u64 = if (progress.dash != null and dash.tui) cfg.refresh_ns else 0;
 
-    const result = runner.run(arena, io, &cfg, frame_ns, ctx, cb) catch |err| {
+    // Ctrl-C stops the run and still reports what was measured — a long run
+    // interrupted near its end otherwise threw all of it away. The watcher sets
+    // a flag the runner polls rather than canceling it: cancellation discards
+    // the measurement, which is the opposite of what an interrupt should do.
+    var interrupt = std.atomic.Value(bool).init(false);
+    var sig_group: Io.Group = .init;
+    const watching = installInterrupt(io, &sig_group, &interrupt);
+    defer if (watching) sig_group.cancel(io);
+
+    const result = runner.run(arena, io, &cfg, frame_ns, ctx, cb, if (watching) &interrupt else null) catch |err| {
         try printRunError(io, err);
         std.process.exit(1);
     };
     var snapshot = result.snapshot;
 
     if (json) {
-        try writeJsonReport(arena, io, &cfg, &snapshot, result.elapsed_s, result.launched);
+        try writeJsonReport(arena, io, &cfg, &snapshot, result.elapsed_s, result.launched, result.interrupted);
     } else if (cfg.output_path) |path| {
         // Text report redirected to --output; leave a breadcrumb on stdout.
         try writeTextReport(io, &dash, path, &snapshot, result.elapsed_s);
@@ -102,12 +111,42 @@ pub fn main(init: std.process.Init) !void {
         try writeHdrFile(io, path, &snapshot.hist);
     }
 
+    // An interrupted run is not a result to gate on: it covers less than
+    // --duration, so a passing --slo-p99 would mean nothing. Exit 130 (the
+    // shell's SIGINT convention) without evaluating the gates.
+    if (result.interrupted) std.process.exit(130);
+
     // CI gates: a breach exits 3 so a harness can fail the build.
     const slo = report.checkSlo(&cfg, &snapshot);
     if (!slo.passed()) {
         try printSloBreach(io, &cfg, &snapshot, slo);
         std.process.exit(3);
     }
+}
+
+/// Watch for SIGINT for the duration of the run. The first one asks the runner
+/// to stop and report; a second means the user wants out now, so take the
+/// process down rather than waiting for a graceful stop that is evidently not
+/// arriving. Returns false if the watcher could not be installed, in which case
+/// the default disposition stays and Ctrl-C kills the process as before.
+fn installInterrupt(io: Io, group: *Io.Group, flag: *std.atomic.Value(bool)) bool {
+    group.concurrent(io, watchInterrupt, .{ io, flag }) catch return false;
+    return true;
+}
+
+fn watchInterrupt(io: Io, flag: *std.atomic.Value(bool)) void {
+    var sig = zio.Signal.init(.interrupt) catch return;
+    defer sig.deinit();
+    sig.wait() catch return; // canceled at end of run
+    flag.store(true, .monotonic);
+    // Sole owner of the interrupt notice. `main` deliberately prints nothing
+    // more: two tasks writing stderr concurrently interleaved and truncated
+    // each other, and the graceful stop can take a moment at high `-c`, so the
+    // message that matters is this one — printed the instant Ctrl-C lands,
+    // telling the user it was heard and how to give up waiting.
+    writeAll(io, .stderr(), "\nzrk: interrupt received, stopping (Ctrl-C again to abort)\n") catch {};
+    sig.wait() catch return;
+    std.process.exit(130);
 }
 
 /// Write the wrk2-style text report to `--output` (text mode with -o set).
@@ -121,13 +160,13 @@ fn writeTextReport(io: Io, dash: *tui.Dashboard, path: []const u8, snap: *const 
 }
 
 /// Write the JSON summary to `--output` (or stdout when unset).
-fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, elapsed_s: f64, launched: u32) !void {
+fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, elapsed_s: f64, launched: u32, interrupted: bool) !void {
     var close = false;
     const file = try openOut(io, cfg.output_path, &close);
     defer if (close) file.close(io);
     var buf: [8192]u8 = undefined;
     var fw: Io.File.Writer = .init(file, io, &buf);
-    try report.writeJson(gpa, &fw.interface, cfg, snap, elapsed_s, launched);
+    try report.writeJson(gpa, &fw.interface, cfg, snap, elapsed_s, launched, interrupted);
     try fw.interface.flush();
 }
 

--- a/src/report.zig
+++ b/src/report.zig
@@ -61,6 +61,7 @@ pub fn writeJson(
     snap: *const stats.Snapshot,
     elapsed_s: f64,
     launched: u32,
+    interrupted: bool,
 ) !void {
     const c = snap.counters;
     const h = &snap.hist;
@@ -96,6 +97,10 @@ pub fn writeJson(
     );
 
     try w.print("  \"duration_s\": {d:.3},\n", .{elapsed_s});
+    // Explicit rather than leaving a consumer to infer it from duration_s being
+    // short of config.duration_s: an interrupted run is not a completed one, and
+    // whatever reads this (a CI gate, a regression baseline) needs to say so.
+    if (interrupted) try w.print("  \"interrupted\": true,\n", .{});
     try w.print("  \"requests\": {d},\n", .{c.completed});
     try w.print("  \"bytes\": {d},\n", .{c.bytes});
     try w.print("  \"achieved_rate\": {d:.2},\n", .{achieved});
@@ -297,7 +302,7 @@ test "writeJson emits parseable, well-formed summary" {
     defer alloc.deinit();
     var cfg = testConfig();
     cfg.deadline_ns = 250 * std.time.ns_per_ms;
-    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, 1.0, 4);
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, 1.0, 4, false);
     const out = alloc.written();
 
     // Spot-check structure and key fields.

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -22,6 +22,11 @@ pub const Report = struct {
     snapshot: stats.Snapshot,
     elapsed_s: f64,
     launched: u32,
+    /// The run stopped early because the caller raised `interrupt`. The report
+    /// covers `elapsed_s`, not the configured duration — a consumer that gates
+    /// on these numbers (an SLO check, a regression baseline) must not treat an
+    /// interrupted run as a completed one.
+    interrupted: bool = false,
 };
 
 /// Which consumers a progress callback is for. The dashboard redraws on the
@@ -42,6 +47,13 @@ pub const ProgressFn = *const fn (
     tick: Tick,
 ) void;
 
+/// How often the progress loop rechecks `interrupt` while otherwise idle. The
+/// loop already sleeps only to its next frame/row deadline, which with a long
+/// `--interval` can be seconds away; capping the sleep bounds how long a
+/// Ctrl-C sits unnoticed. The extra wakes are nearly free — one timestamp and
+/// two comparisons, then straight back to sleep, since no tick deadline passed.
+const interrupt_poll_ns: i128 = 100 * std.time.ns_per_ms;
+
 /// Run one constant-throughput load test to completion. Blocks the
 /// calling thread (worker connections run on executor threads); returns
 /// after the configured duration with the final merged report.
@@ -57,6 +69,10 @@ pub fn run(
     frame_interval_ns: u64,
     progress_context: ?*anyopaque,
     progress: ?ProgressFn,
+    /// Raise to stop the run early and return what was measured so far, with
+    /// `Report.interrupted` set. Preferred over canceling the task running
+    /// `run`: cancellation discards the measurement, this keeps it.
+    interrupt: ?*const std.atomic.Value(bool),
 ) !Report {
     const request = try httpmod.buildRequest(arena, cfg);
     const address = try resolveAddress(io, cfg.url.host, cfg.url.port);
@@ -156,10 +172,18 @@ pub fn run(
     const frame_ns: i128 = if (frame_interval_ns > 0) @intCast(frame_interval_ns) else row_ns;
     var next_row: i128 = start.nanoseconds + row_ns;
     var next_frame: i128 = start.nanoseconds + frame_ns;
+    var interrupted = false;
     while (true) {
+        if (interrupt) |flag| if (flag.load(.monotonic)) {
+            interrupted = true;
+            break;
+        };
         const before = Io.Timestamp.now(io, .awake);
         if (before.nanoseconds >= end.nanoseconds) break;
-        const next_wake = @min(@min(next_frame, next_row), end.nanoseconds);
+        var next_wake = @min(@min(next_frame, next_row), end.nanoseconds);
+        // Bound the sleep so the interrupt check above runs on a fixed cadence
+        // rather than only at the next frame/row deadline.
+        if (interrupt != null) next_wake = @min(next_wake, before.nanoseconds + interrupt_poll_ns);
         if (next_wake > before.nanoseconds) {
             // Propagate rather than `catch break`. The only failure here is
             // cancellation, and breaking would run the normal completion path:
@@ -205,7 +229,12 @@ pub fn run(
     const elapsed = start.durationTo(Io.Timestamp.now(io, .awake));
     const elapsed_s: f64 = @as(f64, @floatFromInt(elapsed.nanoseconds)) / std.time.ns_per_s;
     fleet.readFinal(&snap);
-    return .{ .snapshot = snap, .elapsed_s = elapsed_s, .launched = launched };
+    return .{
+        .snapshot = snap,
+        .elapsed_s = elapsed_s,
+        .launched = launched,
+        .interrupted = interrupted,
+    };
 }
 
 /// Resolve a host (literal IP or DNS name) to a single address. DNS is
@@ -291,7 +320,7 @@ test "run's elapsed time tracks the duration, not the interval grid" {
         .interval_ns = 1 * std.time.ns_per_s,
         .url = try cli.parseUrl(url),
     };
-    const result = try run(arena_state.allocator(), io, &cfg, 0, null, null);
+    const result = try run(arena_state.allocator(), io, &cfg, 0, null, null, null);
 
     group.await(io) catch {};
     server.deinit(io);
@@ -304,10 +333,59 @@ test "run's elapsed time tracks the duration, not the interval grid" {
     try testing.expect(result.elapsed_s < 0.9);
 }
 
+test "an interrupted run keeps its measurement and says it was cut short" {
+    var rt = try zio.Runtime.init(testing.allocator, .{ .executors = .exact(2) });
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    var serve_group: Io.Group = .init;
+    serve_group.async(io, testServe, .{ io, &server });
+    const port = server.socket.address.getPort();
+
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+
+    var url_buf: [64]u8 = undefined;
+    const url = try std.fmt.bufPrint(&url_buf, "http://127.0.0.1:{d}/", .{port});
+    var cfg: cli.Config = .{
+        .connections = 1,
+        .rate = 500,
+        .duration_ns = 60 * std.time.ns_per_s,
+        // Far longer than the run will last: the interrupt must not wait for a
+        // stats window to come around.
+        .interval_ns = 30 * std.time.ns_per_s,
+        .url = try cli.parseUrl(url),
+    };
+
+    var interrupt = std.atomic.Value(bool).init(false);
+    var raiser: Io.Group = .init;
+    raiser.async(io, raiseAfter, .{ io, &interrupt, 200 * std.time.ns_per_ms });
+
+    const result = try run(arena_state.allocator(), io, &cfg, 0, null, null, &interrupt);
+
+    raiser.cancel(io);
+    serve_group.cancel(io);
+    server.deinit(io);
+
+    try testing.expect(result.interrupted);
+    // Stopped near the interrupt, not at the 60s duration or the 30s window.
+    try testing.expect(result.elapsed_s >= 0.19);
+    try testing.expect(result.elapsed_s < 5.0);
+    // The whole point: the partial run's measurement survives.
+    try testing.expect(result.snapshot.counters.completed > 0);
+}
+
+fn raiseAfter(io: Io, flag: *std.atomic.Value(bool), delay_ns: u64) void {
+    io.sleep(Io.Duration.fromNanoseconds(delay_ns), .awake) catch return;
+    flag.store(true, .monotonic);
+}
+
 /// Runs a load test to completion and stores whatever `run` returned, so a
 /// canceled run's outcome can be inspected from outside the coroutine.
 fn runCapturing(io: Io, gpa: std.mem.Allocator, cfg: *const cli.Config, out: *?anyerror!Report) void {
-    out.* = run(gpa, io, cfg, 0, null, null);
+    out.* = run(gpa, io, cfg, 0, null, null, null);
 }
 
 test "a canceled run propagates instead of reporting a truncated success" {


### PR DESCRIPTION
`Ctrl-C` killed the process outright, so a run interrupted near its end threw
away everything it had measured. It now stops the run and writes the report for
the elapsed time.

## How

The watcher sets a flag the progress loop polls — it does **not** cancel the
task running `run`. Cancellation discards the measurement, which is the opposite
of what an interrupt should do here, and it would lean on zio's cancel path,
which is racy (lalinsky/zio#622).

The loop already sleeps only to its next frame/row deadline, so the sleep is
capped at 100ms while a flag is installed; otherwise `--interval 20s` would sit
on a `Ctrl-C` for up to 20s. The extra wakes cost a timestamp and two
comparisons before going straight back to sleep.

An interrupted run is not a result to gate on, so SLO checks are skipped and the
exit code is **130**. A partial sample must never report a passing `--slo-p99`.

`Report.interrupted` carries this to embedders and `"interrupted": true` to
`--format json`, rather than leaving a consumer to infer it from `duration_s`
falling short of `config.duration_s`. A second `Ctrl-C` exits immediately.

## Verified against a live server

| check | result |
|---|---|
| JSON mode, SIGINT at 3s of 60s | exit 130, `"interrupted": true`, `duration_s` 3.000, 6000 requests kept |
| text mode, SIGINT at 2s of 30s | exit 130, full percentile report printed |
| `--interval 20s` | stops in **2.01s**, not 20s |
| `--slo-p99 5s` (would pass) + interrupt | exit **130**, not 0 |
| double `Ctrl-C` | exit 130 immediately |
| uninterrupted run | unchanged: exit 0, no `interrupted` field |

Plus a unit test that raises the flag from another task and asserts the run
stops early, reports `interrupted`, and still has `completed > 0`.

## One bug worth calling out

First cut had `main` print its own notice alongside the watcher's. The two
tasks writing stderr concurrently interleaved and truncated each other —
observed output was a clean line followed by the fragment `gain to abort)`.
The notice now has a single owner (the watcher, since it lands the instant
Ctrl-C is pressed and the graceful stop can take a moment at high `-c`).

## Docs

README gains an "Interrupting a run" section and an exit-code table (0/1/2/3/130),
which did not exist before — exit 3 was only mentioned in passing.

## Note

The end-of-run teardown still goes through `Group.cancel`, exactly as a normal
run does, so this adds no new exposure to zio#622.