### PR TITLE
feat: handle SIGTERM alongside SIGINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,19 @@ Short options may be attached (`-c100`) or separated (`-c 100`).
 
 ### Interrupting a run
 
-`Ctrl-C` stops the run and still reports what was measured, rather than
-discarding it — useful when a long run has already shown you what you needed.
+`Ctrl-C` (SIGINT) and SIGTERM both stop the run and still report what was
+measured, rather than discarding it — useful when a long run has already shown
+you what you needed, and the reason `docker stop` on a containerized run no
+longer throws the measurement away.
+
 The report covers the elapsed time, not `--duration`: `duration_s` is the real
-figure, `--format json` adds `"interrupted": true`, and the exit code is **130**.
-CI gates are *not* evaluated on an interrupted run, so a partial sample can
-never report a passing `--slo-p99`. A second `Ctrl-C` aborts immediately.
+figure and `--format json` adds `"interrupted": true`. CI gates are *not*
+evaluated on an interrupted run, so a partial sample can never report a passing
+`--slo-p99`. A second signal aborts immediately, without a report.
+
+Note for supervisors: the graceful stop has to tear down every connection, which
+at high `-c` takes a moment, so allow some grace before SIGKILL (`docker stop`
+defaults to 10s, which is ample).
 
 ### Exit codes
 
@@ -118,7 +125,8 @@ never report a passing `--slo-p99`. A second `Ctrl-C` aborts immediately.
 | 1 | the run failed to start or complete (see the message on stderr) |
 | 2 | bad arguments, or a `--body` file that could not be read |
 | 3 | run completed but a `--slo-p99` / `--max-error-rate` gate was breached |
-| 130 | interrupted with `Ctrl-C`; a partial report was still written |
+| 130 | interrupted by SIGINT (`Ctrl-C`); a partial report was still written |
+| 143 | interrupted by SIGTERM; a partial report was still written |
 
 ### Examples
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -81,16 +81,17 @@ pub fn main(init: std.process.Init) !void {
     // and headless runs stay on the --interval stats window.
     const frame_ns: u64 = if (progress.dash != null and dash.tui) cfg.refresh_ns else 0;
 
-    // Ctrl-C stops the run and still reports what was measured — a long run
-    // interrupted near its end otherwise threw all of it away. The watcher sets
-    // a flag the runner polls rather than canceling it: cancellation discards
-    // the measurement, which is the opposite of what an interrupt should do.
-    var interrupt = std.atomic.Value(bool).init(false);
+    // Ctrl-C (or SIGTERM) stops the run and still reports what was measured — a
+    // long run interrupted near its end otherwise threw all of it away. The
+    // watchers set a flag the runner polls rather than canceling it:
+    // cancellation discards the measurement, the opposite of what an interrupt
+    // should do here.
+    var interrupt: Interrupt = .{};
     var sig_group: Io.Group = .init;
     const watching = installInterrupt(io, &sig_group, &interrupt);
     defer if (watching) sig_group.cancel(io);
 
-    const result = runner.run(arena, io, &cfg, frame_ns, ctx, cb, if (watching) &interrupt else null) catch |err| {
+    const result = runner.run(arena, io, &cfg, frame_ns, ctx, cb, if (watching) &interrupt.flag else null) catch |err| {
         try printRunError(io, err);
         std.process.exit(1);
     };
@@ -112,9 +113,9 @@ pub fn main(init: std.process.Init) !void {
     }
 
     // An interrupted run is not a result to gate on: it covers less than
-    // --duration, so a passing --slo-p99 would mean nothing. Exit 130 (the
-    // shell's SIGINT convention) without evaluating the gates.
-    if (result.interrupted) std.process.exit(130);
+    // --duration, so a passing --slo-p99 would mean nothing. Exit 128+signal
+    // without evaluating the gates.
+    if (result.interrupted) std.process.exit(interrupt.exit_code.load(.monotonic));
 
     // CI gates: a breach exits 3 so a harness can fail the build.
     const slo = report.checkSlo(&cfg, &snapshot);
@@ -124,29 +125,59 @@ pub fn main(init: std.process.Init) !void {
     }
 }
 
-/// Watch for SIGINT for the duration of the run. The first one asks the runner
-/// to stop and report; a second means the user wants out now, so take the
-/// process down rather than waiting for a graceful stop that is evidently not
-/// arriving. Returns false if the watcher could not be installed, in which case
-/// the default disposition stays and Ctrl-C kills the process as before.
-fn installInterrupt(io: Io, group: *Io.Group, flag: *std.atomic.Value(bool)) bool {
-    group.concurrent(io, watchInterrupt, .{ io, flag }) catch return false;
-    return true;
+/// Shared state for the signal watchers. One watcher runs per signal kind, so
+/// everything here is touched from several tasks at once.
+const Interrupt = struct {
+    /// Polled by the runner's progress loop; raising it ends the run early.
+    flag: std.atomic.Value(bool) = .init(false),
+    /// Claimed by whichever watcher sees the *first* signal. Shared across kinds
+    /// so SIGINT-then-SIGTERM aborts rather than printing a second notice — two
+    /// tasks writing stderr at once interleave and truncate each other.
+    claimed: std.atomic.Value(bool) = .init(false),
+    /// 128 + signal number, the shell's convention: 130 for SIGINT, 143 for
+    /// SIGTERM. Set by the watcher that claims the stop.
+    exit_code: std.atomic.Value(u8) = .init(130),
+};
+
+/// Watch for SIGINT and SIGTERM for the duration of the run. The first signal
+/// asks the runner to stop and report; a second (of either kind) means whoever
+/// sent it wants out now, so take the process down rather than keep waiting on
+/// a graceful stop that is evidently not arriving. Returns false if no watcher
+/// could be installed, in which case the default disposition stays and a signal
+/// kills the process as before.
+fn installInterrupt(io: Io, group: *Io.Group, it: *Interrupt) bool {
+    var any = false;
+    // SIGTERM matters as much as SIGINT here: `docker stop` and most CI
+    // cancellations send it, and without this a containerized run loses
+    // everything it measured.
+    for ([_]SignalSpec{
+        .{ .kind = .interrupt, .code = 130, .notice = "\nzrk: interrupt received, stopping (Ctrl-C again to abort)\n" },
+        .{ .kind = .terminate, .code = 143, .notice = "\nzrk: SIGTERM received, stopping (signal again to abort)\n" },
+    }) |spec| {
+        group.concurrent(io, watchSignal, .{ io, spec, it }) catch continue;
+        any = true;
+    }
+    return any;
 }
 
-fn watchInterrupt(io: Io, flag: *std.atomic.Value(bool)) void {
-    var sig = zio.Signal.init(.interrupt) catch return;
+const SignalSpec = struct {
+    kind: zio.SignalKind,
+    code: u8,
+    notice: []const u8,
+};
+
+fn watchSignal(io: Io, spec: SignalSpec, it: *Interrupt) void {
+    var sig = zio.Signal.init(spec.kind) catch return;
     defer sig.deinit();
-    sig.wait() catch return; // canceled at end of run
-    flag.store(true, .monotonic);
-    // Sole owner of the interrupt notice. `main` deliberately prints nothing
-    // more: two tasks writing stderr concurrently interleaved and truncated
-    // each other, and the graceful stop can take a moment at high `-c`, so the
-    // message that matters is this one — printed the instant Ctrl-C lands,
-    // telling the user it was heard and how to give up waiting.
-    writeAll(io, .stderr(), "\nzrk: interrupt received, stopping (Ctrl-C again to abort)\n") catch {};
-    sig.wait() catch return;
-    std.process.exit(130);
+    while (true) {
+        sig.wait() catch return; // canceled at end of run
+        // Whoever gets here first owns the stop and the notice; anyone after —
+        // a repeat of this signal, or the other kind — is the abort request.
+        if (it.claimed.swap(true, .acq_rel)) std.process.exit(spec.code);
+        it.exit_code.store(spec.code, .monotonic);
+        it.flag.store(true, .monotonic);
+        writeAll(io, .stderr(), spec.notice) catch {};
+    }
 }
 
 /// Write the wrk2-style text report to `--output` (text mode with -o set).


### PR DESCRIPTION
#40 made SIGINT stop the run gracefully and report the partial result. SIGTERM
still killed the process outright — and that is the signal `docker stop` and
most CI cancellations send, so a containerized run lost everything it had
measured.

## How

One watcher task per signal kind, sharing an `Interrupt` struct.

The `claimed` flag is shared **across kinds**, not per-watcher. Without that,
SIGINT followed by SIGTERM would have two tasks writing the notice to stderr
concurrently — exactly the interleaving that truncated a message in #40. First
signal of either kind owns the stop and the notice; anything after is the abort
request.

Exit code follows the shell's 128+signal convention per kind — **130** for
SIGINT, **143** for SIGTERM — rather than reporting 130 for both, so a
supervisor can tell which it was.

## Verified against a live server

| check | result |
|---|---|
| SIGTERM at 2s of 60s | exit **143**, `"interrupted": true`, 3999 requests kept |
| SIGINT | still exit **130** |
| SIGTERM at `-c2000` | graceful teardown, 51056 requests kept |
| SIGINT → SIGTERM | exactly one intact notice; second aborts |
| uninterrupted run | unchanged |

One detail worth noting from testing: with a 300ms gap between SIGINT and
SIGTERM the graceful stop *won* — exit 130 with the report written. The abort
path only wins when the second signal arrives before the stop completes, which
is the intended behaviour.

## Docs

README's "Interrupting a run" now covers both signals, adds 143 to the exit-code
table, and notes that supervisors should allow grace before SIGKILL since
teardown at high `-c` takes a moment (`docker stop`'s 10s default is ample).

## CI note

One local run hit the zio#622 flake (`finishCompletion` assert in the
pre-existing `run's elapsed time tracks the duration` test, untouched here);
6/6 clean on re-run.