### PR TITLE
deps: bump zio for the cross-thread timer fixes

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio#a8a88c0e85ba87525ec9555aa409544873443142",
-            .hash = "zio-0.16.0-xHbVVGNDIwDYoZmY7GkL3RMCKuyc4JjK2hv_4TOBx8x2",
+            .url = "git+https://github.com/lalinsky/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
+            .hash = "zio-0.16.0-xHbVVDxFJADhW5CgWRdQmPa8bg_YrOAiPFHTKGFq8jwk",
         },
     },
     .paths = .{


### PR DESCRIPTION
Fixes a hang/abort under sustained overload at high connection counts: the run stops emitting `--timeseries` rows while the process stays alive and keeps serving, or aborts outright.

## Reproduction

A target that answers after 0–60ms, with `--timeout 25ms` so most requests time out and every one of them shuts its socket down and reconnects:

```
zrk -c1000 -R200000 -d40s -t2 --timeout 25ms --interval 1s --timeseries ts.ndjson
```

| build | result |
|---|---|
| **old pin**, ReleaseFast | 6/6 fail — 4 aborts, 2 hangs (2 rows, then alive until `SIGKILL` at 55s) |
| **old pin**, ReleaseSafe | panics with the trace below |
| **new pin**, ReleaseSafe | 6/6 complete, all 40 rows |
| **new pin**, ReleaseFast | 6/6 complete, all 40 rows |

```
thread panic: reached unreachable code
  assert(self.root.load(.monotonic).? == v)   ev/heap.zig:92  in remove
  ev/loop.zig:486:56                          in clearTimer
  io.zig:1800:30                              in sleepImpl
```

## Cause

`Waiter.timedWaitClock` arms a timer on the executor the task is running on, then clears it through `timer.c.loop` after the wait — by which point the task may have migrated to another executor:

```zig
task.getExecutor().loop.setTimer(&timer, timeout);
defer timer.c.loop.?.clearTimer(&timer);
```

So `clearTimer` can touch a loop's timer heap from a different thread while that loop is mid-fire on the same timer. Upstream [`68ddb10`](https://github.com/lalinsky/zio/commit/68ddb107285e40c91c4cc74eb35440f8f83b2fd0) closes exactly that window. The bump range also carries the completion-state rework and two mutex/waker lost-wakeup fixes.

`zrk` hits it hard because every request arms a `watchTimer` and cancels it when the response lands — ~20k arm/clear pairs per second at this rate. `-t1` never fails (no migration, so no cross-thread clear); `-t2` fails reliably.

## Not a `stats.Sweeper` regression

The Sweeper was the initial suspect. It is not involved:

- **v1.1.1**, which predates the Sweeper entirely, fails the same way — 3 hangs + 3 aborts in 6 runs.
- The Sweeper alone, at 10000 connections and ~4M publishes/sec of `Publish.mutex` contention, completes 300 sweeps with no stall.
- No Sweeper frame appears in any trace.

The ~2.9GB at `-c10000` is also expected, not a leak: 10000 × 2 × 136KiB ≈ 2.7GB of histograms, as documented in `stats.zig`.

## Also retires lalinsky/zio#622

The ~2-in-30 test-suite abort filed upstream is gone: **0 failures in 30 consecutive `zig build test` runs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)