### PR TITLE
fix: resample the latency spectrogram without banding

### DIFF
--- a/src/hdr.zig
+++ b/src/hdr.zig
@@ -389,24 +389,56 @@ pub const Histogram = struct {
     /// Fold the recorded counts into `out.len` equal-width log2 latency bins that
     /// tile `[1, highest_trackable]`, so a caller (the live spectrogram) can render
     /// a fixed-axis heatmap column without touching the bucket layout. `out` is
-    /// zeroed first; a value `v` maps to bin `floor(log2(v)/log2(highest)·out.len)`,
-    /// clamped to the last bin. Inverse of `log2BinEdge`. Total count is conserved.
+    /// zeroed first; bin `b` covers `[log2BinEdge(out.len, b), log2BinEdge(out.len,
+    /// b+1))`. Total count is conserved exactly.
+    ///
+    /// Each bucket's count is spread across the bins its *equivalent value range*
+    /// covers, in proportion to the overlap, rather than dropped whole onto the
+    /// bin holding the bucket's midpoint. The difference matters at the low end:
+    /// a bucket there is one `lowest_discernible` unit wide, so at 19µs it spans
+    /// ~7% of an octave while a bin spans ~2.5% — point-mapping would leave two
+    /// bins in three empty and the spectrogram would render a comb of stripes
+    /// that is an artifact of the axis rather than a feature of the latencies.
     pub fn binByLog2(self: *const Histogram, out: []u64) void {
         @memset(out, 0);
         if (out.len == 0) return;
-        const span = std.math.log2(@as(f64, @floatFromInt(self.highest_trackable)));
-        if (span <= 0) return;
-        const scale = @as(f64, @floatFromInt(out.len)) / span;
+        const axis = std.math.log2(@as(f64, @floatFromInt(self.highest_trackable)));
+        if (axis <= 0) return;
+        const scale = @as(f64, @floatFromInt(out.len)) / axis;
+        const top = out.len - 1;
         const s = self.touchedSpan() orelse return;
         var i: u32 = s.lo;
         while (i <= s.hi) : (i += 1) {
             const cnt = self.counts[i];
             if (cnt == 0) continue;
-            const v = self.medianEquivalentValue(self.valueFromIndex(i));
-            const l2 = std.math.log2(@as(f64, @floatFromInt(@max(v, 1))));
-            var b: usize = @intFromFloat(l2 * scale);
-            if (b >= out.len) b = out.len - 1;
-            out[b] += cnt;
+            // The bucket covers [lo_v, hi_v) in value space, hence [lo, hi) on
+            // the log2 bin axis.
+            const lo_v = @max(self.valueFromIndex(i), 1);
+            const hi_v = lo_v +| self.sizeOfEquivalentRange(lo_v);
+            const lo = @max(std.math.log2(@as(f64, @floatFromInt(lo_v))) * scale, 0);
+            const hi = @max(std.math.log2(@as(f64, @floatFromInt(hi_v))) * scale, lo);
+            const width = hi - lo;
+            const total: f64 = @floatFromInt(cnt);
+
+            // Hand each bin the rounded share of `cnt` that lies below its top
+            // edge, minus what the bins before it already took. Telescoping like
+            // this keeps the split exact: the last bin's cumulative share is
+            // `cnt`, so nothing is created or lost by rounding.
+            var placed: u64 = 0;
+            var b: usize = @intFromFloat(lo);
+            while (placed < cnt) : (b += 1) {
+                if (b >= top) {
+                    out[top] += cnt - placed;
+                    break;
+                }
+                const edge: f64 = @floatFromInt(b + 1);
+                const share: u64 = if (width <= 0 or edge >= hi)
+                    cnt
+                else
+                    @intFromFloat(@round(total * (edge - lo) / width));
+                out[b] += share - placed;
+                placed = share;
+            }
         }
     }
 
@@ -1132,23 +1164,57 @@ test "binByLog2 conserves count and separates two modes into ordered bins" {
     for (bins) |b| total += b;
     try testing.expectEqual(@as(u64, 12), total);
 
-    // Exactly two occupied bins, low mode strictly before the high mode.
-    var lo: ?usize = null;
-    var hi: ?usize = null;
-    var occupied: usize = 0;
-    for (bins, 0..) |b, i| if (b > 0) {
-        if (lo == null) lo = i;
-        hi = i;
-        occupied += 1;
-    };
-    try testing.expectEqual(@as(usize, 2), occupied);
-    try testing.expect(lo.? < hi.?);
-    try testing.expectEqual(@as(u64, 5), bins[lo.?]);
-    try testing.expectEqual(@as(u64, 7), bins[hi.?]);
+    // Two clusters, the low mode strictly before the high one with empty bins
+    // between. A bucket whose value range straddles a bin edge splits across
+    // both, so a mode is a short run of adjacent bins rather than always one.
+    var i: usize = 0;
+    while (i < bins.len and bins[i] == 0) i += 1;
+    const lo_start = i;
+    var lo_sum: u64 = 0;
+    while (i < bins.len and bins[i] > 0) : (i += 1) lo_sum += bins[i];
+    const lo_end = i - 1;
+    const gap = i;
+    while (i < bins.len and bins[i] == 0) i += 1;
+    try testing.expect(i > gap); // the modes don't touch
+    const hi_start = i;
+    var hi_sum: u64 = 0;
+    while (i < bins.len and bins[i] > 0) : (i += 1) hi_sum += bins[i];
+    const hi_end = i - 1;
+    while (i < bins.len) : (i += 1) try testing.expectEqual(@as(u64, 0), bins[i]);
 
-    // Each mode's value falls within its bin's [edge(b), edge(b+1)) latency range.
-    try testing.expect(h.log2BinEdge(512, lo.?) <= 100 and 100 < h.log2BinEdge(512, lo.? + 1));
-    try testing.expect(h.log2BinEdge(512, hi.?) <= 100_000 and 100_000 < h.log2BinEdge(512, hi.? + 1));
+    try testing.expectEqual(@as(u64, 5), lo_sum);
+    try testing.expectEqual(@as(u64, 7), hi_sum);
+
+    // Each mode's value falls within the [edge(first), edge(last+1)) latency
+    // range its bins cover.
+    try testing.expect(h.log2BinEdge(512, lo_start) <= 100 and 100 < h.log2BinEdge(512, lo_end + 1));
+    try testing.expect(h.log2BinEdge(512, hi_start) <= 100_000 and 100_000 < h.log2BinEdge(512, hi_end + 1));
+}
+
+test "binByLog2 spreads a bucket across every bin its value range covers" {
+    var h = try newDefault();
+    defer h.deinit();
+    // Tens of microseconds: one bucket is 1µs wide there, which spans several
+    // log2 bins at this axis resolution. Dropping each bucket's count onto a
+    // single bin would leave the bins between the recorded values empty, and
+    // the spectrogram would draw that comb as vertical stripes.
+    var v: u64 = 20;
+    while (v <= 60) : (v += 1) h.recordCount(v, 100);
+
+    var bins: [1024]u64 = undefined;
+    h.binByLog2(&bins);
+
+    var total: u64 = 0;
+    for (bins) |b| total += b;
+    try testing.expectEqual(h.total_count, total);
+
+    var lo: usize = 0;
+    while (bins[lo] == 0) lo += 1;
+    var hi: usize = bins.len - 1;
+    while (bins[hi] == 0) hi -= 1;
+    // The values are contiguous, so their bins are too: no holes in between.
+    try testing.expect(hi - lo >= 40);
+    for (bins[lo .. hi + 1]) |b| try testing.expect(b > 0);
 }
 
 test "log2BinEdge is monotonic and spans the configured range" {

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -445,31 +445,48 @@ pub const Dashboard = struct {
         // repaint. Storage/render buffers stay sized to the spec_width maximum.
         const width = @max(@min(spec_width, self.term_cols -| 1), 1);
 
-        // Aggregate each row's storage bins into `width` display columns,
-        // tracking the global peak for a log-compressed intensity scale (so a
-        // smaller mode still shows rather than washing out next to the dominant
-        // one). Empty ring slots (before the waterfall fills) stay all-zero.
-        var cells: [spec_rows_max][spec_width]u64 = std.mem.zeroes([spec_rows_max][spec_width]u64);
-        var peak: u64 = 1;
+        // Resample each row's storage bins onto `width` display columns, tracking
+        // the global peak for a log-compressed intensity scale (so a smaller mode
+        // still shows rather than washing out next to the dominant one). Empty
+        // ring slots (before the waterfall fills) stay all-zero.
+        //
+        // A column is a weighted *average* of the bins around its center, not a
+        // sum over the bins it happens to straddle: `span` rarely divides
+        // `width`, so summing makes a column that covers two bins twice as hot
+        // as its one-bin neighbour and the picture bands into vertical stripes
+        // that move with the terminal size. The tent kernel spans one column
+        // (radius `colw`/2), widening to a full bin when a column is narrower
+        // than one, which interpolates instead of replicating when the framed
+        // range is upsampled. Bins outside the frame count as zeros, so the
+        // occupied range fades out at its edges rather than ending in a cliff.
+        var cells: [spec_rows_max][spec_width]f64 = std.mem.zeroes([spec_rows_max][spec_width]f64);
+        var peak: f64 = 0;
         if (have_data) {
+            const colw = @as(f64, @floatFromInt(span)) / @as(f64, @floatFromInt(width));
+            const radius = @max(colw / 2, 1.0);
             for (0..n) |r| {
                 const row = self.rowAt(r, n);
                 for (0..width) |x| {
-                    const lo = minb + x * span / width;
-                    // Advance at least one bin per column so upsampling a narrow
-                    // span leaves no artificial gaps; real gaps between modes
-                    // (empty bins) still read as empty columns.
-                    const hi = @max(lo + 1, minb + (x + 1) * span / width);
-                    var sum: u64 = 0;
-                    var b = lo;
-                    while (b < hi and b <= maxb) : (b += 1) sum += row[b];
+                    const center = @as(f64, @floatFromInt(minb)) + (@as(f64, @floatFromInt(x)) + 0.5) * colw;
+                    var acc: f64 = 0;
+                    var wsum: f64 = 0;
+                    var b: isize = @intFromFloat(@floor(center - radius));
+                    const last: isize = @intFromFloat(@ceil(center + radius));
+                    while (b <= last) : (b += 1) {
+                        const d = @abs(@as(f64, @floatFromInt(b)) + 0.5 - center);
+                        if (d >= radius) continue;
+                        const weight = 1 - d / radius;
+                        wsum += weight;
+                        if (b >= 0 and b < spec_bins) acc += @as(f64, @floatFromInt(row[@intCast(b)])) * weight;
+                    }
+                    const v = if (wsum > 0) acc / wsum else 0;
                     // Newest data sits on the bottom rows; older rows pad the top.
-                    cells[spec_rows_max - n + r][x] = sum;
-                    if (sum > peak) peak = sum;
+                    cells[spec_rows_max - n + r][x] = v;
+                    if (v > peak) peak = v;
                 }
             }
         }
-        const denom = std.math.log2(@as(f64, @floatFromInt(1 + peak)));
+        const denom = std.math.log2(1 + peak);
         const color_on = k.reset.len > 0; // theme active (TTY and not NO_COLOR)
         const hottest = heat_ramp.len - 1;
 
@@ -477,12 +494,12 @@ pub const Dashboard = struct {
         for (0..spec_rows_max) |r| {
             for (0..width) |x| {
                 const q = cells[r][x];
-                if (q == 0) {
+                if (q <= 0) {
                     try w.writeAll(" ");
                     continue;
                 }
                 const frac: f64 = if (denom > 0)
-                    std.math.clamp(std.math.log2(@as(f64, @floatFromInt(1 + q))) / denom, 0.0, 1.0)
+                    std.math.clamp(std.math.log2(1 + q) / denom, 0.0, 1.0)
                 else
                     1.0;
                 const stop = heat_ramp[@intFromFloat(@round(frac * @as(f64, @floatFromInt(hottest))))];
@@ -814,6 +831,83 @@ test "spectrogram renders a bimodal interval as two separated clusters" {
     const g1 = std.mem.indexOfScalar(u8, data_row, 0xE2) orelse return error.NoGlyph;
     const gap = std.mem.indexOfScalarPos(u8, data_row, g1, ' ') orelse return error.NoGap;
     try testing.expect(std.mem.indexOfScalarPos(u8, data_row, gap, 0xE2) != null);
+}
+
+test "spectrogram renders a dense interval as an unbroken gradient" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const cfg = cli.Config{ .url = try cli.parseUrl("http://127.0.0.1/"), .interval_ns = std.time.ns_per_s };
+    var dash_buf: [64]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, .empty, &dash_buf);
+    dash.colors = .{}; // disabled: cells are glyph-or-space with no SGR to parse
+    dash.term_cols = 120; // wider than spec_width, so the full 100 columns render
+
+    // One dense mode: a lognormal around 78µs, wide enough (20µs..300µs, ~2
+    // octaves more than the 100 columns can hold) that the framed bin range is
+    // downsampled onto the columns — the regime the issue's run was in.
+    var h = try stats.newHistogram(testing.allocator);
+    defer h.deinit();
+    var v: u64 = 20;
+    while (v <= 300) : (v += 1) {
+        const z = (@log(@as(f64, @floatFromInt(v))) - @log(78.0)) / 0.35;
+        h.recordCount(v, @intFromFloat(3.0e6 * @exp(-0.5 * z * z) / @as(f64, @floatFromInt(v))));
+    }
+    dash.pushSpecRow(&h);
+
+    var out = Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    _ = try dash.drawSpectrogram(&out.writer, h.highest_trackable);
+
+    // The newest row is the last one carrying glyphs.
+    var it = std.mem.splitScalar(u8, out.written(), '\n');
+    var row: []const u8 = "";
+    while (it.next()) |ln| {
+        if (std.mem.indexOfScalar(u8, ln, 0xE2) != null) row = ln;
+    }
+
+    // Decode the row into one intensity level per column: a space is 0, and the
+    // four block glyphs (U+2591..U+2593, U+2588) climb from 1 to 4.
+    var level: [spec_width]u8 = undefined;
+    var cols: usize = 0;
+    var i: usize = 0;
+    while (i < row.len) : (cols += 1) {
+        if (row[i] == ' ') {
+            level[cols] = 0;
+            i += 1;
+            continue;
+        }
+        level[cols] = switch (std.mem.readInt(u24, row[i..][0..3], .big)) {
+            0xE29691 => 1, // ░
+            0xE29692 => 2, // ▒
+            0xE29693 => 3, // ▓
+            0xE29688 => 4, // █
+            else => return error.UnexpectedGlyph,
+        };
+        i += 3;
+    }
+
+    // A single mode must render as a single run of occupied cells: no interior
+    // blanks. Bins finer than the histogram's resolution used to leave gaps
+    // there, drawing an unbroken distribution as a comb of stripes (#43).
+    var lo: usize = 0;
+    while (lo < cols and level[lo] == 0) lo += 1;
+    var hi: usize = cols - 1;
+    while (hi > lo and level[hi] == 0) hi -= 1;
+    try testing.expect(hi - lo > 20); // the mode spans most of the width
+    for (level[lo .. hi + 1]) |l| try testing.expect(l > 0);
+
+    // And it must render as one hill: intensity climbs to the peak, then falls.
+    // Summing whole bins per column made a column covering two of them twice as
+    // hot as its one-bin neighbour, which shows up here as a dip on the way up
+    // (or a bump on the way down).
+    var peak = lo;
+    for (level[lo .. hi + 1], lo..) |l, x| if (l > level[peak]) {
+        peak = x;
+    };
+    for (lo..peak) |x| try testing.expect(level[x] <= level[x + 1]);
+    for (peak..hi) |x| try testing.expect(level[x] >= level[x + 1]);
 }
 
 test "spectrogram reserves full height even before any data" {


### PR DESCRIPTION
Fixes #43.

## Problem

The spectrogram drew hard vertical stripes through what is a single smooth latency mode, and the stripe pattern changed with the terminal width. Two independent causes, both artifacts of the axis rather than features of the latencies:

1. **The fold onto the log2 axis left a comb.** `binByLog2` dropped each histogram bucket's whole count onto the single bin holding the bucket's midpoint. At tens of microseconds a bucket is one `lowest_discernible` unit (1µs) wide — ~7% of an octave — while a bin is ~2.5% of one, so two bins in three received nothing. The occupied bins alternated with empty ones and the waterfall rendered that comb as stripes.

2. **The column resampling was width-dependent.** `drawSpectrogram` gave each display column the *sum* of the bins it straddled. `span` rarely divides `width` evenly (the issue's run framed ~135 bins onto 100 columns), so a column covering two bins came out twice as hot as its one-bin neighbour — a full color stop apart. Resizing the terminal reshuffles which columns those are, which is why the banding moved.

## Fix

- `hdr.binByLog2` spreads each bucket's count across every bin its *equivalent value range* covers, in proportion to the overlap. Each bin takes the rounded cumulative share up to its top edge minus what earlier bins took, so the telescoping split stays exact — total count is still conserved, and `log2BinEdge` is unchanged.
- `drawSpectrogram` resamples with a tent kernel one column wide (radius `colw/2`), normalized by the kernel weight, so a column is a weighted *average* — a density — instead of a sum over however many bins it happens to cover. Where the framed range is upsampled the kernel widens to a full bin, interpolating rather than replicating the same bin across neighbouring columns. Bins outside the frame count as zeros, so the occupied range fades at its edges instead of ending in a cliff.

Cells are `f64` now; the ramp, the glyphs, the auto-framing and the fixed panel height are untouched.

## Tests

- `hdr`: new — a contiguous run of recorded values folds to a contiguous run of bins with no holes, and the count is conserved. The existing two-mode test now asserts the property that matters (each mode's bins carry its full count, with a gap between them) rather than "exactly two occupied bins", which only held because those two buckets happened to land inside single bins.
- `tui`: new — a dense lognormal interval spanning 20µs–300µs (so the framed bins downsample onto the columns, the issue's regime) renders as one unbroken run of cells that climbs to a peak and falls, with no interior blanks and no dips.

Both new assertions were checked against the old code: reverting either fix alone fails the `tui` test, and reverting the fold fails the `hdr` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)