### PR TITLE
fix: keep Ctrl-C from tearing the live panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ figure and `--format json` adds `"interrupted": true`. CI gates are *not*
 evaluated on an interrupted run, so a partial sample can never report a passing
 `--slo-p99`. A second signal aborts immediately, without a report.
 
+On the live dashboard the stop shows up on the panel itself: the blinking
+recording dot beside the clock becomes a `✕` and a line under the counters says
+the run is winding down (joining a large fleet takes a moment). Without a live
+panel — `--plain`, a pipe, `--format json` — the notice goes to stderr instead.
+
 Note for supervisors: the graceful stop has to tear down every connection, which
 at high `-c` takes a moment, so allow some grace before SIGKILL (`docker stop`
 defaults to 10s, which is ample).

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,8 +88,13 @@ pub fn main(init: std.process.Init) !void {
     // should do here.
     var interrupt: Interrupt = .{};
     var sig_group: Io.Group = .init;
-    const watching = installInterrupt(io, &sig_group, &interrupt);
+    // With a live panel the terminal belongs to the dashboard: the watchers stay
+    // silent and the panel reports the stop itself, since a stderr notice
+    // printed under the panel scrolls it out from under the repaint accounting.
+    const live_panel = progress.dash != null and dash.tui;
+    const watching = installInterrupt(io, &sig_group, &interrupt, !live_panel);
     defer if (watching) sig_group.cancel(io);
+    if (watching) dash.stop_requested = &interrupt.flag;
 
     const result = runner.run(arena, io, &cfg, frame_ns, ctx, cb, if (watching) &interrupt.flag else null) catch |err| {
         try printRunError(io, err);
@@ -145,7 +150,10 @@ const Interrupt = struct {
 /// a graceful stop that is evidently not arriving. Returns false if no watcher
 /// could be installed, in which case the default disposition stays and a signal
 /// kills the process as before.
-fn installInterrupt(io: Io, group: *Io.Group, it: *Interrupt) bool {
+///
+/// `notify` writes the stop notice to stderr; pass false when a live dashboard
+/// owns the terminal, which shows the stop on the panel instead.
+fn installInterrupt(io: Io, group: *Io.Group, it: *Interrupt, notify: bool) bool {
     var any = false;
     // SIGTERM matters as much as SIGINT here: `docker stop` and most CI
     // cancellations send it, and without this a containerized run loses
@@ -154,7 +162,7 @@ fn installInterrupt(io: Io, group: *Io.Group, it: *Interrupt) bool {
         .{ .kind = .interrupt, .code = 130, .notice = "\nzrk: interrupt received, stopping (Ctrl-C again to abort)\n" },
         .{ .kind = .terminate, .code = 143, .notice = "\nzrk: SIGTERM received, stopping (signal again to abort)\n" },
     }) |spec| {
-        group.concurrent(io, watchSignal, .{ io, spec, it }) catch continue;
+        group.concurrent(io, watchSignal, .{ io, spec, it, notify }) catch continue;
         any = true;
     }
     return any;
@@ -166,7 +174,7 @@ const SignalSpec = struct {
     notice: []const u8,
 };
 
-fn watchSignal(io: Io, spec: SignalSpec, it: *Interrupt) void {
+fn watchSignal(io: Io, spec: SignalSpec, it: *Interrupt, notify: bool) void {
     var sig = zio.Signal.init(spec.kind) catch return;
     defer sig.deinit();
     while (true) {
@@ -176,7 +184,7 @@ fn watchSignal(io: Io, spec: SignalSpec, it: *Interrupt) void {
         if (it.claimed.swap(true, .acq_rel)) std.process.exit(spec.code);
         it.exit_code.store(spec.code, .monotonic);
         it.flag.store(true, .monotonic);
-        writeAll(io, .stderr(), spec.notice) catch {};
+        if (notify) writeAll(io, .stderr(), spec.notice) catch {};
     }
 }
 

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -174,14 +174,10 @@ pub fn run(
     var next_frame: i128 = start.nanoseconds + frame_ns;
     var interrupted = false;
     while (true) {
-        if (interrupt) |flag| if (flag.load(.monotonic)) {
-            interrupted = true;
-            break;
-        };
         const before = Io.Timestamp.now(io, .awake);
         if (before.nanoseconds >= end.nanoseconds) break;
         var next_wake = @min(@min(next_frame, next_row), end.nanoseconds);
-        // Bound the sleep so the interrupt check above runs on a fixed cadence
+        // Bound the sleep so the interrupt check below runs on a fixed cadence
         // rather than only at the next frame/row deadline.
         if (interrupt != null) next_wake = @min(next_wake, before.nanoseconds + interrupt_poll_ns);
         if (next_wake > before.nanoseconds) {
@@ -202,8 +198,16 @@ pub fn run(
         // The wake at `end` flushes both consumers so the last partial window
         // is never dropped.
         const at_end = t.nanoseconds >= end.nanoseconds;
+        // A raised interrupt ends the run here rather than at the top of the
+        // next pass, so it takes the same last-frame flush as `at_end` does.
+        // Stopping is not instant — the fleet still has to be joined — and
+        // without that frame a live dashboard sits frozen on its last
+        // pre-interrupt paint, giving no sign the signal even arrived.
+        if (interrupt) |flag| if (flag.load(.monotonic)) {
+            interrupted = true;
+        };
         const tick: Tick = .{
-            .frame = at_end or t.nanoseconds >= next_frame,
+            .frame = at_end or interrupted or t.nanoseconds >= next_frame,
             .row = at_end or t.nanoseconds >= next_row,
         };
         // A hair-early sleep return crosses no deadline: sleep again rather
@@ -217,7 +221,7 @@ pub fn run(
         if (progress) |callback| {
             callback(progress_context, &snap, t.nanoseconds, elapsed_s, total_s, tick);
         }
-        if (at_end) break;
+        if (at_end or interrupted) break;
     }
 
     // Signal stop, then cancel: connections idling between paced sends

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -94,6 +94,14 @@ pub const Dashboard = struct {
     /// Lines the previous frame drew — how far to move up before repainting.
     prev_lines: usize = 0,
 
+    /// Raised by the caller's signal watchers once a stop has been requested, so
+    /// the panel can report it *itself*. Nothing else may write to this terminal
+    /// while the panel is live: two lines printed under it (the old stderr
+    /// "interrupt received" notice) scroll the panel down without `prev_lines`
+    /// knowing, so the next repaint moves up too few lines, lands mid-panel and
+    /// leaves a duplicated header stranded above it.
+    stop_requested: ?*const std.atomic.Value(bool) = null,
+
     // Counter samples per frame, so displayed rates are measured over the
     // --interval stats window regardless of how fast --refresh redraws. A
     // per-frame delta at a 10ms refresh holds ~a handful of requests and
@@ -132,6 +140,12 @@ pub const Dashboard = struct {
 
     fn writer(self: *Dashboard) *Io.Writer {
         return &self.fw.interface;
+    }
+
+    /// Whether a signal has asked the run to stop (see `stop_requested`).
+    fn stopping(self: *const Dashboard) bool {
+        const flag = self.stop_requested orelse return false;
+        return flag.load(.monotonic);
     }
 
     /// Newest ring sample at least one --interval older than `now` — the base
@@ -258,10 +272,17 @@ pub const Dashboard = struct {
         // it toggles on a ~1s wall-clock phase (rather than the SGR blink
         // attribute, which most terminals ignore), and the cell stays one column
         // wide — a space while dark — so the clock never jitters. Once finished
-        // it settles to a static dim dot: the panel stays on screen as the run's
-        // record, and a still grey dot reads as "stopped", not "recording".
-        if (finished) {
-            try w.print("{s}●{s} ", .{ k.dim, k.reset });
+        // it settles to a static dim mark: the panel stays on screen as the
+        // run's record, and a still grey mark reads as "stopped", not
+        // "recording". The mark's *shape* says how the run ended — a dot when it
+        // ran its course, a cross when a signal cut it short — and the blink
+        // stops the moment a stop is requested, since the fleet is winding down
+        // from then on and "recording" would be a lie.
+        const stop_req = self.stopping();
+        if (finished or stop_req) {
+            const mark: []const u8 = if (stop_req) "✕" else "●";
+            const tint = if (stop_req and !finished) k.red else k.dim;
+            try w.print("{s}{s}{s} ", .{ tint, mark, k.reset });
         } else {
             const blink_on = (@as(u64, @intFromFloat(@max(elapsed_s, 0) * 2)) & 1) == 0;
             if (blink_on) try w.print("{s}●{s} ", .{ k.red, k.reset }) else try w.writeAll("  ");
@@ -322,6 +343,19 @@ pub const Dashboard = struct {
                 k.red, c.deadline_errors, k.reset,
                 k.dim, k.reset,           Dur.of(c.max_behind_ns / std.time.ns_per_us),
             });
+            lines += 1;
+        }
+        // The stop notice belongs *in* the panel, counted in `lines` like every
+        // other row: printed underneath it instead (as a stderr line) it would
+        // desync the in-place repaint. Joining a large fleet is not instant, so
+        // while it happens the hint also says how to give up waiting.
+        if (stop_req) {
+            try padTo(w, stat_col);
+            if (finished) {
+                try w.print("{s}stopped early — the numbers above are what was measured{s}\n", .{ k.dim, k.reset });
+            } else {
+                try w.print("{s}stopping — signal again to abort{s}\n", .{ k.dim, k.reset });
+            }
             lines += 1;
         }
         try w.writeAll("\n");
@@ -786,6 +820,59 @@ test "writeFinalSummary renders the compact plain summary to any writer" {
     // No deadline mode here, so neither overload line appears.
     try testing.expect(std.mem.indexOf(u8, text, "deadline misses") == null);
     try testing.expect(std.mem.indexOf(u8, text, "peak schedule lag") == null);
+}
+
+test "a requested stop shows on the panel without breaking its line accounting" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const cfg = cli.Config{ .url = try cli.parseUrl("http://127.0.0.1/") };
+    var dash_buf: [64]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, .empty, &dash_buf);
+    dash.colors = .{};
+    dash.term_cols = 120;
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 100;
+    snap.counters.recordStatus(200);
+
+    var stop = std.atomic.Value(bool).init(false);
+    dash.stop_requested = &stop;
+
+    // The whole point of the accounting: `prev_lines` is how far the *next*
+    // frame moves up, so a panel that writes more newlines than it reports
+    // repaints mid-panel and strands a duplicate header above itself. That is
+    // what the old stderr stop notice did, from outside the panel entirely.
+    var running = Io.Writer.Allocating.init(testing.allocator);
+    defer running.deinit();
+    const live = try dash.drawPanel(&running.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    try testing.expectEqual(std.mem.count(u8, running.written(), "\n"), live);
+    try testing.expect(std.mem.indexOf(u8, running.written(), "✕") == null);
+
+    stop.store(true, .monotonic);
+    var stopping = Io.Writer.Allocating.init(testing.allocator);
+    defer stopping.deinit();
+    const cut = try dash.drawPanel(&stopping.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    try testing.expectEqual(std.mem.count(u8, stopping.written(), "\n"), cut);
+    // The recording dot gives way to a cross, and the notice lands inside the
+    // panel — one line taller than the same frame with no stop pending.
+    try testing.expect(std.mem.indexOf(u8, stopping.written(), "✕") != null);
+    try testing.expect(std.mem.indexOf(u8, stopping.written(), "●") == null);
+    try testing.expect(std.mem.indexOf(u8, stopping.written(), "stopping — signal again to abort") != null);
+    try testing.expectEqual(live + 1, cut);
+
+    // Settled: the panel stays as the run's record, so the cross persists and
+    // the hint gives way to what the numbers mean.
+    var final_out = Io.Writer.Allocating.init(testing.allocator);
+    defer final_out.deinit();
+    const done = try dash.drawPanel(&final_out.writer, &snap, 100, 1000, 1.0, 30.0, true);
+    try testing.expectEqual(std.mem.count(u8, final_out.written(), "\n"), done);
+    try testing.expect(std.mem.indexOf(u8, final_out.written(), "✕") != null);
+    try testing.expect(std.mem.indexOf(u8, final_out.written(), "signal again") == null);
+    try testing.expect(std.mem.indexOf(u8, final_out.written(), "stopped early") != null);
 }
 
 test "spectrogram renders a bimodal interval as two separated clusters" {


### PR DESCRIPTION
Hitting Ctrl-C during a live run moved the panel two lines down and left a duplicate header (the timer / offered / achieved row) stranded above the redraw.

## Cause

The signal watchers wrote `"\nzrk: interrupt received…\n"` to **stderr** while the dashboard owned stdout. Those two newlines scrolled the panel down without `prev_lines` knowing, so the next repaint's `\x1b[{prev_lines}A\x1b[J` moved up two lines too few — landing mid-panel, redrawing from there, and orphaning the panel's first two lines above it.

## Fix

Nothing but the panel may write to that terminal, so the panel reports the stop itself:

- `Dashboard.stop_requested` points at the interrupt flag. A raised flag adds a dim `stopping — signal again to abort` line *inside* the panel, counted in the returned line total like every other row.
- The stderr notice is now emitted only when no live panel owns the terminal — `--plain`, a pipe, `--format json`. That is exactly where it never desynced anything, and its behaviour there is unchanged.
- While a stop is pending the blinking red recording dot becomes a static red `✕`, settling to a dim `✕` on the final panel. The mark's shape now says *how* the run ended (`●` ran its course, `✕` was cut short), and the settled panel reads `stopped early — the numbers above are what was measured`.
- `runner.zig` gives the interrupt the same last-frame flush `at_end` already took. Without it the panel froze on its last pre-interrupt paint for the whole fleet join, so on a run large enough to take a moment to stop, the `✕` would never have been visible.

## Verification

Ran under a pty (`script`), SIGINT at 3s, then checked every repaint's cursor-up count against the newlines of the paint before it: **30 repaints, 0 mismatches**, including the 19-line stopping frame. No `interrupt received` anywhere in the stream.

```
✕ 0:03 / 0:30    offered 200 req/s   achieved 0 req/s
                 transfer 0B (0B/s)
                 2xx 0
                 socket errors 2269   non-2xx/3xx 0
                 stopped early — the numbers above are what was measured
```

Non-TTY path re-checked separately: notice still on stderr, exit 130, full summary written.

A new test pins the invariant that broke — `drawPanel`'s returned line count must equal the newlines it writes — across the running, stopping, and settled states.

## Note

Not addressed here: in debug builds zio logs `Spawning worker thread N` to stderr. It lands before the first paint so it is harmless today, but any zio log emitted mid-run would corrupt the panel the same way, and the panel has no defence against that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)