### PR TITLE
deps: take zio from the fork with the cancel-SQE fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio#3566a3a8ca706e90de0ef1e1c46226ec4464f659",
-            .hash = "zio-0.16.0-xHbVVDxFJADhW5CgWRdQmPa8bg_YrOAiPFHTKGFq8jwk",
+            .url = "git+https://github.com/zoxy-io/zio?ref=fix/cancel-sqe-exhaustion#87db53bdc76c66a95da7dfc5e6ed313b86e2bcbb",
+            .hash = "zio-0.16.0-xHbVVD5KJABBZ_JZWYUgHatZ65KMm2uCSto03fyE-GY8",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Problem
zio drops a cancel when the io_uring submission queue is full, and the dropped cancel doesn't degrade gracefully — the target completion stays `.running` forever, so the race group in `timedWaitForIo` never resolves and the waiting task blocks permanently.

zrk hits this directly: every operation timeout submits its own cancel when it expires, and a run holding thousands of connections against a saturated server has thousands of timeouts come due together against a 256-entry ring. Observed at 10k connections:

```
error(zio): Failed to get io_uring SQE for cancel
```

...followed by a wedge with no further output until CI killed the job.

## Fix
Point the zio pin at `zoxy-io/zio#fix/cancel-sqe-exhaustion`, which flushes the submission queue and retries instead of giving up on the cancel. Filed upstream as lalinsky/zio#623; revert to upstream zio once it lands there.

Only the zio pin changes (`build.zig.zon`), so this is a clean single-variable delta on v1.3.1.

## Tests
- CI (build + test on Linux/macOS)