### PR TITLE
deps: switch zio back to upstream now that the cancel-SQE fix landed

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .zio = .{
-            .url = "git+https://github.com/zoxy-io/zio?ref=fix/cancel-sqe-exhaustion#87db53bdc76c66a95da7dfc5e6ed313b86e2bcbb",
-            .hash = "zio-0.16.0-xHbVVD5KJABBZ_JZWYUgHatZ65KMm2uCSto03fyE-GY8",
+            .url = "git+https://github.com/lalinsky/zio?ref=main#b822fda55af546ce47918776950338cdf23315c0",
+            .hash = "zio-0.16.0-xHbVVJqoJADE1sz0O0ssHXOjaYODH86TWCUG9Pg4N69C",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Problem

`build.zig.zon` has pinned `zoxy-io/zio`'s `fix/cancel-sqe-exhaustion` branch
since #47, as a stopgap for a deadlock: when the io_uring submission queue was
full, a cancel got dropped instead of retried, leaving its target completion
stuck `.running` forever and wedging the task waiting on it in
`timedWaitForIo`. That was filed upstream as lalinsky/zio#623.

## Fix

Upstream merged an equivalent fix in [lalinsky/zio#628](https://github.com/lalinsky/zio/pull/628)
(`0423f05`, "io_uring: flush a full submission queue instead of dropping
SQEs"), now on `main` at `b822fda`. This points `build.zig.zon` back at
upstream `lalinsky/zio` instead of the fork.

Not yet in a tagged release — `v0.16.0` predates the fix — so this pins to a
specific commit on `main` rather than a tag, same convention the fork pin
used.

## Tests

- [x] `zig build --fetch` — fetches cleanly, hash verified against a fresh
      (non-cached) download of the pinned commit
- [x] `zig build`
- [x] `zig build test`