### PR TITLE
tls: swap std.crypto.tls for ztls, and negotiate h2 over ALPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ zig build test            # run the unit + integration tests
 ## Usage
 
 ```
-zrk [options] <url>
+zrk — constant-throughput HTTP load generator
 
-  -t, --threads     <B>     Total number of threads to execute load (default 2)
+Usage: zrk [options] <url>
+
+Options:
+  -t, --threads     <N>     Total number of threads to execute load (default 2)
   -c, --connections <N>     Total connections to keep open (default 10)
   -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
   -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
@@ -109,17 +112,20 @@ zrk [options] <url>
                             scheduled send: a too-stale request is shed
                             (failed as a `deadline` error, not sent or
                             recorded) before sending (0 = off)
-      --deadline-abort      Also abort in-flight requests past the deadline.
-                            Resets the connection per miss and churns under
-                            saturation; off by default
+      --deadline-abort      Also abort in-flight requests past the
+                            deadline. Resets the connection per miss and
+                            churns under saturation; off by default
       --interval    <T>     Stats window: --timeseries rows and --plain
                             lines                          (default 1s)
       --refresh     <T>     Live dashboard redraw rate     (default 80ms)
       --latency             Print full latency spectrum in the final report
+      --http2               Speak HTTP/2. Cleartext uses prior knowledge
+                            (h2c); https negotiates it over ALPN and
+                            fails the connection if the server declines
   -k, --insecure            Skip TLS certificate verification
       --plain               Append-only output instead of a live dashboard
 
-  Reporting:
+Reporting:
       --format  <text|json> Final report format            (default text)
   -o, --output      <FILE>  Write the final report to FILE (default stdout)
       --hdr         <FILE>  Also write the HdrHistogram percentile
@@ -129,12 +135,12 @@ zrk [options] <url>
       --timeseries-histogram  Add each interval's full latency histogram
                             (HdrHistogram base64) to every --timeseries row
       --no-record-timeouts  Drop wire-timed-out requests from the latency
-                            histogram (default: record them, so the tail isn't
-                            truncated). --deadline misses are never recorded.
+                            histogram (default: record them). Independent
+                            of --deadline misses, which are never recorded.
 
-  CI gates (exit code 3 on breach):
+CI gates (exit code 3 on breach):
       --slo-p99     <T>     Fail if final p99 latency exceeds T
-      --max-error-rate <F>  Fail if error rate exceeds F (e.g. 0.01 or 1%)
+      --max-error-rate <F>  Fail if error rate exceeds F (0..1)
 
   -h, --help                Show this help
       --version             Show version

--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,53 @@ pub fn build(b: *std.Build) void {
     build_info.addOption([]const u8, "version", manifest.version);
     const build_info_mod = build_info.createModule();
 
+    // TLS, and the libcrypto under it.
+    //
+    // The three lines below are what the `ztls-probe` branch cost six CI runs
+    // to establish, and none of them is obvious. On a native build pkg-config
+    // supplies all three invisibly through `linkSystemLibrary("crypto")`; a
+    // cross-build has no pkg-config, so each becomes explicit:
+    //
+    //   1. a library search path, so ztls's `linkSystemLibrary` finds the
+    //      archive at all;
+    //   2. an include path on **ztls's own module**, because include paths are
+    //      per-module and the `@cImport` of `openssl/base.h` lives there, not
+    //      here;
+    //   3. `bcm` as well as `crypto` — modern BoringSSL splits the primitives
+    //      into a second archive that declares no dependency on the first, and
+    //      omitting it leaves 236 undefined `BN_*` symbols.
+    const boringssl = b.dependency("boringssl", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const ztls_dep = b.dependency("ztls", .{
+        .target = target,
+        .optimize = optimize,
+        .@"crypto-backend" = @as([]const u8, "boringssl"),
+        // We supply libcrypto, so pkg-config must not. Left on, it injects the
+        // system OpenSSL's include path ahead of BoringSSL's, `openssl/base.h`
+        // resolves to one and its neighbours to the other, and the C import
+        // dies on typedef collisions — but only on machines where pkg-config
+        // knows about OpenSSL, so it passes CI and breaks on a laptop.
+        .@"crypto-pkg-config" = false,
+    });
+    const ztls_core = ztls_dep.module("ztls");
+    ztls_core.addIncludePath(boringssl.namedLazyPath("ssl_include"));
+    const ztls_std = ztls_dep.module("ztls_std");
+
+    // Every artifact that reaches `src/tls.zig` needs both archives and the
+    // search path; they always travel together, so they are set in one place
+    // rather than repeated per artifact.
+    const linkCrypto = struct {
+        fn apply(module: *std.Build.Module, bssl: *std.Build.Dependency) void {
+            const crypto = bssl.artifact("crypto");
+            module.addLibraryPath(crypto.getEmittedBinDirectory());
+            module.linkLibrary(crypto);
+            module.linkLibrary(bssl.artifact("bcm"));
+            module.link_libc = true;
+        }
+    }.apply;
+
     // The reusable library module: embedders `@import("zrk")` this.
     const mod = b.addModule("zrk", .{
         .root_source_file = b.path("src/root.zig"),
@@ -37,8 +84,10 @@ pub fn build(b: *std.Build) void {
             .{ .name = "build_info", .module = build_info_mod },
             .{ .name = "zio", .module = zio.module("zio") },
             .{ .name = "h2", .module = h2.module("h2") },
+            .{ .name = "ztls_std", .module = ztls_std },
         },
     });
+    linkCrypto(mod, boringssl);
 
     // A standing check that the dependency options above actually applied.
     const pin_tests = b.addTest(.{
@@ -62,10 +111,26 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "build_info", .module = build_info_mod },
                 .{ .name = "zio", .module = zio.module("zio") },
                 .{ .name = "h2", .module = h2.module("h2") },
+                .{ .name = "ztls_std", .module = ztls_std },
             },
         }),
     });
+    linkCrypto(exe.root_module, boringssl);
     b.installArtifact(exe);
+
+    // Type-check without linking.
+    //
+    // `zig build` needs libcrypto, which means building BoringSSL — minutes,
+    // and impossible in a sandbox that cannot reach the two non-GitHub hosts
+    // its package pulls from. An object needs no libraries, so this answers
+    // "does the Zig compile" in seconds, which is the question most edits
+    // actually raise.
+    const check = b.addObject(.{
+        .name = "zrk-check",
+        .root_module = exe.root_module,
+    });
+    b.step("check", "Type-check without linking (no libcrypto needed)")
+        .dependOn(&check.step);
 
     // `zig build run -- <args>` runs the installed binary.
     const run_step = b.step("run", "Run the app");

--- a/build.zig
+++ b/build.zig
@@ -88,6 +88,10 @@ pub fn build(b: *std.Build) void {
         },
     });
     linkCrypto(mod, boringssl);
+    // `cli.zig` checks the README's usage block against the real help text.
+    // `@embedFile` cannot escape the module root, so the file arrives as a named
+    // import instead.
+    mod.addAnonymousImport("readme", .{ .root_source_file = b.path("README.md") });
 
     // A standing check that the dependency options above actually applied.
     const pin_tests = b.addTest(.{

--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,12 @@ pub fn build(b: *std.Build) void {
     // `cli.zig` checks the README's usage block against the real help text.
     // `@embedFile` cannot escape the module root, so the file arrives as a named
     // import instead.
+    //
+    // Added to both modules, because `main.zig` reaches `cli.zig` by file
+    // import rather than through the `zrk` module — so it is compiled into the
+    // executable's root module too, and an import given to only one of them is
+    // missing from the other. Every other dependency here is already listed
+    // twice for exactly that reason; this one was not, and CI caught it.
     mod.addAnonymousImport("readme", .{ .root_source_file = b.path("README.md") });
 
     // A standing check that the dependency options above actually applied.
@@ -120,9 +126,15 @@ pub fn build(b: *std.Build) void {
         }),
     });
     linkCrypto(exe.root_module, boringssl);
+    exe.root_module.addAnonymousImport("readme", .{ .root_source_file = b.path("README.md") });
     b.installArtifact(exe);
 
     // Type-check without linking.
+    //
+    // Does not cover `test` blocks: an object has no test runner, so their
+    // bodies are never analysed. An import used only inside a test passes this
+    // and fails `zig build test` — which is exactly how the `readme` import
+    // above reached CI.
     //
     // `zig build` needs libcrypto, which means building BoringSSL — minutes,
     // and impossible in a sandbox that cannot reach the two non-GitHub hosts

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -65,8 +65,8 @@
         // ztls is Linux and macOS only by design; the Windows release targets
         // were dropped for it in 5a36623.
         .ztls = .{
-            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#c4d0f552c7d16fb2c7bc587c71ba5376a8a37562",
-            .hash = "ztls-0.0.0-SHHDXkr0FgBp4kN6V23SQy0cdPOC5St9cBNoJIIyzzn_",
+            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#03c246477370d83bfc38d5168250e10fb235f358",
+            .hash = "ztls-0.0.0-SHHDXrvzFgAxDlPTWEEam3B2YclV_S0hHpOrD3qGFnEp",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -40,6 +40,34 @@
             .url = "git+https://github.com/zoxy-io/h2#ce82b9a886435d8fdd53e1a8cfbe72ed918fb53e",
             .hash = "h2-0.0.0--ngLtzZFBgCrbAucjP1hgw2-vJ2K12mf-04oR-EdzitD",
         },
+        // libcrypto for ztls, built by Zig rather than found on the system.
+        //
+        // ztls declares `linkSystemLibrary("crypto")`, which pkg-config would
+        // normally satisfy — but pkg-config only works when the host is the
+        // target, which is why zoxy builds natively on one runner per target
+        // and lost cross-compilation when it gained this dependency. A Zig-built
+        // BoringSSL linked as an artifact keeps zrk's single-runner
+        // cross-compile: proven for all four remaining targets on the
+        // `ztls-probe` branch, aarch64 included.
+        .boringssl = .{
+            .url = "git+https://github.com/allyourcodebase/boringssl#ec7cca75cbf5381ba4a9e111d1f12236f8f2bd6a",
+            .hash = "boringssl-0.20260526.0-EhtkNaI5AAAUWRtpFwiFhqdvxjAMMWkcx-iHkKIppGBV",
+        },
+        // TLS 1.3, for ALPN and therefore for HTTP/2 over TLS (#21).
+        //
+        // Pinned to `zoxy-tls`, the line zoxy audits and pins rather than
+        // `main`, so both consumers are on the same audited snapshot. It
+        // carries zoxy-io/ztls#2, which exposes the `std.Io` integration as a
+        // module — without it that adapter is a subdirectory no `zig fetch` can
+        // reach, and zrk's only options were vendoring 1177 lines of it or
+        // writing a second one.
+        //
+        // ztls is Linux and macOS only by design; the Windows release targets
+        // were dropped for it in 5a36623.
+        .ztls = .{
+            .url = "git+https://github.com/zoxy-io/ztls?ref=zoxy-tls#c4d0f552c7d16fb2c7bc587c71ba5376a8a37562",
+            .hash = "ztls-0.0.0-SHHDXkr0FgBp4kN6V23SQy0cdPOC5St9cBNoJIIyzzn_",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -81,13 +81,17 @@ pub const Config = struct {
     /// Speak HTTP/2 with prior knowledge (RFC 9113 section 3.4) instead of
     /// HTTP/1.1.
     ///
-    /// Prior knowledge means h2c: no ALPN and no upgrade dance, so the target
-    /// has to be a cleartext server that already speaks h2 — which is what a
-    /// benchmark target behind a terminator usually is. One request is in
-    /// flight per connection either way, so `-c`, the pacing, and every latency
-    /// number keep exactly their HTTP/1.1 meaning; only the wire format
-    /// changes. Multiplexing is a separate question about what concurrency
-    /// means for a coordinated-omission-corrected generator (zoxy-io/zrk#21).
+    /// Over cleartext this is prior knowledge (h2c) — no upgrade dance, so the
+    /// target must already speak h2, which a benchmark target behind a
+    /// terminator generally does. Over TLS it is ALPN, and a server that
+    /// declines `h2` fails the connection rather than being benchmarked over a
+    /// protocol nobody asked for.
+    ///
+    /// One request is in flight per connection either way, so `-c`, the pacing,
+    /// and every latency number keep exactly their HTTP/1.1 meaning; only the
+    /// wire format changes. Multiplexing is a separate question about what
+    /// concurrency means for a coordinated-omission-corrected generator
+    /// (zoxy-io/zrk#21).
     http2: bool = false,
     /// Skip TLS certificate verification.
     insecure: bool = false,
@@ -136,7 +140,6 @@ pub const ParseError = error{
     ZeroRate,
     ZeroInterval,
     ZeroRefresh,
-    Http2RequiresCleartext,
     OutOfMemory,
 };
 
@@ -186,9 +189,9 @@ pub const usage =
     \\                            lines                          (default 1s)
     \\      --refresh     <T>     Live dashboard redraw rate     (default 80ms)
     \\      --latency             Print full latency spectrum in the final report
-    \\      --http2               Speak HTTP/2 with prior knowledge (h2c).
-    \\                            Cleartext only for now: no ALPN, so an https
-    \\                            URL still negotiates HTTP/1.1
+    \\      --http2               Speak HTTP/2. Cleartext uses prior knowledge
+    \\                            (h2c); https negotiates it over ALPN and
+    \\                            fails the connection if the server declines
     \\  -k, --insecure            Skip TLS certificate verification
     \\      --plain               Append-only output instead of a live dashboard
     \\
@@ -334,15 +337,6 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
 
-    // Refused rather than attempted. HTTP/2 over TLS is chosen by ALPN (RFC
-    // 9113 section 3.2), and the TLS client this binary links — `std.crypto.tls`
-    // — has no ALPN at all. Without it the server negotiates HTTP/1.1 and we
-    // would send an h2 connection preface into an h1 connection: the run would
-    // fail in a way that looks like the *target* misbehaving, which is the
-    // worst outcome for a measurement tool. Lifting this is the ztls decision
-    // in zoxy-io/zrk#21, and it is a distribution question rather than an
-    // HTTP/2 one.
-    if (cfg.http2 and cfg.url.isTls()) return error.Http2RequiresCleartext;
     cfg.headers = try headers.toOwnedSlice(arena);
     return .{ .config = cfg };
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -732,3 +732,25 @@ test "rate parses scalar and ramp forms" {
     try testing.expectEqual(@as(?u64, 5000), attached.rate_end);
     try testing.expectError(error.ZeroRate, parse(a, &[_][]const u8{ "-R", "100:0", "http://x/" }));
 }
+
+test "the README's usage block is the real help text" {
+    // The README duplicated this by hand, and drifted: `--http2` was missing
+    // entirely, `--threads` took `<B>` where the program says `<N>`, and three
+    // descriptions had diverged in wording. Every one of those is a promise the
+    // binary does not keep.
+    //
+    // Comparing them is cheaper than remembering. `@embedFile` reads the README
+    // at compile time, so a change to either side that leaves them different
+    // fails the build rather than shipping documentation for a program that
+    // does not exist.
+    const readme = @embedFile("readme");
+
+    const opening = "## Usage\n\n```\n";
+    const start = (std.mem.indexOf(u8, readme, opening) orelse
+        return error.UsageSectionMissing) + opening.len;
+    const rest = readme[start..];
+    const end = std.mem.indexOf(u8, rest, "```") orelse return error.UsageBlockUnterminated;
+    const documented = std.mem.trimEnd(u8, rest[0..end], "\n");
+
+    try std.testing.expectEqualStrings(std.mem.trimEnd(u8, usage, "\n"), documented);
+}

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -223,13 +223,28 @@ pub fn run(p: *Params) void {
         var plain_writer: net.Stream.Writer = undefined;
         if (p.is_tls) {
             const ts = p.tls_state.?;
-            ts.handshake(io, p.allocator, stream, p.host, p.insecure, p.ca_store) catch {
+            // Offer `h2` only when this run speaks it. A server that answers
+            // `http/1.1` to an `h2` offer is a real thing to meet, so the
+            // negotiated protocol is checked below rather than assumed.
+            const alpn = if (p.http2) tlsmod.alpn_http2 else tlsmod.alpn_http1;
+            ts.handshake(io, p.allocator, stream, p.host, p.insecure, p.ca_store, alpn) catch {
                 // A failed handshake counts as a connect error; try again later.
                 noteError(p, .connect);
                 stream.close(io);
                 io.sleep(Io.Duration.fromMilliseconds(5), .awake) catch return;
                 continue;
             };
+            // What the peer actually chose. `--http2` against a server that
+            // does not speak it would otherwise send an HTTP/2 preface into an
+            // HTTP/1.1 connection and report the target as broken — which is
+            // exactly the failure mode the cleartext-only guard existed to
+            // prevent, now that ALPN makes the question answerable.
+            if (p.http2 and !alpnIs(ts.negotiatedAlpn(), "h2")) {
+                noteError(p, .connect);
+                stream.close(io);
+                io.sleep(Io.Duration.fromMilliseconds(5), .awake) catch return;
+                continue;
+            }
             app_reader = ts.reader();
             app_writer = ts.writer();
         } else {
@@ -402,10 +417,10 @@ fn performWork(
 ) WorkResult {
     if (session) |active| return performWorkHttp2(p, active);
     app_writer.writeAll(p.request) catch return .write_failed;
+    // One flush is enough: ztls-std's writer encrypts *and* writes the records
+    // to the socket handle itself, where `std.crypto.tls` only encrypted into
+    // the socket writer's buffer and needed a second flush behind it.
     app_writer.flush() catch return .write_failed;
-    // For TLS the app writer only encrypts into the socket writer's buffer; the
-    // underlying stream writer must be flushed to actually send the ciphertext.
-    if (p.is_tls) p.tls_state.?.swriter.interface.flush() catch return .write_failed;
     const resp = httpmod.parseResponse(app_reader, p.method) catch return .read_failed;
     return .{ .ok = resp };
 }
@@ -427,6 +442,13 @@ fn performWorkHttp2(p: *Params, session: *h2conn.Session) WorkResult {
         error.Protocol, error.TooLarge => return .read_failed,
     };
     return .{ .ok = resp };
+}
+
+/// Whether ALPN settled on `want`. Null means the peer selected nothing, which
+/// for an `h2` offer is a refusal rather than a default.
+fn alpnIs(selected: ?[]const u8, want: []const u8) bool {
+    const chosen = selected orelse return false;
+    return std.mem.eql(u8, chosen, want);
 }
 
 fn now(io: Io) Io.Timestamp {

--- a/src/main.zig
+++ b/src/main.zig
@@ -365,15 +365,6 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.ZeroRate => "zrk: rate (-R) must be greater than 0\n\n",
         error.ZeroInterval => "zrk: --interval must be greater than 0\n\n",
         error.ZeroRefresh => "zrk: --refresh must be greater than 0\n\n",
-        error.Http2RequiresCleartext =>
-            \\zrk: --http2 needs an http:// URL
-            \\
-            \\HTTP/2 over TLS is selected by ALPN, and the TLS client this binary
-            \\links does not implement it. Point --http2 at a cleartext h2c
-            \\endpoint, or drop --http2 to benchmark the https URL over HTTP/1.1.
-            \\
-            \\
-        ,
         error.OutOfMemory => "zrk: out of memory\n\n",
     };
     try writeAll(io, .stderr(), msg);

--- a/src/tls.zig
+++ b/src/tls.zig
@@ -2,22 +2,38 @@
 //!
 //! `CaStore` holds the system CA bundle, loaded once and shared (read-mostly)
 //! across all connections. `State` is a per-connection, pinned block of buffers
-//! plus the `std.crypto.tls.Client`; it wraps a connected stream and exposes the
-//! decrypted reader/writer that the HTTP layer talks to.
+//! plus the TLS client; it wraps a connected stream and exposes the decrypted
+//! reader/writer that the HTTP layer talks to.
+//!
+//! ## Why ztls rather than `std.crypto.tls`
+//!
+//! ALPN. HTTP/2 over TLS is selected by it (RFC 9113 section 3.2) and
+//! `std.crypto.tls` has none, so `--http2` could only ever have been cleartext.
+//! That is the whole reason for the swap, and it is why `Options.alpn` is the
+//! one field this wrapper adds to what it had before.
+//!
+//! The cost is real and was paid deliberately: ztls's primitives are
+//! libcrypto's, so zrk now links C where it linked none, and ztls is Linux and
+//! macOS by design — its entropy shim is an outright `@compileError` elsewhere,
+//! which is why the Windows release targets were dropped. See zoxy-io/zrk#21.
+//!
+//! ztls-std imposes no timeout of its own; a slow peer can stall a handshake or
+//! a read indefinitely, and the right mechanism is `std.Io` cancellation.
+//! `connection.zig` already owns that: `watchTimer` shuts the socket down, and
+//! the cancellation surfaces here as a transport error.
 
 const std = @import("std");
 const Io = std.Io;
 const net = std.Io.net;
-const tls = std.crypto.tls;
 const Certificate = std.crypto.Certificate;
-
-/// Encrypted-record buffer size required by the TLS client.
-const record_len = tls.max_ciphertext_record_len;
-/// Room for a full HTTP response head on top of one TLS record.
-const app_read_len = record_len + 16 * 1024;
-const app_write_len = 8 * 1024;
+const ztls = @import("ztls_std");
 
 /// The system trust store, loaded once and shared by all connections.
+///
+/// `Verify.system_bundle` would rescan the OS trust store on every handshake
+/// and free it again — fine for a program that opens one connection, wrong for
+/// one that opens thousands. This is the `.bundle` case ztls-std documents for
+/// exactly that reason.
 pub const CaStore = struct {
     bundle: Certificate.Bundle,
     lock: Io.RwLock = .init,
@@ -33,22 +49,28 @@ pub const CaStore = struct {
     }
 };
 
+/// The TLS client, with buffers sized for one HTTP exchange at a time.
+///
+/// `peer_chain_storage` is left null: retaining the verified chain costs about
+/// 64 KiB per connection and zrk never reports it. A load generator holds
+/// hundreds of these at once, so the default that suits a demo client is the
+/// wrong one here.
+const Client = ztls.ClientWith(.{});
+
 /// Per-connection TLS state. Must not be moved once `handshake` has run, since
-/// the `tls.Client` stores pointers into its own buffers and stream adapters.
+/// the client stores pointers into its own buffers and stream adapters.
 /// Reused across reconnects by simply re-running `handshake`.
 pub const State = struct {
-    app_read: [app_read_len]u8 = undefined,
-    sock_read: [record_len]u8 = undefined,
-    sock_write: [record_len]u8 = undefined,
-    app_write: [app_write_len]u8 = undefined,
-    sreader: net.Stream.Reader = undefined,
-    swriter: net.Stream.Writer = undefined,
-    client: tls.Client = undefined,
+    client: Client = undefined,
 
-    pub const HandshakeError = tls.Client.InitError;
+    pub const HandshakeError = ztls.ConnectError;
 
-    /// Perform the TLS handshake over `stream`. When `insecure` is true, neither
-    /// the hostname nor the certificate chain is verified (`-k`).
+    /// Perform the TLS handshake over `stream`, offering `alpn`.
+    ///
+    /// When `insecure` is true neither the hostname nor the certificate chain
+    /// is verified (`-k`). Note that `.insecure` in ztls-std skips the chain
+    /// anchor but still verifies the hostname unless `host` is null, so `-k`
+    /// passes null to get what `-k` has always meant here.
     pub fn handshake(
         self: *State,
         io: Io,
@@ -57,42 +79,44 @@ pub const State = struct {
         host: []const u8,
         insecure: bool,
         ca: ?*CaStore,
+        alpn: []const []const u8,
     ) HandshakeError!void {
-        self.sreader = stream.reader(io, &self.sock_read);
-        self.swriter = stream.writer(io, &self.sock_write);
-
-        var entropy: [tls.Client.Options.entropy_len]u8 = undefined;
-        io.random(&entropy);
-
-        const host_opt: @FieldType(tls.Client.Options, "host") =
-            if (insecure) .no_verification else .{ .explicit = host };
-        const ca_opt: @FieldType(tls.Client.Options, "ca") = if (insecure or ca == null)
-            .no_verification
+        _ = gpa;
+        // A bundle we own, never `.system_bundle`: see `CaStore`.
+        const verify: ztls.Verify = if (insecure or ca == null)
+            .insecure
         else
-            .{ .bundle = .{
-                .gpa = gpa,
-                .io = io,
-                .lock = &ca.?.lock,
-                .bundle = &ca.?.bundle,
-            } };
+            .{ .bundle = &ca.?.bundle };
 
-        self.client = try tls.Client.init(&self.sreader.interface, &self.swriter.interface, .{
-            .host = host_opt,
-            .ca = ca_opt,
-            .read_buffer = &self.app_read,
-            .write_buffer = &self.app_write,
-            .entropy = &entropy,
-            .realtime_now = Io.Timestamp.now(io, .real),
-            // Safe for HTTP: responses are framed by Content-Length / chunked.
-            .allow_truncation_attacks = true,
+        try self.client.connect(io, stream, .{
+            .host = if (insecure) null else host,
+            .verify = verify,
+            .alpn = alpn,
         });
     }
 
+    /// The protocol ALPN settled on, or null if the peer selected none.
+    ///
+    /// Checked by the caller rather than asserted here: a server that ignores
+    /// the offer and answers HTTP/1.1 to an `h2` request is a real thing to
+    /// meet, and a load generator should report it rather than crash on it.
+    pub fn negotiatedAlpn(self: *State) ?[]const u8 {
+        return self.client.info().alpn;
+    }
+
     pub fn reader(self: *State) *Io.Reader {
-        return &self.client.reader;
+        return self.client.reader();
     }
 
     pub fn writer(self: *State) *Io.Writer {
-        return &self.client.writer;
+        return self.client.writer();
     }
 };
+
+/// What to offer for each protocol, in preference order.
+///
+/// `http/1.1` is offered alongside `h2` so that a server without HTTP/2 answers
+/// on the protocol it does have instead of failing the handshake — the caller
+/// then sees the mismatch through `negotiatedAlpn` and can report it.
+pub const alpn_http1: []const []const u8 = &.{"http/1.1"};
+pub const alpn_http2: []const []const u8 = &.{ "h2", "http/1.1" };


### PR DESCRIPTION
Closes the TLS half of #21. `--http2 https://…` now offers `h2, http/1.1` and
**refuses the connection if the peer declines h2**, instead of pushing an HTTP/2
preface into an HTTP/1.1 connection and reporting the target as broken. The
`Http2RequiresCleartext` parse error existed only because `std.crypto.tls` has
no ALPN and the question was unanswerable; it is gone.

## libcrypto: not the way zoxy does it

zoxy resolves libcrypto through pkg-config, which only works when host ==
target. Its release workflow records the price:

> These used to cross-compile from a single Linux runner, which stopped working
> the moment zoxy gained a C dependency … it took the release from four
> platforms to one.

zrk links a **Zig-built BoringSSL as an artifact** instead, which keeps the
single-runner cross-compile. Proven for all four remaining targets on the
`ztls-probe` branch, aarch64 included — that branch is what this PR's approach
rests on and should be deleted once this merges.

Three things `build.zig` does explicitly that pkg-config would supply
invisibly: a library search path; an include path on **ztls's own module**
(include paths are per-module and the `@cImport` lives there); and linking `bcm`
alongside `crypto`, since modern BoringSSL splits the primitives into a second
archive — omitting it leaves 236 undefined `BN_*` symbols. Plus
`-Dcrypto-pkg-config=false`, without which the system OpenSSL's headers land
ahead of BoringSSL's and the C import dies on typedef collisions — a failure
that passes CI and breaks on a laptop.

## Four upstream fixes this required

zrk is the first `std.Io` consumer of `integrations/ztls-std`, and found it
unreachable (zoxy-io/ztls#2), unshipped (#3), colliding with system OpenSSL
(#4), and **not compiling at all** since `634567a` made P-256 keygen fallible
(#5).

Worth knowing separately: `zoxy-io/ztls` has had **zero workflow runs, ever** —
none on `zoxy-tls`, none on those four PRs. `ci.yml` triggers on
`push: branches: [main]` and `zoxy-tls` is not main. That is why a broken
integration sat there, and it means zrk is currently the only thing that builds
`ztls-std` anywhere.

## Verified / not verified

`zig build check` (new step: compiles without linking) passes locally. The
**link does not and cannot** here — BoringSSL's Zig package fetches nasm and GNU
patch from hosts outside GitHub, which this environment blocks. So this PR's CI
run is the first time this code has ever been linked or its tests run.

Note the release matrix is already four targets: Windows went in 5a36623,
because ztls is Linux and macOS by design.