### PR TITLE
ci: cross-compile every release target; curated release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,44 @@ jobs:
 
       - name: Test
         run: nix develop --command zig build test --summary all
+
+  # Every target the release ships, built the way the release builds them.
+  #
+  # `build-test` above compiles for the host only. That was harmless while zrk
+  # was pure Zig and cross-compiled to anything for free; it stopped being
+  # harmless the moment TLS brought in libcrypto, because a C dependency is
+  # exactly what breaks a cross-compile and nothing here would notice until a
+  # tag was pushed.
+  #
+  # zoxy learned this the expensive way — its release workflow records that
+  # gaining a C dependency "took the release from four platforms to one", found
+  # on the 0.2.0 tag. This job is that lesson, paid for in CI minutes instead of
+  # a broken release.
+  cross:
+    name: cross ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      # Every target reports. "At least one broke" is not the useful answer;
+      # "which ones" is.
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-linux-musl
+          - aarch64-linux-musl
+          - x86_64-macos
+          - aarch64-macos
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      # ReleaseFast, matching release.yml: a debug cross-compile would not
+      # exercise the same code generation, and it is the release this is
+      # standing in for.
+      - name: Cross-compile
+        run: |
+          nix develop --command zig build \
+            -Dtarget=${{ matrix.target }} -Doptimize=ReleaseFast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,34 @@ jobs:
           ( cd dist && sha256sum * > SHA256SUMS.txt )
           ls -la dist
 
+      # Curated notes when `docs/releases/<tag>.md` exists, generated otherwise.
+      #
+      # Generated notes are a commit list. That is the right answer for a patch
+      # release and the wrong one for a release that takes something away: a
+      # Windows user reading "release: drop the Windows targets" learns what
+      # happened but not why, whether it is coming back, or what to do instead.
+      - name: Select release notes
+        id: notes
+        run: |
+          set -euo pipefail
+          path="docs/releases/${{ steps.ver.outputs.tag }}.md"
+          if [ -f "$path" ]; then
+            echo "path=$path" >> "$GITHUB_OUTPUT"
+            echo "generate=false" >> "$GITHUB_OUTPUT"
+            echo "using curated notes from $path"
+          else
+            echo "path=" >> "$GITHUB_OUTPUT"
+            echo "generate=true" >> "$GITHUB_OUTPUT"
+            echo "no $path; generating notes from commits"
+          fi
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           files: dist/*
-          generate_release_notes: true
+          body_path: ${{ steps.notes.outputs.path }}
+          generate_release_notes: ${{ steps.notes.outputs.generate }}
 
       - name: Update Homebrew formula
         env:

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,0 +1,61 @@
+zrk speaks HTTP/2.
+
+```sh
+zrk --http2 http://host/path      # h2c, prior knowledge
+zrk --http2 https://host/path     # ALPN; fails if the server declines h2
+```
+
+One request is in flight per connection, exactly as over HTTP/1.1. `-c`, the
+pacing, the coordinated-omission correction, the deadline shedding and every
+latency number keep the meaning they had — only the wire format changed. That is
+deliberate, and multiplexing is tracked separately in #50 because it is a
+measurement question before it is a code change.
+
+## Breaking: no more Windows binaries
+
+**If you run zrk on Windows, this release does not include a binary for you, and
+v1.4.3 remains the last one that does.**
+
+HTTP/2 over TLS is selected by ALPN, which `std.crypto.tls` does not implement,
+so `--http2` could only ever have worked over cleartext. Getting it required a
+TLS stack that does — [ztls](https://github.com/zoxy-io/ztls) — and ztls is
+Linux and macOS by design: its entropy shim is a compile error anywhere else.
+
+This cost a working platform. Windows binaries did HTTP/1.1 over TLS perfectly
+well, and they were traded for HTTP/2 over TLS on the others. The alternative —
+keeping Windows on the old TLS stack behind a compile-time seam — was considered
+and not taken, in favour of one code path everywhere.
+
+Releases now ship four archives: x86_64 and aarch64, Linux and macOS.
+
+## Breaking: different TLS
+
+`https://` benchmarks now run on ztls with a Zig-built BoringSSL, not on
+`std.crypto.tls`. Same protocol, different implementation — if you compare
+numbers across this boundary, compare them knowing that.
+
+zrk also links C for the first time. It is still a single static binary and
+still cross-compiles to every target from one machine.
+
+## Also in this release
+
+- `--http2` (`--h2c`), documented in `--help` and the README, which are now
+  checked against each other by a test rather than kept in step by hand.
+- The HTTP/2 codec is its own package,
+  [zoxy-io/h2](https://github.com/zoxy-io/h2) — RFC 9113 framing, RFC 7541
+  HPACK, and the RFC 9113 §8.2/§8.3 field rules, with no allocator in its
+  public API. It is shared with [zoxy](https://github.com/zoxy-io/zoxy).
+- The request block is HPACK-encoded once at startup and replayed
+  byte-identically on every stream, so a fixed request costs no per-request
+  compression work.
+- `SETTINGS_HEADER_TABLE_SIZE = 0` is advertised, which forbids the peer the
+  dynamic table and keeps response decoding stateless — HPACK makes header
+  decoding mandatory where HTTP/1.1 was a scan for CRLF, and this keeps that off
+  the hot path.
+- CI now cross-compiles every release target on every change, so a dependency
+  that breaks one is caught before a tag rather than by it.
+
+## Upgrading
+
+Nothing changes for existing HTTP/1.1 invocations except the TLS implementation
+under `https://`. `--http2` is opt-in.

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -34,8 +34,9 @@ Releases now ship four archives: x86_64 and aarch64, Linux and macOS.
 `std.crypto.tls`. Same protocol, different implementation — if you compare
 numbers across this boundary, compare them knowing that.
 
-zrk also links C for the first time. It is still a single static binary and
-still cross-compiles to every target from one machine.
+zrk also links C for the first time. BoringSSL is built by Zig and linked in
+statically, so the binaries still have nothing to install alongside them, and
+every target is still cross-compiled from one machine.
 
 ## Also in this release
 


### PR DESCRIPTION
`build-test` builds for the **host only**. Harmless while zrk was pure Zig;
not harmless since f7270da, when TLS brought in libcrypto — a C dependency is
precisely what breaks a cross-compile, and nothing in CI would notice until a
tag was pushed.

zoxy already paid for this. Its release workflow records that gaining a C
dependency *"took the release from four platforms to one"*, found on the 0.2.0
tag — a release that existed to fix a macOS hang and shipped without macOS.

zrk is one `git tag` away from the same position: same new C dependency, same
host-only CI, and 2.0.0 about to be cut. This is that lesson paid for in CI
minutes instead of a broken release.

Four targets, `fail-fast: false` so the answer is *which* broke rather than
*that* one did, and ReleaseFast to match `release.yml`.

Each job builds BoringSSL from source; they run in parallel, so it costs
wall-clock minutes rather than a multiple of them. **This PR's own run is the
first time zrk has ever been cross-compiled with ztls** — the `ztls-probe`
branch proved a standalone program could be, not zrk.

---

Also carries the release notes for 2.0.0, since they are the other half of
cutting it safely.

`generate_release_notes: true` produces a commit list. That is the right answer
for a patch release and the wrong one for a release that takes something away:
a Windows user reading *"release: drop the Windows targets"* learns what
happened, but not why, whether it is coming back, or what to do instead.

`release.yml` now uses `docs/releases/<tag>.md` as the release body when that
file exists, and generates notes as before when it does not — so a patch
release needs no ceremony, and a release with consequences can have them
spelled out. `docs/releases/v2.0.0.md` leads with the dropped platform rather
than the new feature.