### PR TITLE
deps: swap BoringSSL for the shared OpenSSL fork

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,47 +31,52 @@ pub fn build(b: *std.Build) void {
 
     // TLS, and the libcrypto under it.
     //
-    // The three lines below are what the `ztls-probe` branch cost six CI runs
-    // to establish, and none of them is obvious. On a native build pkg-config
-    // supplies all three invisibly through `linkSystemLibrary("crypto")`; a
+    // On a native build pkg-config supplies the search path, the include path
+    // and the archive invisibly through `linkSystemLibrary("crypto")`. A
     // cross-build has no pkg-config, so each becomes explicit:
     //
-    //   1. a library search path, so ztls's `linkSystemLibrary` finds the
-    //      archive at all;
+    //   1. a library search path, so ztls's `linkSystemLibrary("crypto")`
+    //      finds an archive by that name at all — see the alias below;
     //   2. an include path on **ztls's own module**, because include paths are
-    //      per-module and the `@cImport` of `openssl/base.h` lives there, not
-    //      here;
-    //   3. `bcm` as well as `crypto` — modern BoringSSL splits the primitives
-    //      into a second archive that declares no dependency on the first, and
-    //      omitting it leaves 236 undefined `BN_*` symbols.
-    const boringssl = b.dependency("boringssl", .{
+    //      per-module and the `@cImport` of `openssl/crypto.h` lives there,
+    //      not here. `linkLibrary` carries the package's installed headers, so
+    //      linking the artifact into that module covers both.
+    const openssl = b.dependency("openssl", .{
         .target = target,
         .optimize = optimize,
     });
+    const libcrypto = openssl.artifact("openssl");
+
+    // ztls asks the linker for `-lcrypto` by name, and this package emits
+    // `libopenssl.a`. Linking the artifact resolves every symbol, but the
+    // linker still has to *find* a file called `libcrypto.a` or it fails
+    // before it gets that far — so publish one under that name and point the
+    // search path at it. A copy, not a rename of the artifact, because the
+    // artifact's name is the package's API and other consumers use it.
+    const crypto_alias = b.addWriteFiles();
+    _ = crypto_alias.addCopyFile(libcrypto.getEmittedBin(), "libcrypto.a");
+    const crypto_alias_dir = crypto_alias.getDirectory();
+
     const ztls_dep = b.dependency("ztls", .{
         .target = target,
         .optimize = optimize,
-        .@"crypto-backend" = @as([]const u8, "boringssl"),
         // We supply libcrypto, so pkg-config must not. Left on, it injects the
-        // system OpenSSL's include path ahead of BoringSSL's, `openssl/base.h`
-        // resolves to one and its neighbours to the other, and the C import
-        // dies on typedef collisions — but only on machines where pkg-config
-        // knows about OpenSSL, so it passes CI and breaks on a laptop.
+        // system OpenSSL's include path ahead of ours, and the C import dies
+        // on typedef collisions — but only on machines where pkg-config knows
+        // about OpenSSL, so it passes CI and breaks on a laptop.
         .@"crypto-pkg-config" = false,
     });
     const ztls_core = ztls_dep.module("ztls");
-    ztls_core.addIncludePath(boringssl.namedLazyPath("ssl_include"));
+    ztls_core.linkLibrary(libcrypto);
     const ztls_std = ztls_dep.module("ztls_std");
 
-    // Every artifact that reaches `src/tls.zig` needs both archives and the
+    // Every artifact that reaches `src/tls.zig` needs the archive and the
     // search path; they always travel together, so they are set in one place
     // rather than repeated per artifact.
     const linkCrypto = struct {
-        fn apply(module: *std.Build.Module, bssl: *std.Build.Dependency) void {
-            const crypto = bssl.artifact("crypto");
-            module.addLibraryPath(crypto.getEmittedBinDirectory());
-            module.linkLibrary(crypto);
-            module.linkLibrary(bssl.artifact("bcm"));
+        fn apply(module: *std.Build.Module, lib: *std.Build.Step.Compile, alias_dir: std.Build.LazyPath) void {
+            module.addLibraryPath(alias_dir);
+            module.linkLibrary(lib);
             module.link_libc = true;
         }
     }.apply;
@@ -87,7 +92,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "ztls_std", .module = ztls_std },
         },
     });
-    linkCrypto(mod, boringssl);
+    linkCrypto(mod, libcrypto, crypto_alias_dir);
     // `cli.zig` checks the README's usage block against the real help text.
     // `@embedFile` cannot escape the module root, so the file arrives as a named
     // import instead.
@@ -125,7 +130,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    linkCrypto(exe.root_module, boringssl);
+    linkCrypto(exe.root_module, libcrypto, crypto_alias_dir);
     exe.root_module.addAnonymousImport("readme", .{ .root_source_file = b.path("README.md") });
     b.installArtifact(exe);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,12 +46,23 @@
         // normally satisfy — but pkg-config only works when the host is the
         // target, which is why zoxy builds natively on one runner per target
         // and lost cross-compilation when it gained this dependency. A Zig-built
-        // BoringSSL linked as an artifact keeps zrk's single-runner
-        // cross-compile: proven for all four remaining targets on the
-        // `ztls-probe` branch, aarch64 included.
-        .boringssl = .{
-            .url = "git+https://github.com/allyourcodebase/boringssl#ec7cca75cbf5381ba4a9e111d1f12236f8f2bd6a",
-            .hash = "boringssl-0.20260526.0-EhtkNaI5AAAUWRtpFwiFhqdvxjAMMWkcx-iHkKIppGBV",
+        // libcrypto linked as an artifact keeps zrk's single-runner
+        // cross-compile.
+        //
+        // OpenSSL rather than BoringSSL, and the same pin zoxy uses, so the two
+        // programs terminate and originate TLS on the same primitives. The
+        // BoringSSL family has no `CRYPTO_set_mem_functions`, which zoxy's fixed
+        // libcrypto heap cannot start without — so a shared pin had to be this
+        // one. zrk itself does not install allocation hooks; it changes here to
+        // stop the two from drifting.
+        //
+        // The fork carries allyourcodebase/openssl#5 (pre-generated perlasm for
+        // aarch64, which upstream has only for x86_64) on top of a 3.5.7 bump:
+        // the LTS line, supported to 2030. Verified building for all four
+        // release targets.
+        .openssl = .{
+            .url = "git+https://github.com/zoxy-io/openssl?ref=openssl-3.5.7#546ec9845fa43013021609a8590e03678cc0fb20",
+            .hash = "openssl-3.5.7-TC9C3eDHfwHNGqKQk63LrMZg6g-YSvctDN8wNP1uktMX",
         },
         // TLS 1.3, for ALPN and therefore for HTTP/2 over TLS (#21).
         //


### PR DESCRIPTION
zrk and zoxy both reach TLS through ztls, and until now did it on different
primitives: zrk on a Zig-built BoringSSL, zoxy on whatever libcrypto the build
machine's nix store happened to hold. One pin now serves both.

**It had to be OpenSSL, and not for zrk's sake.** The BoringSSL family has no
`CRYPTO_set_mem_functions`, so zoxy's fixed libcrypto heap cannot install and
its `main.zig` refuses to start rather than run without its zero-allocation
budget. BoringSSL works fine here — zrk installs no allocation hooks — so this
change buys zrk nothing except not being the odd one out. That is the entire
point: two programs, one libcrypto, one set of CVEs to track, one thing to
audit.

The fork is [zoxy-io/openssl](https://github.com/zoxy-io/openssl), carrying
[allyourcodebase/openssl#5](https://github.com/allyourcodebase/openssl/pull/5)
— pre-generated perlasm for aarch64, which upstream has only for x86_64 — on
top of a bump from 3.3.2 (September 2024) to **3.5.7**, the LTS line supported
to April 2030.

### The wiring gets simpler

BoringSSL needed two archives: it splits the primitives into a `bcm` that
declares no dependency on `crypto`, and omitting it left 236 undefined `BN_*`
symbols. OpenSSL is one archive. The explicit include path on ztls's module is
gone as well — the package installs its headers, so `linkLibrary` carries them.

What remains is one wart, commented in place: ztls asks the linker for
`-lcrypto` **by name**, and this package emits `libopenssl.a`. Linking the
artifact resolves every symbol, but the linker has to *find* a file of that
name before it gets that far, so a copy is published under it. A copy rather
than renaming the artifact, because the artifact's name is the package's API.

### Verified locally — which was not previously possible

BoringSSL could never fetch in my sandbox (blocked to nasm.us and
mirrors.kernel.org), so every crypto change until now was validated only by
pushing to CI. This one was checked before pushing:

- `zig build test` green
- `zrk --version` runs
- all four release targets cross-compile: x86_64 and aarch64, Linux and macOS

### Companion change

zoxy's side is the one with teeth: there `linkSystemLibrary("crypto")` was the
single line behind its native-only release matrix, its missing `x86_64-macos`
platform, and its `pkgsStatic.openssl` + `PKG_CONFIG_PATH` dance. Its
`tls-heap-proof` passes on the new pin — a real handshake running entirely on
the fixed heap — along with `zig build ci` (4096 simulation seeds) and an
`otool -L` showing libSystem and nothing else.