### PR TITLE
build: stop UBSan-trapping the vendored libcrypto

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,26 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     const libcrypto = openssl.artifact("openssl");
+    // Zig's C sanitizers off for the vendored C, in every mode. `sanitize_c`
+    // defaults to `.full` in Debug and `.trap` in ReleaseSafe, and only the
+    // `.full` arm passes `-fno-sanitize=function` (Zig's src/Compilation.zig),
+    // whose comment there calls the pattern it flags "very common, and
+    // well-defined"; `lib/zig/ubsan_rt.zig` leaves the matching handler
+    // commented out for the same reason. So the one check Zig deliberately
+    // disables is armed only in ReleaseSafe, as a `ud1` trap, and
+    // `OPENSSL_sk_pop_free` calling its `free_func` through a cast pointer is
+    // the first one a TLS run reaches — 12039 traps in the binary, 2401 of
+    // them that check, and `-Doptimize=ReleaseSafe` dies in
+    // `privateKeyFromSecret` generating the client's ephemeral key before a
+    // single request goes out.
+    //
+    // Preventive rather than a bug fix: every build this project ships is
+    // ReleaseFast (ci.yml, release.yml), where `sanitize_c` is already `.off`,
+    // and nothing in CI builds ReleaseSafe to notice otherwise. Not
+    // theoretical, though — this line missing is what shipped zoxy v0.6.0 with
+    // TLS that could not start (zoxy-io/zoxy#283). Set explicitly so the
+    // answer is a decision here rather than a consequence of an optimize flag.
+    libcrypto.root_module.sanitize_c = .off;
 
     // ztls asks the linker for `-lcrypto` by name, and this package emits
     // `libopenssl.a`. Linking the artifact resolves every symbol, but the


### PR DESCRIPTION
Preventive. **Nothing zrk ships is affected** — `ci.yml` and `release.yml` both build ReleaseFast, where `sanitize_c` is already `.off`, and zoxy pins this package at ReleaseFast too. Which is also why no gate here would have caught it.

## The defect

`sanitize_c` is `.full` in Debug and `.trap` in ReleaseSafe. Both emit `-fsanitize=undefined`, but only the `.full` arm goes on to pass `-fno-sanitize=function` (Zig's `src/Compilation.zig`), whose comment there explains that a pointer with a different-but-compatible element type across a C ABI is "very common, and well-defined" — and `lib/zig/ubsan_rt.zig` leaves the matching handler commented out for the same reason.

So the one check Zig deliberately disables is armed **only** in ReleaseSafe, and OpenSSL's `OPENSSL_sk_pop_free` calling its `free_func` through a cast pointer trips it the first time anything fetches an EVP algorithm.

## Measured, not theoretical

`zig build -Doptimize=ReleaseSafe` today produces a zrk with **12039 trap sites**, 2401 of them that check, and it dies on the first https request:

```
Illegal instruction
  crypto/stack/stack.c:440         OPENSSL_sk_pop_free
  ...
  crypto/evp/p_lib.c:539           EVP_PKEY_new_raw_private_key
  ztls/src/crypto/backend_openssl.zig:199  privateKeyFromSecret
```

That is the client's ephemeral key being generated, before a byte goes out. With this line: zero traps, and the same run completes 60 requests over TLS.

This is the same line whose absence shipped zoxy v0.6.0 with TLS that could not start (zoxy-io/zoxy#283, fixed in zoxy v0.6.1). Setting it explicitly makes the answer a decision here rather than a consequence of whichever optimize flag a build happens to use.

## Gates

`zig build` and `zig build test` green — 14/14 steps, 227/227 tests.

Unrelated observation while here: `src/bench.zig` and `src/tui.zig` are unformatted on `main` (`zig fmt --check` flags both). CI runs `zig build` and `zig build test` but no format gate. Left alone — not this PR's business.

🤖 Generated with [Claude Code](https://claude.com/claude-code)