### PR TITLE
ci: run `zig fmt --check`, and format the two files that had drifted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
           extra_nix_config: |
             experimental-features = nix-command flakes
 
+      # Before Build, because it is the cheapest gate here and a formatting
+      # failure should not cost a compile to discover. Nothing enforced this
+      # until now, and two files had drifted unnoticed.
+      - name: Check formatting
+        run: nix develop --command zig fmt --check build.zig build.zig.zon src
+
       - name: Build
         run: nix develop --command zig build
 

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -77,7 +77,6 @@ pub fn main() !void {
     }
     const span = if (hi >= lo) hi - lo + 1 else 0;
 
-    
     print("histogram: counts_len={d}  ({d:.1} KiB)\n", .{ counts_len, @as(f64, @floatFromInt(bytes)) / 1024.0 });
     print("recorded:  n=200000  min={d}us max={d}us\n", .{ src.min_value, src.max_value });
     print("touched:   [{d}..{d}]  span={d}  ({d:.1}% of array)\n\n", .{

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -210,10 +210,10 @@ pub const Dashboard = struct {
             self.prev_lines = try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, false);
         } else {
             try w.print("[{d:6.1}s] {d:8.0} req/s {f}/s  p50={f} p99={f} p99.9={f} max={f}  errs={d}\n", .{
-                elapsed_s,                             rate,
-                Bytes.of(bps),                         Dur.of(snap.hist.valueAtPercentile(50)),
+                elapsed_s,                               rate,
+                Bytes.of(bps),                           Dur.of(snap.hist.valueAtPercentile(50)),
                 Dur.of(snap.hist.valueAtPercentile(99)), Dur.of(snap.hist.valueAtPercentile(99.9)),
-                Dur.of(snap.hist.max()),               snap.counters.socketErrors() + snap.counters.status_errors + snap.counters.deadline_errors,
+                Dur.of(snap.hist.max()),                 snap.counters.socketErrors() + snap.counters.status_errors + snap.counters.deadline_errors,
             });
         }
         try self.fw.interface.flush();


### PR DESCRIPTION
Nothing enforced formatting in this repo, so it drifted. `zig fmt --check` fails on `main` today:

- `src/bench.zig` — a blank line of trailing whitespace
- `src/tui.zig` — a multiline struct literal whose columns no longer align

Both are pure whitespace: **3 insertions, 4 deletions, no semantic change.** Which is exactly why they survived — nothing looks wrong until `zig fmt --check` is asked, and nothing asked.

## The gate

Added to the existing `build-test` matrix job, before `Build`, because it is the cheapest check in the file and a formatting failure should not cost a compile to discover. Targets are `build.zig build.zig.zon src` — the whole of what this package formats.

Found while fixing the libcrypto sanitizer flag (#55), where `zig fmt --check` got run out of habit and turned out to fail on `main`. Kept out of that PR so a build fix would not carry an unrelated whitespace diff.

## Gates

`zig fmt --check build.zig build.zig.zon src` clean, `zig build test` green (14/14 steps, 227/227 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)