### PR TITLE
tui: present each panel repaint as one synchronized frame

### DIFF
--- a/src/tui.zig
+++ b/src/tui.zig
@@ -79,6 +79,16 @@ const Colors = struct {
     }
 };
 
+/// DEC private mode 2026 — synchronized output. Between these two the
+/// terminal holds its display still and presents the result as one finished
+/// frame, so a repaint is never caught mid-erase: without them `\x1b[J` blanks
+/// the panel and the next ~1KB-15KB of cells fill it back in wherever the
+/// terminal happens to draw, which at the 80ms default refresh is a visible
+/// flicker on every frame. Terminals that don't implement it ignore both as
+/// unknown private modes, so there is nothing to detect and no fallback.
+const sync_begin = "\x1b[?2026h";
+const sync_end = "\x1b[?2026l";
+
 pub const Dashboard = struct {
     io: Io,
     cfg: *const cli.Config,
@@ -206,8 +216,7 @@ pub const Dashboard = struct {
             // that rewraps old lines can leave artifacts for one frame; the
             // next repaint absorbs them.)
             self.term_cols = termWidth(self.file);
-            if (self.prev_lines > 0) try w.print("\r\x1b[{d}A\x1b[J", .{self.prev_lines});
-            self.prev_lines = try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, false);
+            try self.repaint(w, snap, rate, bps, elapsed_s, total_s, false);
         } else {
             try w.print("[{d:6.1}s] {d:8.0} req/s {f}/s  p50={f} p99={f} p99.9={f} max={f}  errs={d}\n", .{
                 elapsed_s,                               rate,
@@ -217,6 +226,37 @@ pub const Dashboard = struct {
             });
         }
         try self.fw.interface.flush();
+    }
+
+    /// Erase the previous frame and draw a new one inside a single synchronized
+    /// update, recording the new height for the next repaint. Shared by the live
+    /// frame and the settled final panel so the two can't drift — and so the
+    /// invariant that every `sync_begin` is matched lives in exactly one place.
+    ///
+    /// `term_cols` is the caller's to refresh: both call sites re-read it from
+    /// the terminal first, which leaves tests free to pin a width.
+    fn repaint(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, rate: f64, bps: f64, elapsed_s: f64, total_s: f64, finished: bool) !void {
+        try w.writeAll(sync_begin);
+        // A frame that dies between the two sequences leaves the terminal
+        // holding its display with nothing left to release it — that reads as a
+        // hung program rather than a failed paint, and no later frame reopens it
+        // because a failed dashboard is not called again. Closing has to reach
+        // the terminal, not just the buffer: a colored panel outruns the 8KiB
+        // buffer, so `sync_begin` may already have gone out on an auto-flush.
+        // Best-effort by construction — whatever broke the frame most likely
+        // breaks these too, and there is no better move left either way.
+        errdefer closeSync(w);
+        if (self.prev_lines > 0) try w.print("\r\x1b[{d}A\x1b[J", .{self.prev_lines});
+        self.prev_lines = try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, finished);
+        try w.writeAll(sync_end);
+    }
+
+    /// Release a synchronized update that a failed frame left open (see
+    /// `repaint`). Silent: the caller is already unwinding an error worth more
+    /// than anything these two writes could report.
+    fn closeSync(w: *Io.Writer) void {
+        w.writeAll(sync_end) catch {};
+        w.flush() catch {};
     }
 
     /// One status segment: a dim label and a (possibly colored) value.
@@ -626,8 +666,7 @@ pub const Dashboard = struct {
             const bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
             const total_s: f64 = @as(f64, @floatFromInt(self.cfg.duration_ns)) / std.time.ns_per_s;
             self.term_cols = termWidth(self.file);
-            if (self.prev_lines > 0) try w.print("\r\x1b[{d}A\x1b[J", .{self.prev_lines});
-            self.prev_lines = try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, true);
+            try self.repaint(w, snap, rate, bps, elapsed_s, total_s, true);
         } else {
             try self.writeFinalSummary(w, snap, elapsed_s);
         }
@@ -883,6 +922,60 @@ test "a requested stop shows on the panel without breaking its line accounting" 
     try testing.expect(std.mem.indexOf(u8, final_out.written(), "✕") != null);
     try testing.expect(std.mem.indexOf(u8, final_out.written(), "signal again") == null);
     try testing.expect(std.mem.indexOf(u8, final_out.written(), "stopped early") != null);
+}
+
+test "a live repaint is bracketed by exactly one synchronized update" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io_ = rt.io();
+
+    const cfg = cli.Config{ .url = try cli.parseUrl("http://127.0.0.1/") };
+    var dash_buf: [64]u8 = undefined;
+    var dash = Dashboard.init(io_, &cfg, .empty, &dash_buf);
+    dash.colors = .{}; // no SGR, so the only escapes left are the ones under test
+    dash.term_cols = 120;
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 100;
+    snap.counters.recordStatus(200);
+
+    var first = Io.Writer.Allocating.init(testing.allocator);
+    defer first.deinit();
+    try dash.repaint(&first.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    const f = first.written();
+
+    // The whole frame sits inside the update: opened before anything is drawn
+    // (the erase included — mid-erase is exactly the state being hidden) and
+    // closed only once the last cell is out.
+    try testing.expect(std.mem.startsWith(u8, f, sync_begin));
+    try testing.expect(std.mem.endsWith(u8, f, sync_end));
+    // Balanced, and nothing else escapes: an unmatched or duplicated open would
+    // leave the terminal holding its display, which looks like a hung run.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, f, sync_begin));
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, f, sync_end));
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, f, "\x1b"));
+    // The bracket carries no newlines, so `prev_lines` still counts panel rows
+    // and the next repaint moves up exactly as far as it did before.
+    try testing.expectEqual(std.mem.count(u8, f, "\n"), dash.prev_lines);
+
+    // The second frame erases the first from *inside* the update — the point of
+    // the bracket — and is still opened and closed exactly once.
+    var second = Io.Writer.Allocating.init(testing.allocator);
+    defer second.deinit();
+    const before = dash.prev_lines;
+    try dash.repaint(&second.writer, &snap, 100, 1000, 2.0, 30.0, false);
+    const g = second.written();
+
+    var cursor_up_buf: [16]u8 = undefined;
+    const cursor_up = try std.fmt.bufPrint(&cursor_up_buf, "\r\x1b[{d}A\x1b[J", .{before});
+    const up_at = std.mem.indexOf(u8, g, cursor_up) orelse return error.NoRepaintSeek;
+    try testing.expect(up_at > std.mem.indexOf(u8, g, sync_begin).?);
+    try testing.expect(up_at < std.mem.indexOf(u8, g, sync_end).?);
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, g, sync_begin));
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, g, sync_end));
+    try testing.expectEqual(std.mem.count(u8, g, "\n"), dash.prev_lines);
 }
 
 test "spectrogram renders a bimodal interval as two separated clusters" {


### PR DESCRIPTION
## What

Wrap the live panel's erase-and-redraw in DEC private mode 2026 (synchronized output), so each repaint is presented as one finished frame instead of an erase followed by a visibly filling panel.

## Why

`frame()` repaints by moving to the top of the panel and erasing below it, then drawing the whole thing again. Between those two there is a window on every frame where the terminal can present a blanked or half-filled panel. At the 80ms default `--refresh` that is a visible flicker, and it scales with the panel: a colored spectrogram cell costs ~17 bytes (SGR + glyph + reset), so a wide frame is up to ~15KB of cells landing wherever the terminal happens to draw them.

Mode 2026 tells the terminal to hold its display still until the closing sequence. Terminals that don't implement it ignore both as unknown private modes — so there is nothing to detect, no capability query, no fallback path, and no dependency.

This came out of a survey of Zig TUI libraries ([libvaxis](https://github.com/rockorager/libvaxis) et al.) as the one thing they do here that we didn't. The survey's other conclusion was that adopting one isn't worth it: the terminal mechanics are ~50 of `tui.zig`'s 795 implementation lines, and vaxis imports `zigimg` unconditionally, which would put an image-decoding library in a load generator's dependency graph.

## Notes for review

Three things worth a look:

- **Both call sites now go through a shared `repaint`.** `frame()` and `final()` each carried their own copy of the cursor-up-and-draw pair. The invariant that every open is matched belongs in one place, and the live frame and the settled final panel shouldn't be able to drift apart.
- **The erase is inside the bracket**, deliberately — mid-erase is exactly the state being hidden.
- **The `errdefer` is load-bearing.** A frame that dies between the two sequences leaves the terminal holding its display with nothing left to release it: it reads as a hung run rather than a failed paint, and no later frame reopens it, because `main.zig` stops calling a dashboard that failed once. It flushes as well as writes, because a colored panel outruns the 8KiB `dash_buf` — the opening sequence may already have gone out on an auto-flush, so closing has to reach the terminal too, not just the buffer.

`--plain`, a pipe, and `--output` are untouched: those paths emit no escape sequences at all, and the existing test asserting the redirectable report stays free of them still passes.

## Testing

`zig build test` — 121 pass (was 120), `zig fmt --check` clean.

The new test pins that a frame opens with the sequence, ends with its match, contains exactly one of each, and — with colors disabled — that those are the *only* two escapes in the output. It also checks the second frame's cursor-up lands between them, and that `prev_lines` still equals the newline count, so the bracket didn't disturb the line accounting the in-place repaint depends on.

Mutation-checked: deleting the closing `writeAll` makes it fail rather than pass silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)