### PR TITLE
deps: bump zio to 38206678

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .zio = .{
-            .url = "git+https://github.com/lalinsky/zio?ref=main#df666c286380bf513dfe843f65a8133207ad7373",
-            .hash = "zio-0.17.0-xHbVVJPWJwBY3c_AkOFjUCF_pTIMnMc7ia9ujTjAfsbk",
+            .url = "git+https://github.com/lalinsky/zio?ref=main#38206678edca2abf4e27ce18bb963bfa6f4297ab",
+            .hash = "zio-0.17.0-xHbVVK-DKABkbm_XZgK-21SgNvYr9U5zr1MgOw7Q6JtM",
         },
         .h2 = .{
             .url = "git+https://github.com/zoxy-io/h2#ce82b9a886435d8fdd53e1a8cfbe72ed918fb53e",


### PR DESCRIPTION
Moves the `zio` pin from `df666c28` (2026-08-21) to `38206678` (2026-08-25), 17 commits.

## Why

Most of those commits are `select`/`channel` protocol work the connection hot path never touches. The one that matters here is **#711**, which is a correctness fix for the per-connection watchdog added in #64.

Before #711, the cached awake snapshot refreshed at the top of `poll` — *before* the backend poll. After a poll that slept, everything running until the next one (completion callbacks, and the post-wake task batch) armed `.duration` timers from a snapshot as old as the sleep. The timer was backdated by the whole wait and fired on the next scan instead of at its deadline.

`watchConnection` arms exactly such a timer via `io.sleep`, so on the old pin an idle connection's watcher could wake early. The `deadline > now(io)` re-check kept that from aborting a live request — it never mis-fired a timeout — but it could re-arm in a spin until the snapshot refreshed.

Worth noting for anyone tracing latency numbers: this never affected zrk's *measurements*. `nowImpl` does a real clock read, not the cached snapshot, so only internally-armed timers were exposed.

## Not a perf change

Measured, in case anyone expects a speedup: against nginx (4 workers pinned to cores 0-3, generator `-t 4` on cores 4-7), medians of 4 reps with arm order rotated per rep.

| | c=256 | c=512 |
|---|---|---|
| this pin | 432,019 | 392,503 |
| old pin | 423,998 | 397,960 |
| | +1.9% | −1.4% |

Noise in both directions — as expected for select/channel work.

## Testing

- `zig build test` — 121 pass
- `zig fmt --check` clean, ReleaseFast builds
- closed-loop 525,848 rps at zero errors (c=256/t=4)
- paced `rate_ratio` 0.9977 at `-R 100000`, zero errors
- wire timeout still fires against a peer that accepts and never answers (`nc -k -l`, `-c 2 --timeout 300ms`): 7 timeout errors, correctly classified

## Note for review

The pin is a floating `ref=main` snapshot taken mid-week, so if you'd rather land this alongside whatever zio releases next, the only thing lost by waiting is the #711 spin on idle connections — which is a wasted-wakeup issue, not a correctness one for reported results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
