### PR TITLE
feat: make --timeseries consumable by a streaming plotter

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,10 @@ Reporting:
       --hdr         <FILE>  Also write the HdrHistogram percentile
                             distribution (.hgrm) to FILE
       --timeseries  <FILE>  Stream per-interval NDJSON (throughput +
-                            latency percentiles) to FILE
+                            latency percentiles) to FILE. "-" streams to
+                            stdout for piping into a live plotter; the
+                            dashboard is then suppressed and the final
+                            report goes to stderr unless -o is given
       --timeseries-histogram  Add each interval's full latency histogram
                             (HdrHistogram base64) to every --timeseries row
       --no-record-timeouts  Drop wire-timed-out requests from the latency
@@ -243,6 +246,10 @@ zrk -c50 -R1000 -d20s --format json -o result.json --hdr latency.hgrm \
 zrk -c50 -R1000 -d20s --format json -o result.json \
     --slo-p99 250ms --max-error-rate 1% http://127.0.0.1:8080/
 
+# Live terminal plot: stream the per-interval rows into jplot
+zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
+  | jplot achieved_rate+target_rate latency_us.p50+latency_us.p90+latency_us.p99 error_rate
+
 # Closed-loop: what's the real max throughput at 100 connections? No -R to
 # guess — achieved_rate finds its own ceiling instead of chasing one.
 zrk -c100 -d20s --closed http://127.0.0.1:8080/
@@ -302,17 +309,74 @@ and format-compatible with wrk2's `--latency` output.
 
 `--timeseries <file>` streams one NDJSON object per `--interval`, each carrying
 that window's offered `target_rate`, `achieved_rate`, request/error counts,
-transfer (`bytes`, `bytes_per_sec`), and a delta-histogram latency percentile
-set:
+transfer (`bytes`, `bytes_per_sec`), the backlog gauge, and a delta-histogram
+latency percentile set:
 
 ```
-{"t":1.006,"target_rate":480.0,"achieved_rate":476.2,"requests":476,"errors":0,"bytes":58852,"bytes_per_sec":58501.0,"latency_us":{"p50":245,"p90":669,"p99":1745,"p99_9":2401,"max":2401}}
+{"t":1.006,"target_rate":480.0,"achieved_rate":476.2,"requests":476,"errors":3,"error_rate":0.006263,"errors_by_kind":{"connect":0,"read":0,"write":0,"timeout":1,"deadline":2,"non_2xx_3xx":0},"bytes":58852,"bytes_per_sec":58501.0,"max_schedule_lag_us":18524,"latency_us":{"p50":245,"p90":669,"p99":1745,"p99_9":2401,"max":2401}}
 ```
 
 This is the artifact a **ramp** (`-R A:B`) exists to produce: a curve of latency
 against offered load, so you can find the rate at which the server's tail breaks
 down. (The final summary's aggregate percentiles blend the whole ramp together,
 so they're less useful for a ramp than the time series is.)
+
+Every count in a row is that **interval's** delta, so the rows sum to the run.
+`errors_by_kind` splits the `errors` scalar the same way the final summary's
+`errors` object does — worth plotting stacked, because a tail that broke into
+`deadline` misses and one that broke into `connect` failures are different
+findings that the single number cannot tell apart.
+
+`error_rate` is that window's failure fraction, computed exactly like the
+summary's top-level `error_rate` (and so directly comparable to it and to the
+`--max-error-rate` gate). Plot this rather than the raw `errors` count: it sits
+on a fixed 0..1 axis regardless of what `--interval` is set to, whereas the
+count silently rescales with the window. Over a single interval the two
+definitions coincide, so a one-window run's row reports the summary's number.
+
+`max_schedule_lag_us` is the one exception: it is the **cumulative** peak
+`now − scheduled` the fleet has reached *as of* that row, the same running gauge
+the summary reports, not the interval's own peak. It is aggregated by max rather
+than summed, so there is nothing to difference — an interval-local peak would
+mean resetting the gauge on the row cadence and costing the final report its
+true high-water mark. Read the series as a staircase: each riser marks the
+window in which the client fell further behind its schedule than it ever had
+before, which is what dates the onset of a backlog against the latency it
+explains.
+
+### Streaming to a live plotter
+
+`--timeseries -` sends the rows to **stdout** instead of a file, so they can be
+piped straight into a streaming plotter such as
+[jplot](https://github.com/rs/jplot), which reads newline-delimited JSON and
+addresses fields by dotted path:
+
+```sh
+zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
+  | jplot achieved_rate+target_rate \
+          latency_us.p50+latency_us.p90+latency_us.p99 \
+          error_rate
+```
+
+Each space-separated spec is its own graph, so keep `error_rate` off the
+throughput one — it is a 0..1 fraction, not a req/s figure. Do **not** prefix
+zrk's fields with jplot's `counter:`: that option exists to difference
+monotonic counters, and these rows are already per-interval deltas.
+
+
+Note there is no `jaggr` stage: aggregating raw samples into per-interval
+percentiles is what zrk already does in-process, with real HdrHistograms.
+
+Because stdout then belongs to the row stream, `--timeseries -` suppresses the
+live dashboard and sends the final report to `--output` if given, else to
+**stderr** — so the summary still lands in your terminal without corrupting the
+pipe.
+
+Pair it with `-o` when the report is machine-read: `--format json --timeseries -`
+puts the JSON summary on stderr *alongside* the human notices (an SLO breach, a
+sink warning), so a parser reading stderr whole can trip over the trailing line.
+`--format json -o result.json --timeseries -` keeps all three streams apart —
+rows on stdout, report in the file, notices on stderr.
 
 Add `--timeseries-histogram` to append each interval's **full** latency
 distribution as an HdrHistogram V2 base64 blob (`latency_histogram`) to every

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -116,6 +116,7 @@ pub const Config = struct {
     hdr_path: ?[]const u8 = null,
     /// If set, stream one NDJSON object per `--interval` with that window's
     /// throughput and latency percentiles (a time series, ideal for ramps).
+    /// `"-"` streams to stdout instead of a file — see `timeseriesOnStdout`.
     timeseries_path: ?[]const u8 = null,
     /// Augment each `--timeseries` row with that interval's full latency
     /// distribution as an HdrHistogram V2 base64 blob (lossless, mergeable).
@@ -132,6 +133,15 @@ pub const Config = struct {
     max_error_rate: ?f64 = null,
 
     url: Url = undefined,
+
+    /// True when `--timeseries -` handed stdout to the NDJSON stream, so it can
+    /// be piped straight into a live plotter. stdout then belongs to the rows:
+    /// the live dashboard is suppressed and the final report goes to `--output`
+    /// if set, else stderr — otherwise the two would interleave on one stream.
+    pub fn timeseriesOnStdout(self: *const Config) bool {
+        const path = self.timeseries_path orelse return false;
+        return std.mem.eql(u8, path, "-");
+    }
 };
 
 pub const ParseError = error{
@@ -218,7 +228,10 @@ pub const usage =
     \\      --hdr         <FILE>  Also write the HdrHistogram percentile
     \\                            distribution (.hgrm) to FILE
     \\      --timeseries  <FILE>  Stream per-interval NDJSON (throughput +
-    \\                            latency percentiles) to FILE
+    \\                            latency percentiles) to FILE. "-" streams to
+    \\                            stdout for piping into a live plotter; the
+    \\                            dashboard is then suppressed and the final
+    \\                            report goes to stderr unless -o is given
     \\      --timeseries-histogram  Add each interval's full latency histogram
     \\                            (HdrHistogram base64) to every --timeseries row
     \\      --no-record-timeouts  Drop wire-timed-out requests from the latency
@@ -778,6 +791,23 @@ test "rate parses scalar and ramp forms" {
     try testing.expectEqual(@as(u64, 100), attached.rate);
     try testing.expectEqual(@as(?u64, 5000), attached.rate_end);
     try testing.expectError(error.ZeroRate, parse(a, &[_][]const u8{ "-R", "100:0", "http://x/" }));
+}
+
+test "--timeseries - claims stdout for the row stream" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const stdout = (try parse(a, &[_][]const u8{ "--timeseries", "-", "http://x/" })).config;
+    try testing.expectEqualStrings("-", stdout.timeseries_path.?);
+    try testing.expect(stdout.timeseriesOnStdout());
+
+    const to_file = (try parse(a, &[_][]const u8{ "--timeseries", "run.ndjson", "http://x/" })).config;
+    try testing.expect(!to_file.timeseriesOnStdout());
+
+    // No --timeseries at all: stdout stays the report's.
+    const none = (try parse(a, &[_][]const u8{"http://x/"})).config;
+    try testing.expect(!none.timeseriesOnStdout());
 }
 
 test "the README's usage block is the real help text" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,23 +56,33 @@ pub fn main(init: std.process.Init) !void {
 
     // Optional per-interval NDJSON time series. The File.Writer is a pinned
     // local (TimeSeries only borrows a *Io.Writer) so nothing dangles on a move.
+    //
+    // `--timeseries -` streams the rows to stdout so they can be piped into a
+    // live plotter; stdout is then the series' and not the report's, so the
+    // dashboard is suppressed below and the summary goes elsewhere.
+    const ts_stdout = cfg.timeseriesOnStdout();
     var ts_buf: [4096]u8 = undefined;
     var ts_file: Io.File = undefined;
     var ts_fw: Io.File.Writer = undefined;
     var ts_obj: report.TimeSeries = undefined;
     var ts_ptr: ?*report.TimeSeries = null;
     if (cfg.timeseries_path) |path| {
-        ts_file = try Io.Dir.cwd().createFile(io, path, .{});
-        ts_fw = .init(ts_file, io, &ts_buf);
+        ts_file = if (ts_stdout) .stdout() else try Io.Dir.cwd().createFile(io, path, .{});
+        // A created file is ours from offset 0, so positional writes are fine.
+        // stdout is not: it is a shared stream whose offset other writers (and
+        // the shell's `>>`) advance, and pwriting it from 0 would overwrite
+        // whatever is already there -- see the note on `writeAll`.
+        ts_fw = if (ts_stdout) .initStreaming(ts_file, io, &ts_buf) else .init(ts_file, io, &ts_buf);
         ts_obj = try report.TimeSeries.init(arena, &ts_fw.interface, &cfg);
         ts_ptr = &ts_obj;
     }
     defer if (cfg.timeseries_path != null) {
         ts_obj.deinit();
-        ts_file.close(io);
+        // stdout is the process', not ours to close.
+        if (!ts_stdout) ts_file.close(io);
     };
 
-    var progress: Progress = .{ .io = io, .dash = if (json) null else &dash, .ts = ts_ptr };
+    var progress: Progress = .{ .io = io, .dash = if (json or ts_stdout) null else &dash, .ts = ts_ptr };
     const active = progress.dash != null or progress.ts != null;
     const ctx: ?*anyopaque = if (active) @ptrCast(&progress) else null;
     const cb: ?runner.ProgressFn = if (active) onProgress else null;
@@ -105,9 +115,13 @@ pub fn main(init: std.process.Init) !void {
     if (json) {
         try writeJsonReport(arena, io, &cfg, &snapshot, result.elapsed_s, result.launched, result.interrupted);
     } else if (cfg.output_path) |path| {
-        // Text report redirected to --output; leave a breadcrumb on stdout.
+        // Text report redirected to --output; leave a breadcrumb on stdout —
+        // unless the time series owns stdout, where a breadcrumb would land
+        // mid-stream as a line no NDJSON reader can parse.
         try writeTextReport(io, &dash, path, &snapshot, result.elapsed_s);
-        try dash.finalRedirected(path);
+        if (!ts_stdout) try dash.finalRedirected(path);
+    } else if (ts_stdout) {
+        try writeSummaryToStderr(io, &dash, &snapshot, result.elapsed_s);
     } else {
         try dash.final(&snapshot, result.elapsed_s);
     }
@@ -198,14 +212,36 @@ fn writeTextReport(io: Io, dash: *tui.Dashboard, path: []const u8, snap: *const 
     try fw.interface.flush();
 }
 
-/// Write the JSON summary to `--output` (or stdout when unset).
+/// Write the JSON summary to `--output` (or stdout when unset; stderr when
+/// `--timeseries -` has claimed stdout for the row stream).
 fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, elapsed_s: f64, launched: u32, interrupted: bool) !void {
     var close = false;
-    const file = try openOut(io, cfg.output_path, &close);
+    const fallback: Io.File = if (cfg.timeseriesOnStdout()) .stderr() else .stdout();
+    const file = try openOut(io, cfg.output_path, fallback, &close);
     defer if (close) file.close(io);
     var buf: [8192]u8 = undefined;
-    var fw: Io.File.Writer = .init(file, io, &buf);
+    // Only a freshly created --output file can be written positionally; the
+    // stdout/stderr fallback is a shared stream that earlier writes (an SLO
+    // breach notice, a sink warning) have already advanced, and pwriting it
+    // from byte 0 corrupts the summary rather than following them.
+    var fw: Io.File.Writer = if (cfg.output_path != null)
+        .init(file, io, &buf)
+    else
+        .initStreaming(file, io, &buf);
     try report.writeJson(gpa, &fw.interface, cfg, snap, elapsed_s, launched, interrupted);
+    try fw.interface.flush();
+}
+
+/// Write the compact text summary to stderr. Used when `--timeseries -` owns
+/// stdout and no `--output` was given: the run still has to report itself
+/// somewhere, and stderr is the stream a plotting pipe leaves free.
+fn writeSummaryToStderr(io: Io, dash: *tui.Dashboard, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+    var buf: [8192]u8 = undefined;
+    // Streaming, not positional: stderr is shared with the interrupt notice, the
+    // sink warnings and the SLO breach message, and a pwrite from byte 0 would
+    // interleave with them instead of following them (see `writeAll`).
+    var fw: Io.File.Writer = .initStreaming(.stderr(), io, &buf);
+    try dash.writeFinalSummary(&fw.interface, snap, elapsed_s);
     try fw.interface.flush();
 }
 
@@ -220,13 +256,13 @@ fn writeHdrFile(io: Io, path: []const u8, h: *const hdr.Histogram) !void {
     try fw.interface.flush();
 }
 
-fn openOut(io: Io, path: ?[]const u8, close: *bool) !Io.File {
+fn openOut(io: Io, path: ?[]const u8, fallback: Io.File, close: *bool) !Io.File {
     if (path) |p| {
         close.* = true;
         return Io.Dir.cwd().createFile(io, p, .{});
     }
     close.* = false;
-    return Io.File.stdout();
+    return fallback;
 }
 
 /// Upper bound on a request body read from a file/stdin, so a wrong path can't

--- a/src/report.zig
+++ b/src/report.zig
@@ -17,9 +17,18 @@ const connection = @import("connection.zig");
 /// overload the rate reflects the fraction of the offered schedule that could
 /// not be served within the deadline. 0 when idle.
 pub fn errorRate(c: connection.Counters) f64 {
-    const failures = c.socketErrors() + c.deadline_errors;
-    const errs = c.status_errors + failures;
-    const total = c.completed + failures;
+    return failureFraction(c.completed, c.status_errors, c.socketErrors() + c.deadline_errors);
+}
+
+/// The arithmetic behind both `errorRate` and the per-interval `error_rate` row
+/// field, factored out so the summary and the time series cannot drift apart.
+/// `failures` are the attempts that never produced a response (socket errors and
+/// deadline misses); each counts as an error *and* as an attempt, so a window
+/// spent shedding a backlog reports a rate near 1 rather than dividing by the
+/// handful of requests that got through.
+fn failureFraction(completed: u64, status_errs: u64, failures: u64) f64 {
+    const errs = status_errs + failures;
+    const total = completed + failures;
     if (total == 0) return 0;
     return @as(f64, @floatFromInt(errs)) / @as(f64, @floatFromInt(total));
 }
@@ -166,9 +175,10 @@ pub const TimeSeries = struct {
     /// transient encode buffers never accumulate in the caller's arena when
     /// `--timeseries-histogram` is on. Backed by the page allocator.
     scratch: std.heap.ArenaAllocator,
-    prev_completed: u64 = 0,
-    prev_bytes: u64 = 0,
-    prev_errors: u64 = 0,
+    /// Previous cumulative counters: every count in a row is `snap - prev`.
+    /// `max_behind_ns` is the exception — it is a running peak, not a tally,
+    /// so it is reported as-is rather than differenced (see `record`).
+    prev_counters: connection.Counters = .{},
     prev_elapsed_s: f64 = 0,
 
     pub fn init(arena: std.mem.Allocator, w: *Io.Writer, cfg: *const cli.Config) !TimeSeries {
@@ -205,25 +215,59 @@ pub const TimeSeries = struct {
         self.delta.setToDifference(&snap.hist, &self.prev_cum);
         const h = &self.delta;
 
+        const c = snap.counters;
+        const p = self.prev_counters;
         const interval_s = elapsed_s - self.prev_elapsed_s;
-        const d_completed = snap.counters.completed -| self.prev_completed;
-        const d_bytes = snap.counters.bytes -| self.prev_bytes;
-        const cur_errors = snap.counters.status_errors + snap.counters.socketErrors() + snap.counters.deadline_errors;
-        const d_errors = cur_errors -| self.prev_errors;
+        const d_completed = c.completed -| p.completed;
+        const d_bytes = c.bytes -| p.bytes;
+        // Per-kind, so a consumer can plot *how* a window failed — a tail that
+        // broke into deadline misses is a different story from one that broke
+        // into connect errors, and the scalar `errors` cannot tell them apart.
+        const d_connect = c.connect_errors -| p.connect_errors;
+        const d_read = c.read_errors -| p.read_errors;
+        const d_write = c.write_errors -| p.write_errors;
+        const d_timeout = c.timeouts -| p.timeouts;
+        const d_deadline = c.deadline_errors -| p.deadline_errors;
+        const d_status = c.status_errors -| p.status_errors;
+        const d_failures = d_connect + d_read + d_write + d_timeout + d_deadline;
+        const d_errors = d_failures + d_status;
         const achieved: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_completed)) / interval_s else 0;
         const bps: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_bytes)) / interval_s else 0;
 
+        // `error_rate` is this window's failure fraction, computed exactly like
+        // the summary's — so a row is directly comparable to the final number
+        // and to the `--max-error-rate` gate, and stays on one 0..1 axis no
+        // matter what `--interval` is set to (the raw `errors` count does not).
         try self.w.print(
-            "{{\"t\":{d:.3},\"target_rate\":{d:.1},\"achieved_rate\":{d:.1},\"requests\":{d},\"errors\":{d}," ++
-                "\"bytes\":{d},\"bytes_per_sec\":{d:.1}," ++
+            "{{\"t\":{d:.3},\"target_rate\":{d:.1},\"achieved_rate\":{d:.1},\"requests\":{d}," ++
+                "\"errors\":{d},\"error_rate\":{d:.6},",
+            .{
+                elapsed_s, if (self.cfg.closed) achieved else self.targetRate(elapsed_s),
+                achieved,  d_completed,
+                d_errors,  failureFraction(d_completed, d_status, d_failures),
+            },
+        );
+        try self.w.print(
+            "\"errors_by_kind\":{{\"connect\":{d},\"read\":{d},\"write\":{d}," ++
+                "\"timeout\":{d},\"deadline\":{d},\"non_2xx_3xx\":{d}}},",
+            .{ d_connect, d_read, d_write, d_timeout, d_deadline, d_status },
+        );
+        // The backlog gauge, in the row so it can be read against the same time
+        // axis as the latency it explains. Unlike every other count here it is
+        // *cumulative*: `max_behind_ns` is a running peak that is aggregated by
+        // max, not summed, so there is nothing to difference — an interval-local
+        // peak would need the connections to reset the gauge on the row cadence,
+        // which would cost the final report its true peak. Read the series as a
+        // staircase: each riser marks the window in which the fleet fell further
+        // behind its schedule than it ever had before.
+        try self.w.print(
+            "\"bytes\":{d},\"bytes_per_sec\":{d:.1},\"max_schedule_lag_us\":{d}," ++
                 "\"latency_us\":{{\"p50\":{d},\"p90\":{d},\"p99\":{d},\"p99_9\":{d},\"max\":{d}}}",
             .{
-                elapsed_s,                 if (self.cfg.closed) achieved else self.targetRate(elapsed_s),
-                achieved,                  d_completed,
-                d_errors,                  d_bytes,
-                bps,                       h.valueAtPercentile(50),
-                h.valueAtPercentile(90),   h.valueAtPercentile(99),
-                h.valueAtPercentile(99.9), h.max(),
+                d_bytes,                              bps,
+                c.max_behind_ns / std.time.ns_per_us, h.valueAtPercentile(50),
+                h.valueAtPercentile(90),              h.valueAtPercentile(99),
+                h.valueAtPercentile(99.9),            h.max(),
             },
         );
 
@@ -242,9 +286,7 @@ pub const TimeSeries = struct {
         try self.w.flush();
 
         snap.hist.copyInto(&self.prev_cum);
-        self.prev_completed = snap.counters.completed;
-        self.prev_bytes = snap.counters.bytes;
-        self.prev_errors = cur_errors;
+        self.prev_counters = c;
         self.prev_elapsed_s = elapsed_s;
     }
 };
@@ -395,6 +437,84 @@ test "time series row carries the interval HDR blob when enabled" {
     var decoded = try hdr.decodeBase64(testing.allocator, out[start..end]);
     defer decoded.deinit();
     try testing.expectEqual(@as(u64, 50), decoded.count());
+}
+
+test "time series rows break errors out by kind, as interval deltas" {
+    const cfg = testConfig();
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var ts = try TimeSeries.init(testing.allocator, &alloc.writer, &cfg);
+    defer ts.deinit();
+
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+
+    // First window: two deadline misses and a 500.
+    snap.hist.record(1000);
+    snap.counters.completed = 1;
+    snap.counters.recordStatus(500);
+    snap.counters.deadline_errors = 2;
+    snap.counters.max_behind_ns = 5_000; // 5ms peak so far
+    try ts.record(&snap, 1.0);
+
+    // Second window, against the same *cumulative* counters: one more deadline
+    // miss, one timeout, no new 500 — so the row must show 1/1/0, not 3/1/1.
+    snap.hist.record(2000);
+    snap.counters.completed = 2;
+    snap.counters.deadline_errors = 3;
+    snap.counters.timeouts = 1;
+    snap.counters.max_behind_ns = 40_000; // the peak stepped up to 40ms
+    try ts.record(&snap, 2.0);
+
+    var it = std.mem.splitScalar(u8, std.mem.trimEnd(u8, alloc.written(), "\n"), '\n');
+    const first = it.next().?;
+    const second = it.next().?;
+    try testing.expect(it.next() == null);
+
+    try testing.expect(std.mem.indexOf(u8, first, "\"errors\":3,") != null);
+    // 1 completed + 2 deadline misses = 3 attempts, all 3 outcomes errors
+    // (the 500 plus the two misses): the same arithmetic the summary uses.
+    try testing.expect(std.mem.indexOf(u8, first, "\"error_rate\":1.000000,") != null);
+    try testing.expect(std.mem.indexOf(u8, first, "\"deadline\":2,\"non_2xx_3xx\":1}") != null);
+    try testing.expect(std.mem.indexOf(u8, first, "\"max_schedule_lag_us\":5,") != null);
+
+    try testing.expect(std.mem.indexOf(u8, second, "\"errors\":2,") != null);
+    // Second window: 1 completed + 1 deadline + 1 timeout = 3 attempts, 2 errors.
+    try testing.expect(std.mem.indexOf(u8, second, "\"error_rate\":0.666667,") != null);
+    try testing.expect(std.mem.indexOf(u8, second, "\"timeout\":1,\"deadline\":1,\"non_2xx_3xx\":0}") != null);
+    try testing.expect(std.mem.indexOf(u8, second, "\"connect\":0,\"read\":0,\"write\":0,") != null);
+    // The lag gauge is a running peak, not a per-interval delta: it carries the
+    // new high water mark rather than the 35ms difference.
+    try testing.expect(std.mem.indexOf(u8, second, "\"max_schedule_lag_us\":40,") != null);
+}
+
+test "row error_rate agrees with the summary's over a single window" {
+    const cfg = testConfig();
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var ts = try TimeSeries.init(testing.allocator, &alloc.writer, &cfg);
+    defer ts.deinit();
+
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 97;
+    snap.counters.recordStatus(500); // one non-2xx/3xx
+    snap.counters.timeouts = 2;
+    snap.counters.deadline_errors = 1;
+
+    // Over one interval the row's delta *is* the cumulative total, so the row's
+    // rate must be the number the final summary would report.
+    try ts.record(&snap, 1.0);
+    var buf: [32]u8 = undefined;
+    const expected = try std.fmt.bufPrint(&buf, "\"error_rate\":{d:.6},", .{errorRate(snap.counters)});
+    try testing.expect(std.mem.indexOf(u8, alloc.written(), expected) != null);
 }
 
 test "time series omits the HDR blob by default" {

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -137,7 +137,10 @@ pub const Dashboard = struct {
     pub fn init(io: Io, cfg: *const cli.Config, environ: std.process.Environ, buffer: []u8) Dashboard {
         const file = Io.File.stdout();
         const is_tty = file.isTty(io) catch false;
-        const tui_on = is_tty and !cfg.plain;
+        // `--timeseries -` hands stdout to the NDJSON rows: the panel cannot own
+        // a terminal it is not the one writing to, and its colors would be ANSI
+        // noise in whatever the summary is redirected to.
+        const tui_on = is_tty and !cfg.plain and !cfg.timeseriesOnStdout();
         return .{
             .io = io,
             .cfg = cfg,


### PR DESCRIPTION
Makes the per-interval time series something an external plotter can consume
directly, so reporting stays outside the binary.

## `--timeseries -`

Streams the NDJSON rows to stdout instead of a file, so they pipe straight into
a plotter such as [jplot](https://github.com/rs/jplot), which reads
newline-delimited JSON and addresses fields by dotted path:

```sh
zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
  | jplot achieved_rate+target_rate \
          latency_us.p50+latency_us.p90+latency_us.p99 \
          error_rate
```

No `jaggr` stage: aggregating raw samples into per-interval percentiles is what
zrk already does in-process, with real HdrHistograms.

stdout then belongs to the row stream, so the dashboard is suppressed and the
final report goes to `--output` if set, else stderr. Without that, the plain
append-only lines interleave with the rows and the reader dies on the first one
— `[   0.5s]  100 req/s` decodes as an array, then fails on the `s`.

## New row fields

```json
{"t":1.006,...,"errors":3,"error_rate":0.006263,
 "errors_by_kind":{"connect":0,"read":0,"write":0,"timeout":1,"deadline":2,"non_2xx_3xx":0},
 ...,"max_schedule_lag_us":18524,"latency_us":{...}}
```

- **`errors_by_kind`** — splits the `errors` scalar the way the summary's
  `errors` object does. A tail that broke into deadline misses and one that
  broke into connect failures are different findings the single number can't
  tell apart.
- **`error_rate`** — the window's failure fraction, on a fixed 0..1 axis where
  the raw count silently rescales with `--interval`. Shares its arithmetic with
  the summary's `errorRate` (extracted into `failureFraction`) so the two can't
  drift; a test asserts a one-window run's row equals the summary's number.
- **`max_schedule_lag_us`** — deliberately *not* a delta. It's a running peak
  aggregated by max, not a tally, so there's nothing to difference; an
  interval-local peak would mean resetting the gauge on the row cadence and
  costing the final report its true peak. Reads as a staircase: each riser
  dates a window where the client fell further behind than it ever had.

## Writer modes (three bugs caught in review)

Every new writer onto a shared stream is now streaming rather than positional.
`.init` pwrites from byte 0 on each fresh Writer — right for a file we just
created, wrong for stdout/stderr where earlier writes advanced the offset. This
is the hazard already documented on `writeAll`. Positional writers produced:

| case | symptom |
|---|---|
| text summary + SLO breach, stderr → file | breach notice overwrote the middle of the report |
| `--format json --timeseries -`, stderr → file | **invalid JSON** |
| `--timeseries - >> file` | pre-existing file content **destroyed** from byte 0 |

The JSON case predates this branch (`--format json >>file` had the same flaw)
and is fixed too, by picking the mode from whether `--output` opened a file.

Also documented: pair `--format json --timeseries -` with `-o`, since otherwise
the JSON summary and the human notices share stderr.

## Testing

`zig build test` and `zig fmt --check` pass. All three writer bugs were
reproduced against a local server before the fix and re-verified after.
Regression-swept the untouched paths: `--plain`, json→stdout, json→`-o` +
`--hdr`, text→`-o` breadcrumb, `--timeseries`→file.

Not verified here: jplot's actual rendering — it refuses to draw when its
stdout isn't an image-capable terminal. The data contract is checked (every
field path in the documented command resolves on every emitted row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
