### PR TITLE
feat: add --disable-keepalive for one connection per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ Options:
                             No coordinated-omission correction; the rate
                             finds its own ceiling instead of chasing one.
                             Incompatible with a ramp (-R A:B) or --deadline
+      --disable-keepalive   Close and reconnect after every response: one
+                            connection per request, like ab. Enforced
+                            client-side, so it also covers servers that
+                            ignore the Connection: close it sends.
+                            Not available with --http2
   -H, --header  <K: V>      Add a request header (repeatable)
   -m, --method      <M>     HTTP method                    (default GET)
   -b, --body     <S|@FILE>  Request body; @FILE reads it from a file

--- a/docs/output.md
+++ b/docs/output.md
@@ -9,7 +9,7 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
 {
   "zrk_version": "0.1.0",
   "target": { "url": "http://127.0.0.1:8080/", "method": "GET" },
-  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "closed": false, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "deadline_abort": false, "record_timeouts": true },
+  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "closed": false, "disable_keepalive": false, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "deadline_abort": false, "record_timeouts": true },
   "duration_s": 20.002,
   "requests": 19998,
   "bytes": 1239876,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -54,6 +54,22 @@ pub const Config = struct {
     /// form and with `--deadline`, both of which presuppose an offered
     /// schedule to fall behind.
     closed: bool = false,
+    /// Close the connection after every response and reconnect for the next
+    /// request (`--disable-keepalive`): one TCP connection per request, like
+    /// `ab` or oha's flag of the same name.
+    ///
+    /// Enforced on our side, not negotiated. zrk normally reuses a connection
+    /// unless the *response* declines to (`Connection: close`, or a
+    /// close-delimited body), so `-H 'Connection: close'` alone reconnects
+    /// only against servers that honour it — and leaves the ones that ignore
+    /// it running at full keep-alive speed, which is the opposite of the
+    /// comparison this flag exists to make. Closing regardless means every
+    /// target pays the same per-request connection cost.
+    ///
+    /// The request advertises `Connection: close` too (unless `-H` already set
+    /// a `Connection` header), so a compliant server can release its end
+    /// promptly instead of holding an idle socket until its own timeout.
+    disable_keepalive: bool = false,
     /// Per-request wire timeout: bounds the attempt on the wire, measured from
     /// the actual send (catches a hung socket / dead server). Does *not* bound
     /// coordinated-omission latency under overload — see `deadline_ns`.
@@ -161,6 +177,7 @@ pub const ParseError = error{
     ZeroRefresh,
     ClosedWithRamp,
     ClosedWithDeadline,
+    KeepaliveWithHttp2,
     OutOfMemory,
 };
 
@@ -199,6 +216,11 @@ pub const usage =
     \\                            No coordinated-omission correction; the rate
     \\                            finds its own ceiling instead of chasing one.
     \\                            Incompatible with a ramp (-R A:B) or --deadline
+    \\      --disable-keepalive   Close and reconnect after every response: one
+    \\                            connection per request, like ab. Enforced
+    \\                            client-side, so it also covers servers that
+    \\                            ignore the Connection: close it sends.
+    \\                            Not available with --http2
     \\  -H, --header  <K: V>      Add a request header (repeatable)
     \\  -m, --method      <M>     HTTP method                    (default GET)
     \\  -b, --body     <S|@FILE>  Request body; @FILE reads it from a file
@@ -290,6 +312,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.plain = true;
         } else if (eq(arg, "--closed")) {
             cfg.closed = true;
+        } else if (eq(arg, "--disable-keepalive")) {
+            cfg.disable_keepalive = true;
         } else if (eq(arg, "--no-record-timeouts")) {
             cfg.record_timeouts = false;
         } else if (eq(arg, "--record-timeouts")) {
@@ -370,6 +394,11 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
     // behind for --deadline to measure against.
     if (cfg.closed and cfg.rate_end != null) return error.ClosedWithRamp;
     if (cfg.closed and cfg.deadline_ns != 0) return error.ClosedWithDeadline;
+    // HTTP/2 has no per-request connection to close. `Connection` is a
+    // malformed field in h2 (RFC 9113 section 8.2.2 — which is why
+    // `buildRequestBlock` omits it), and one stream per connection would
+    // measure the handshake rather than the protocol.
+    if (cfg.disable_keepalive and cfg.http2) return error.KeepaliveWithHttp2;
 
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
@@ -611,6 +640,29 @@ test "closed flag parses; rejects ramp and deadline" {
     // not rejected) since a scalar -R can't be told apart from the default.
     const with_rate = (try parse(a, &[_][]const u8{ "--closed", "-R", "5000", "http://x/" })).config;
     try testing.expect(with_rate.closed);
+}
+
+test "disable-keepalive flag parses; rejects --http2" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    // Off by default: keep-alive is HTTP/1.1's default and zrk's.
+    const default = (try parse(a, &[_][]const u8{"http://x/"})).config;
+    try testing.expect(!default.disable_keepalive);
+
+    const cfg = (try parse(a, &[_][]const u8{ "--disable-keepalive", "-c", "64", "http://x/" })).config;
+    try testing.expect(cfg.disable_keepalive);
+    try testing.expectEqual(@as(u32, 64), cfg.connections);
+
+    // Orthogonal to the pacing mode: closed-loop + a connection per request is
+    // exactly the ab/oha comparison the flag exists for.
+    const with_closed = (try parse(a, &[_][]const u8{ "--closed", "--disable-keepalive", "http://x/" })).config;
+    try testing.expect(with_closed.closed and with_closed.disable_keepalive);
+
+    // h2 has no per-request connection to close, in either flag order.
+    try testing.expectError(error.KeepaliveWithHttp2, parse(a, &[_][]const u8{ "--disable-keepalive", "--http2", "http://x/" }));
+    try testing.expectError(error.KeepaliveWithHttp2, parse(a, &[_][]const u8{ "--http2", "--disable-keepalive", "http://x/" }));
 }
 
 test "refresh flag parses and zero is rejected" {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -162,6 +162,11 @@ pub const Params = struct {
     /// times out on the wire, instead of dropping it (which would truncate the
     /// tail). Does not apply to `deadline` misses, which are never recorded.
     record_timeouts: bool = true,
+    /// Close the connection after every response and reconnect for the next
+    /// request (`--disable-keepalive`), regardless of what the response said
+    /// about reuse. See `cli.Config.disable_keepalive` for why the decision
+    /// cannot be left to the server.
+    disable_keepalive: bool = false,
     /// Monotonic timestamp at which the connection should stop sending.
     end: Io.Timestamp,
     /// Set to true (by the coordinator) to request an early graceful stop.
@@ -400,7 +405,15 @@ pub fn run(p: *Params) void {
                     // A timer may have fired in the same event batch as the
                     // response; the response still counts, but the socket is
                     // shut down so the connection is dead.
-                    if (timed_out or !resp.keep_alive) {
+                    //
+                    // `disable_keepalive` retires the connection here on our
+                    // own terms rather than the server's: a server that ignores
+                    // the `Connection: close` we sent would otherwise keep the
+                    // socket — and its keep-alive throughput — while a
+                    // compliant one paid for a connection per request, which
+                    // would make the two incomparable in the one mode whose
+                    // entire purpose is comparing them.
+                    if (timed_out or !resp.keep_alive or p.disable_keepalive) {
                         conn_open = false;
                     }
                 },
@@ -966,6 +979,75 @@ test "closed schedule sends as fast as the server answers, never behind" {
     // Every completed response is a recorded (round-trip, not CO-adjusted-
     // backward) latency sample, same invariant as the paced schedules above.
     try testing.expectEqual(counters.completed, histogram.count());
+}
+
+test "disable_keepalive retires the connection a keep-alive response would keep" {
+    // `serveConn` answers with no `Connection` header at all, which over
+    // HTTP/1.1 means keep-alive (zurl's parser defaults `keep_alive` to
+    // `version == .@"1.1"`). It is therefore the exact case `-H 'Connection:
+    // close'` cannot reach: a server that will happily go on reusing the
+    // socket no matter what the request asked for. The flag has to win anyway,
+    // or it does nothing for precisely the servers it was added to measure.
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    // One accepted connection for the whole test, as in the sibling tests: so
+    // the SECOND request, if the client reconnects, has nobody to answer it.
+    // That is what makes "did it reuse the socket?" a counter and not a guess.
+    var group: Io.Group = .init;
+    group.async(io, testServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(200));
+
+    var params: Params = .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        .is_tls = false,
+        .insecure = false,
+        .schedule = .closed,
+        // Bounds the reconnects that follow the first response, so the run
+        // reaches `end` instead of parking on a socket nobody is serving.
+        .timeout_ns = 20 * std.time.ns_per_ms,
+        .disable_keepalive = true,
+        .end = end,
+        .stop = &stop,
+        .histogram = &histogram,
+        .counters = &counters,
+    };
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Exactly one: the connection the server served. Without the flag this
+    // same setup completes dozens (see "closed schedule sends as fast as the
+    // server answers", which is this test minus `disable_keepalive`).
+    try testing.expectEqual(@as(u64, 1), counters.completed);
+    // And it did keep going — it reconnected rather than stopping — which is
+    // what distinguishes a retired connection from a dead run. The reconnects
+    // land on a listener nobody is accepting from any more, so they time out
+    // on the wire; that they are timeouts and not connect errors is the proof
+    // the socket was re-established each time.
+    try testing.expect(counters.timeouts > 0);
+    try testing.expectEqual(@as(u64, 0), counters.connect_errors);
+    // `record_timeouts` is on by default, so the histogram holds the timed-out
+    // attempts alongside the one response — the tail is not silently dropped
+    // just because the connection is being cycled.
+    try testing.expectEqual(counters.completed + counters.timeouts, histogram.count());
 }
 
 /// Serves HEAD-style responses: headers advertising a Content-Length that has

--- a/src/http.zig
+++ b/src/http.zig
@@ -47,7 +47,17 @@ pub fn buildRequest(allocator: std.mem.Allocator, cfg: *const cli.Config) ![]u8 
         try w.print("{s}: {s}\r\n", .{ h.name, h.value });
     }
     if (!has_ua) try w.writeAll("User-Agent: zrk\r\n");
-    if (!has_conn) try w.writeAll("Connection: keep-alive\r\n");
+    // Under `--disable-keepalive` the socket goes away after this response
+    // whatever the server answers (see `connection.run`), so say so: a
+    // compliant server can then release its end with the response instead of
+    // parking an idle connection until its own keep-alive timeout. An explicit
+    // `-H Connection: ...` still wins — the flag governs our socket, `-H`
+    // governs the bytes, and a run that wants to see how a server reacts to
+    // being told `keep-alive` while we close anyway is a legitimate probe.
+    if (!has_conn) try w.writeAll(if (cfg.disable_keepalive)
+        "Connection: close\r\n"
+    else
+        "Connection: keep-alive\r\n");
 
     if (!has_cl) {
         if (cfg.body.len > 0) {
@@ -343,6 +353,35 @@ test "buildRequest basic GET" {
     try testing.expect(std.mem.indexOf(u8, req, "Host: example.com\r\n") != null);
     try testing.expect(std.mem.indexOf(u8, req, "Connection: keep-alive\r\n") != null);
     try testing.expect(std.mem.endsWith(u8, req, "\r\n\r\n"));
+}
+
+test "buildRequest advertises close under --disable-keepalive" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var cfg = cli.Config{ .url = try cli.parseUrl("http://example.com/") };
+    cfg.disable_keepalive = true;
+    const req = try buildRequest(arena.allocator(), &cfg);
+    try testing.expect(std.mem.indexOf(u8, req, "Connection: close\r\n") != null);
+    try testing.expect(std.mem.indexOf(u8, req, "Connection: keep-alive\r\n") == null);
+}
+
+test "an explicit -H Connection wins over --disable-keepalive's default" {
+    // The flag governs our socket; `-H` governs the bytes. Telling a server
+    // `keep-alive` while closing anyway is a legitimate probe of how it copes,
+    // and the header must not be silently doubled either way.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var cfg = cli.Config{
+        .url = try cli.parseUrl("http://example.com/"),
+        .headers = &.{.{ .name = "Connection", .value = "keep-alive" }},
+    };
+    cfg.disable_keepalive = true;
+    const req = try buildRequest(arena.allocator(), &cfg);
+    try testing.expect(std.mem.indexOf(u8, req, "Connection: close\r\n") == null);
+    try testing.expectEqual(
+        std.mem.indexOf(u8, req, "Connection: keep-alive\r\n"),
+        std.mem.lastIndexOf(u8, req, "Connection: keep-alive\r\n"),
+    );
 }
 
 test "buildRequest with non-default port, method, body, headers" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -412,6 +412,7 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.ZeroRefresh => "zrk: --refresh must be greater than 0\n\n",
         error.ClosedWithRamp => "zrk: --closed is incompatible with a ramp (-R A:B)\n\n",
         error.ClosedWithDeadline => "zrk: --closed is incompatible with --deadline\n\n",
+        error.KeepaliveWithHttp2 => "zrk: --disable-keepalive is incompatible with --http2\n\n",
         error.OutOfMemory => "zrk: out of memory\n\n",
     };
     try writeAll(io, .stderr(), msg);

--- a/src/report.zig
+++ b/src/report.zig
@@ -100,12 +100,13 @@ pub fn writeJson(
 
     try w.writeAll("  \"config\": {");
     try w.print(
-        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"closed\": {}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"deadline_abort\": {}, \"record_timeouts\": {} }},\n",
+        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"closed\": {}, \"disable_keepalive\": {}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"deadline_abort\": {}, \"record_timeouts\": {} }},\n",
         .{
             cfg.connections,
             launched,
             @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s,
             cfg.closed,
+            cfg.disable_keepalive,
             cfg.rate,
             cfg.timeout_ns / std.time.ns_per_ms,
             cfg.deadline_ns / std.time.ns_per_ms,

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -140,6 +140,7 @@ pub fn run(
         .deadline_ns = cfg.deadline_ns,
         .deadline_abort = cfg.deadline_abort,
         .record_timeouts = cfg.record_timeouts,
+        .disable_keepalive = cfg.disable_keepalive,
         .end = end,
         .stop = &stop,
         .allocator = arena,


### PR DESCRIPTION
## Why

zrk decides whether to reuse a socket from the **response**, never from the request: zurl defaults `keep_alive` to `version == .@"1.1"` (`parser.zig:177`) and only flips it on the server's own `Connection` header (`parser.zig:330-336`).

So `-H 'Connection: close'` reconnects only against servers that honour it, and leaves the ones that *ignore* it running at full keep-alive speed — backwards for the one comparison the header gets reached for. This came up measuring [the-benchmarker/web-frameworks#9421](https://github.com/the-benchmarker/web-frameworks/issues/9421), where 27 frameworks (the httpbeast-derived Nim family, the Workerman/Swoole PHP family, agoo-c, may_minihttp, httpz, mist) all ignore `Connection: close` — precisely the servers under test.

`--disable-keepalive` closes from our side regardless, so every target pays the same price.

## What

- `src/http.zig` — the request advertises `Connection: close` unless `-H` already set a `Connection` header, so a compliant server can release its end with the response instead of parking an idle socket until its own timeout. The flag governs our socket, `-H` governs the bytes; telling a server `keep-alive` while closing anyway stays available as a probe.
- `src/connection.zig` — `if (timed_out or !resp.keep_alive or p.disable_keepalive) conn_open = false;`
- Rejected with `--http2`: `Connection` is malformed in h2 (RFC 9113 §8.2.2, which is why `buildRequestBlock` already omits it), and one stream per connection would measure the handshake rather than the protocol.
- `"disable_keepalive"` added to the JSON `config` object, so a consumer can tell the two modes apart. Additive; every existing field keeps its name, type and meaning.

## Tests

Three added: flag parsing + h2 rejection (`cli.zig`), header emission and `-H` precedence (`http.zig`), and the behavioural one (`connection.zig`) — a server answering `Connection: keep-alive` and never closing, where the flag must retire the socket anyway. That last is the case `-H` cannot reach.

## Measured

Against a server that answers `Connection: keep-alive` and never closes, `-c 8 --closed -d 3s`:

| mode | throughput |
|---|---|
| default | 59450 req/s |
| `-H 'Connection: close'` | 59890 req/s — no effect, as expected |
| `--disable-keepalive` | 5448 req/s |

267 tests pass; `zig fmt --check` clean.