### PR TITLE
report: make a ramp's achieved_rate its tail rate

### DIFF
--- a/docs/library.md
+++ b/docs/library.md
@@ -37,8 +37,25 @@ var cfg: zrk.cli.Config = .{
     .interval_ns = 1 * std.time.ns_per_s,
     .url = try zrk.cli.parseUrl("http://127.0.0.1:8080/"),
 };
-const report = try zrk.runner.run(arena.allocator(), io, &cfg, 0, null, null);
+const report = try zrk.runner.run(arena.allocator(), io, &cfg, 0, null, null, null);
 ```
+
+`Report` carries the merged `snapshot` (counters plus the
+coordinated-omission-corrected histogram), `elapsed_s`, `launched`, and
+`interrupted`. It also carries `end_rate` / `end_bytes_per_sec` /
+`end_window_s` / `end_window_at_s`: throughput over the run's *last*
+`--interval` and where that window sat, rather than
+`completed / elapsed_s`. Under a ramp those differ by design — the whole-run
+average is the midpoint of the offered range and reports ~550 for `-R100:1000`
+no matter what the target did at the top of it, while `end_rate` is the rate it
+was actually serving when the run ended. A run shorter than one interval has no
+window of its own and falls back to the average.
+
+`report.writeJson` takes those as a `report.Run` alongside the snapshot, and
+reports `end_rate` as the summary's `achieved_rate` whenever `cfg.rate_end` is
+set (see [output.md](output.md)); an embedder computing its own headline number
+should make the same choice. Leaving `end_window_s` at 0 says "no window
+measured", and the whole run stands in for it.
 
 ## Which `std.Io` to pass
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -9,13 +9,17 @@ summary object (the live dashboard is suppressed) to stdout or `--output <file>`
 {
   "zrk_version": "0.1.0",
   "target": { "url": "http://127.0.0.1:8080/", "method": "GET" },
-  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "closed": false, "disable_keepalive": false, "target_rate": 1000, "timeout_ms": 2000, "deadline_ms": 0, "deadline_abort": false, "record_timeouts": true },
+  "config": { "connections": 50, "launched": 50, "duration_s": 20.000, "interval_s": 1.000, "closed": false, "disable_keepalive": false, "target_rate": 1000, "target_rate_end": 1000, "timeout_ms": 2000, "deadline_ms": 0, "deadline_abort": false, "record_timeouts": true },
   "duration_s": 20.002,
   "requests": 19998,
   "bytes": 1239876,
   "achieved_rate": 999.80,
   "target_rate": 1000,
+  "target_rate_end": 1000,
   "rate_ratio": 0.9998,
+  "achieved_rate_end": 999.91,
+  "rate_ratio_end": 0.9999,
+  "end_window_s": 1.000,
   "bytes_per_sec": 61987.30,
   "error_rate": 0.000000,
   "max_schedule_lag_us": 84,
@@ -37,12 +41,63 @@ many runs into one aggregate — none of which the summarized percentiles allow.
 `achieved_rate` / `rate_ratio` tell you whether the client actually sustained
 the target load. **If `rate_ratio` is well below 1.0, the client was saturated
 (one request in flight per connection) and the latency numbers reflect client
-backpressure, not the server: increase `-c`.**
+backpressure, not the server: increase `-c`.** For a ramp, that same pair reads
+as "how far up the ramp did the target actually get" — see below.
 
-Under `--closed` (`config.closed: true`), there's no offered rate to compare
-against, so `target_rate` mirrors `achieved_rate` and `rate_ratio` is always
-1.0 — a consumer that doesn't special-case `--closed` still gets coherent
-numbers instead of the unrelated default `-R`.
+### Constant load vs. a ramp
+
+Under **constant** load `achieved_rate` is the whole run averaged —
+`requests / duration_s` — and `rate_ratio` holds it against `-R`.
+
+Under a **ramp** (`-R A:B`) that average is the midpoint of the offered range
+and describes no part of the run: `-R100:1000` reports ~550 whether the server
+held 1000 all the way up or fell over at 200. So a ramp's `achieved_rate` is its
+**tail** instead — the rate served over the last `end_window_s` (one
+`config.interval_s`, give or take), which is the max sustained rate the ramp was
+run to find. `bytes_per_sec` covers the same window, so the two stay
+proportional. The whole-run average is still `requests / duration_s` if you want
+it.
+
+`rate_ratio` divides by the load *offered during that same window*, never by
+`target_rate_end`. `achieved_rate` is an average across a window in which the
+ramp keeps climbing, while `target_rate_end` is the schedule's value at the
+final instant; dividing one by the other would book a perfectly kept ramp as
+short by half a window of slope. A ramp that kept its schedule to the top
+reports `rate_ratio` ~1.0; one that saturated reports the fraction it managed.
+
+| field | what it is |
+| --- | --- |
+| `achieved_rate` | the run's throughput: the tail under a ramp, the whole-run average otherwise |
+| `rate_ratio` | `achieved_rate` over the load offered across the same span |
+| `achieved_rate_end` | **always** the tail, so a harness can read one key without knowing whether a ramp was configured |
+| `rate_ratio_end` | `achieved_rate_end` over the load offered during that window |
+| `target_rate_end` | the offered rate the ramp climbed to (`B`), or `target_rate` for constant load |
+| `end_window_s` | how long the tail window was |
+
+Under a ramp the `*_end` pair is identical to the top-level pair. Under constant
+load it is the last window rather than the whole run — which is how a server
+that degraded partway through a run shows up at all. It is normally the number
+the last `--timeseries` row reports, available without asking for the series —
+but don't assert equality: a duration that isn't a whole number of intervals
+ends on a sliver of a row that zrk deliberately reaches past, and an interrupted
+run raises no row at the signal at all. A run shorter than a single window has
+no tail to measure and falls back to the whole-run average.
+
+`end_window_s` is the window's length, and it closes at the last progress row —
+which on an interrupted run can be most of an `--interval` before `duration_s`.
+Both ratios account for that, so a ramp cut short by Ctrl-C is still judged
+against the load offered where its window actually sat.
+
+Under `--closed` (`config.closed: true`) there is no offered rate to compare
+against, and `--closed` cannot ramp, so `achieved_rate` is the whole-run
+average, `target_rate` mirrors it, `target_rate_end` mirrors
+`achieved_rate_end`, and both ratios are always 1.0 — a consumer that doesn't
+special-case `--closed` still gets coherent numbers instead of the unrelated
+default `-R`.
+
+Note that `config.target_rate` / `config.target_rate_end` are the `-R` endpoints
+**as given** (equal for a constant run), while the top-level pair is the
+*offered schedule*, which `--closed` redefines as above.
 
 Timed-out requests are recorded into the latency histogram by default (as a
 coordinated-omission-corrected sample) so the tail isn't silently truncated;
@@ -58,7 +113,9 @@ and format-compatible with wrk2's `--latency` output.
 ## `--timeseries` — per-interval NDJSON
 
 `--timeseries <file>` streams one NDJSON object per `--interval`, each carrying
-that window's offered `target_rate`, `achieved_rate`, request/error counts,
+that window's offered `target_rate` (the ramp's schedule averaged *across* the
+window, so it is directly comparable to the `achieved_rate` beside it rather
+than sitting half a window of slope above it), `achieved_rate`, request/error counts,
 transfer (`bytes`, `bytes_per_sec`), the backlog gauge, and a delta-histogram
 latency percentile set:
 
@@ -69,7 +126,10 @@ latency percentile set:
 This is the artifact a **ramp** (`-R A:B`) exists to produce: a curve of latency
 against offered load, so you can find the rate at which the server's tail breaks
 down. (The final summary's aggregate percentiles blend the whole ramp together,
-so they're less useful for a ramp than the time series is.)
+so they're less useful for a ramp than the time series is. Its throughput is not
+blended, though: the summary's `achieved_rate` is this file's last
+`achieved_rate`, so a harness that only wants the rate the ramp reached does not
+need the series at all.)
 
 Every count in a row is that **interval's** delta, so the rows sum to the run.
 `errors_by_kind` splits the `errors` scalar the same way the final summary's

--- a/src/main.zig
+++ b/src/main.zig
@@ -112,18 +112,28 @@ pub fn main(init: std.process.Init) !void {
     };
     var snapshot = result.snapshot;
 
+    const run_facts: report.Run = .{
+        .elapsed_s = result.elapsed_s,
+        .launched = result.launched,
+        .interrupted = result.interrupted,
+        .end_rate = result.end_rate,
+        .end_bytes_per_sec = result.end_bytes_per_sec,
+        .end_window_s = result.end_window_s,
+        .end_window_at_s = result.end_window_at_s,
+    };
+
     if (json) {
-        try writeJsonReport(arena, io, &cfg, &snapshot, result.elapsed_s, result.launched, result.interrupted);
+        try writeJsonReport(arena, io, &cfg, &snapshot, run_facts);
     } else if (cfg.output_path) |path| {
         // Text report redirected to --output; leave a breadcrumb on stdout —
         // unless the time series owns stdout, where a breadcrumb would land
         // mid-stream as a line no NDJSON reader can parse.
-        try writeTextReport(io, &dash, path, &snapshot, result.elapsed_s);
+        try writeTextReport(io, &dash, path, &snapshot, run_facts);
         if (!ts_stdout) try dash.finalRedirected(path);
     } else if (ts_stdout) {
-        try writeSummaryToStderr(io, &dash, &snapshot, result.elapsed_s);
+        try writeSummaryToStderr(io, &dash, &snapshot, run_facts);
     } else {
-        try dash.final(&snapshot, result.elapsed_s);
+        try dash.final(&snapshot, run_facts);
     }
 
     // Optional HdrHistogram percentile distribution (.hgrm) export.
@@ -203,18 +213,18 @@ fn watchSignal(io: Io, spec: SignalSpec, it: *Interrupt, notify: bool) void {
 }
 
 /// Write the wrk2-style text report to `--output` (text mode with -o set).
-fn writeTextReport(io: Io, dash: *tui.Dashboard, path: []const u8, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+fn writeTextReport(io: Io, dash: *tui.Dashboard, path: []const u8, snap: *const stats.Snapshot, run: report.Run) !void {
     const file = try Io.Dir.cwd().createFile(io, path, .{});
     defer file.close(io);
     var buf: [8192]u8 = undefined;
     var fw: Io.File.Writer = .init(file, io, &buf);
-    try dash.writeFinalSummary(&fw.interface, snap, elapsed_s);
+    try dash.writeFinalSummary(&fw.interface, snap, run);
     try fw.interface.flush();
 }
 
 /// Write the JSON summary to `--output` (or stdout when unset; stderr when
 /// `--timeseries -` has claimed stdout for the row stream).
-fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, elapsed_s: f64, launched: u32, interrupted: bool) !void {
+fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap: *const stats.Snapshot, run: report.Run) !void {
     var close = false;
     const fallback: Io.File = if (cfg.timeseriesOnStdout()) .stderr() else .stdout();
     const file = try openOut(io, cfg.output_path, fallback, &close);
@@ -228,20 +238,20 @@ fn writeJsonReport(gpa: std.mem.Allocator, io: Io, cfg: *const cli.Config, snap:
         .init(file, io, &buf)
     else
         .initStreaming(file, io, &buf);
-    try report.writeJson(gpa, &fw.interface, cfg, snap, elapsed_s, launched, interrupted);
+    try report.writeJson(gpa, &fw.interface, cfg, snap, run);
     try fw.interface.flush();
 }
 
 /// Write the compact text summary to stderr. Used when `--timeseries -` owns
 /// stdout and no `--output` was given: the run still has to report itself
 /// somewhere, and stderr is the stream a plotting pipe leaves free.
-fn writeSummaryToStderr(io: Io, dash: *tui.Dashboard, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+fn writeSummaryToStderr(io: Io, dash: *tui.Dashboard, snap: *const stats.Snapshot, run: report.Run) !void {
     var buf: [8192]u8 = undefined;
     // Streaming, not positional: stderr is shared with the interrupt notice, the
     // sink warnings and the SLO breach message, and a pwrite from byte 0 would
     // interleave with them instead of following them (see `writeAll`).
     var fw: Io.File.Writer = .initStreaming(.stderr(), io, &buf);
-    try dash.writeFinalSummary(&fw.interface, snap, elapsed_s);
+    try dash.writeFinalSummary(&fw.interface, snap, run);
     try fw.interface.flush();
 }
 

--- a/src/report.zig
+++ b/src/report.zig
@@ -57,6 +57,38 @@ pub fn checkSlo(cfg: *const cli.Config, snap: *const stats.Snapshot) SloResult {
     return r;
 }
 
+/// Offered *total* target rate (req/s) at elapsed `t_s`, honoring a ramp — the
+/// schedule `pace` is driving, sampled for reporting. Constant when `-R` has no
+/// end, and clamped to the ramp's endpoints outside the configured duration.
+/// `--closed` has no offered rate at all; callers substitute the achieved one
+/// there (which is what makes its rate ratios 1).
+pub fn offeredRate(cfg: *const cli.Config, t_s: f64) f64 {
+    const start: f64 = @floatFromInt(cfg.rate);
+    const end_rate = cfg.rate_end orelse return start;
+    const end: f64 = @floatFromInt(end_rate);
+    const dur = @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s;
+    if (dur <= 0) return end;
+    const frac = std.math.clamp(t_s / dur, 0, 1);
+    return start + (end - start) * frac;
+}
+
+/// The run-level facts the summary reports alongside the merged snapshot —
+/// `runner.Report` minus the snapshot itself. A struct rather than a tail of
+/// positional parameters so that adding a measurement doesn't reshuffle every
+/// call site.
+pub const Run = struct {
+    elapsed_s: f64,
+    launched: u32,
+    interrupted: bool = false,
+    /// Throughput over the run's final `--interval` window, and when that
+    /// window closed; see `runner.Report.end_rate`. A caller with no window to
+    /// report leaves `end_window_s` at 0, and the whole run stands in for it.
+    end_rate: f64 = 0,
+    end_bytes_per_sec: f64 = 0,
+    end_window_s: f64 = 0,
+    end_window_at_s: f64 = 0,
+};
+
 /// Write the JSON run summary. Latencies are microseconds (the histogram's
 /// native unit); `duration_s`/`*_rate` are derived from the measured elapsed
 /// time. `latency_histogram` is the full distribution as an HdrHistogram V2
@@ -68,26 +100,61 @@ pub fn writeJson(
     w: *Io.Writer,
     cfg: *const cli.Config,
     snap: *const stats.Snapshot,
-    elapsed_s: f64,
-    launched: u32,
-    interrupted: bool,
+    run: Run,
 ) !void {
     const c = snap.counters;
     const h = &snap.hist;
-    const achieved: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.completed)) / elapsed_s else 0;
-    const bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
-    // For a ramp, compare achieved throughput against the *average* offered rate
-    // (start+end)/2; for a constant run this is just the rate. In --closed mode
-    // there is no offered rate to compare against — report target == achieved
-    // (rate_ratio == 1) so a consumer that doesn't special-case --closed still
-    // gets coherent numbers instead of the unrelated default `rate`.
+    const elapsed_s = run.elapsed_s;
+    const ramping = cfg.rate_end != null;
     const rate_end = cfg.rate_end orelse cfg.rate;
-    const target_rate: u64 = if (cfg.closed) @intFromFloat(@round(achieved)) else cfg.rate;
-    const target_rate_end: u64 = if (cfg.closed) target_rate else rate_end;
-    const avg_target: f64 = if (cfg.closed)
-        achieved
+    const mean_rate: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.completed)) / elapsed_s else 0;
+    const mean_bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
+
+    // An embedder driving `runner.run` gets a measured window; one building a
+    // `Run` by hand (the library docs show only `elapsed_s`/`launched`) may
+    // report none. The whole run is then the only window there is — without
+    // this a ramp's `achieved_rate` would come out 0.00 rather than merely
+    // coarse, and --closed's ratios would contradict their documented 1.0.
+    const measured = run.end_window_s > 0;
+    const end_rate: f64 = if (measured) run.end_rate else mean_rate;
+    const end_bps: f64 = if (measured) run.end_bytes_per_sec else mean_bps;
+    const end_window_s: f64 = if (measured) run.end_window_s else elapsed_s;
+    // Judged on its own, so a caller that reported a window but not when it
+    // closed lands where `runner.run` puts it bar the fleet join, rather than
+    // at second zero — where a ramp's schedule would read as its start rate.
+    const end_window_at_s: f64 = if (run.end_window_at_s > 0) run.end_window_at_s else elapsed_s;
+
+    // Headline throughput. Averaging the whole run is right under constant load
+    // and wrong under a ramp, where the average is the midpoint of the offered
+    // range and describes no part of the run: `-R100:1000` reports ~550 whether
+    // the target held 1000 to the top or fell over at 200. So a ramp reports
+    // its *tail* — the last `end_window_s`, the rate the target was actually
+    // serving when the run ended, which is the number the ramp was run to find.
+    // The average is still `requests / duration_s` for anyone who wants it.
+    const achieved: f64 = if (ramping) end_rate else mean_rate;
+    const bps: f64 = if (ramping) end_bps else mean_bps;
+
+    // The offered load to hold `achieved` against, over the span it was actually
+    // measured over: the ramp's schedule at the tail window's midpoint, or the
+    // flat rate. In --closed mode there is no offered rate at all — report
+    // target == achieved (rate_ratio == 1) so a consumer that doesn't
+    // special-case --closed still gets coherent numbers instead of the
+    // unrelated default `rate`. (--closed and a ramp are mutually exclusive,
+    // so `achieved` is the average in every --closed branch here.)
+    // Anchored on when the window *closed*, not on `elapsed_s`: the two differ
+    // by the fleet join, and by most of an `--interval` when a signal cut the
+    // run short between rows. Reading the schedule that far further up a ramp
+    // overstates the offered load and books a kept ramp as short.
+    const window_mid_s = end_window_at_s - end_window_s / 2.0;
+    const offered_end: f64 = if (cfg.closed) end_rate else offeredRate(cfg, window_mid_s);
+    const target_rate: u64 = if (cfg.closed) @intFromFloat(@round(mean_rate)) else cfg.rate;
+    const target_rate_end: u64 = if (cfg.closed) @intFromFloat(@round(end_rate)) else rate_end;
+    const offered: f64 = if (cfg.closed)
+        mean_rate
+    else if (ramping)
+        offered_end
     else
-        (@as(f64, @floatFromInt(cfg.rate)) + @as(f64, @floatFromInt(rate_end))) / 2.0;
+        @as(f64, @floatFromInt(cfg.rate));
 
     try w.writeAll("{\n");
     try w.print("  \"zrk_version\": \"{s}\",\n", .{cli.version});
@@ -98,16 +165,23 @@ pub fn writeJson(
     try writeJsonString(w, cfg.method);
     try w.writeAll(" },\n");
 
+    // The configuration as given, not as interpreted: `target_rate`/
+    // `target_rate_end` here are the `-R` endpoints verbatim (equal for a
+    // constant run), while the top-level pair below is the *offered* schedule,
+    // which --closed redefines. `interval_s` is the stats window, and so the
+    // window `achieved_rate_end` is measured over.
     try w.writeAll("  \"config\": {");
     try w.print(
-        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"closed\": {}, \"disable_keepalive\": {}, \"target_rate\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"deadline_abort\": {}, \"record_timeouts\": {} }},\n",
+        " \"connections\": {d}, \"launched\": {d}, \"duration_s\": {d:.3}, \"interval_s\": {d:.3}, \"closed\": {}, \"disable_keepalive\": {}, \"target_rate\": {d}, \"target_rate_end\": {d}, \"timeout_ms\": {d}, \"deadline_ms\": {d}, \"deadline_abort\": {}, \"record_timeouts\": {} }},\n",
         .{
             cfg.connections,
-            launched,
+            run.launched,
             @as(f64, @floatFromInt(cfg.duration_ns)) / std.time.ns_per_s,
+            @as(f64, @floatFromInt(cfg.interval_ns)) / std.time.ns_per_s,
             cfg.closed,
             cfg.disable_keepalive,
             cfg.rate,
+            rate_end,
             cfg.timeout_ns / std.time.ns_per_ms,
             cfg.deadline_ns / std.time.ns_per_ms,
             cfg.deadline_abort,
@@ -119,13 +193,30 @@ pub fn writeJson(
     // Explicit rather than leaving a consumer to infer it from duration_s being
     // short of config.duration_s: an interrupted run is not a completed one, and
     // whatever reads this (a CI gate, a regression baseline) needs to say so.
-    if (interrupted) try w.print("  \"interrupted\": true,\n", .{});
+    if (run.interrupted) try w.print("  \"interrupted\": true,\n", .{});
     try w.print("  \"requests\": {d},\n", .{c.completed});
     try w.print("  \"bytes\": {d},\n", .{c.bytes});
     try w.print("  \"achieved_rate\": {d:.2},\n", .{achieved});
     try w.print("  \"target_rate\": {d},\n", .{target_rate});
     try w.print("  \"target_rate_end\": {d},\n", .{target_rate_end});
-    try w.print("  \"rate_ratio\": {d:.4},\n", .{if (avg_target > 0) achieved / avg_target else 0});
+    try w.print("  \"rate_ratio\": {d:.4},\n", .{if (offered > 0) achieved / offered else 0});
+    // The tail, unconditionally — so a harness can read one key without first
+    // working out whether a ramp was configured. Under a ramp these are the
+    // same two numbers as above; under constant load they are the last window
+    // rather than the whole run, which is how a target that degraded partway
+    // through shows up at all.
+    //
+    // Both ratios divide by the offered load averaged over the window the rate
+    // was measured across, never by `target_rate_end`. `achieved_rate_end` is
+    // an average over a window during which a ramp keeps climbing, while
+    // `target_rate_end` is the schedule's value at the final instant; dividing
+    // one by the other would book a perfectly kept ramp as short by half a
+    // window of slope.
+    try w.print("  \"achieved_rate_end\": {d:.2},\n", .{end_rate});
+    try w.print("  \"rate_ratio_end\": {d:.4},\n", .{
+        if (offered_end > 0) end_rate / offered_end else 0,
+    });
+    try w.print("  \"end_window_s\": {d:.3},\n", .{end_window_s});
     try w.print("  \"bytes_per_sec\": {d:.2},\n", .{bps});
     try w.print("  \"error_rate\": {d:.6},\n", .{errorRate(c)});
     // Peak schedule lag (µs): how far behind its intended send the fleet ever
@@ -198,19 +289,6 @@ pub const TimeSeries = struct {
         self.scratch.deinit();
     }
 
-    /// Offered *total* target rate (req/s) at elapsed `t_s`, honoring a ramp.
-    /// `.closed` has no offered rate; the caller substitutes the interval's
-    /// own achieved rate instead (rate_ratio == 1 there too).
-    fn targetRate(self: *const TimeSeries, t_s: f64) f64 {
-        const start: f64 = @floatFromInt(self.cfg.rate);
-        const end_rate = self.cfg.rate_end orelse return start;
-        const end: f64 = @floatFromInt(end_rate);
-        const dur = @as(f64, @floatFromInt(self.cfg.duration_ns)) / std.time.ns_per_s;
-        if (dur <= 0) return end;
-        const frac = std.math.clamp(t_s / dur, 0, 1);
-        return start + (end - start) * frac;
-    }
-
     /// Emit the line for the interval ending at `elapsed_s` and advance state.
     pub fn record(self: *TimeSeries, snap: *const stats.Snapshot, elapsed_s: f64) !void {
         self.delta.setToDifference(&snap.hist, &self.prev_cum);
@@ -235,6 +313,13 @@ pub const TimeSeries = struct {
         const achieved: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_completed)) / interval_s else 0;
         const bps: f64 = if (interval_s > 0) @as(f64, @floatFromInt(d_bytes)) / interval_s else 0;
 
+        // `target_rate` is the load offered *across* this window — the ramp's
+        // schedule at its midpoint — not the schedule at the instant the window
+        // closes. `achieved_rate` beside it is a window average, and a ramp
+        // climbs while the window runs, so the endpoint would sit half a window
+        // of slope above it: plotted together (the README's jplot pipeline), a
+        // target that kept its schedule perfectly would draw a permanent gap.
+        //
         // `error_rate` is this window's failure fraction, computed exactly like
         // the summary's — so a row is directly comparable to the final number
         // and to the `--max-error-rate` gate, and stays on one 0..1 axis no
@@ -243,7 +328,7 @@ pub const TimeSeries = struct {
             "{{\"t\":{d:.3},\"target_rate\":{d:.1},\"achieved_rate\":{d:.1},\"requests\":{d}," ++
                 "\"errors\":{d},\"error_rate\":{d:.6},",
             .{
-                elapsed_s, if (self.cfg.closed) achieved else self.targetRate(elapsed_s),
+                elapsed_s, if (self.cfg.closed) achieved else offeredRate(self.cfg, elapsed_s - interval_s / 2),
                 achieved,  d_completed,
                 d_errors,  failureFraction(d_completed, d_status, d_failures),
             },
@@ -356,7 +441,7 @@ test "writeJson emits parseable, well-formed summary" {
     defer alloc.deinit();
     var cfg = testConfig();
     cfg.deadline_ns = 250 * std.time.ns_per_ms;
-    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, 1.0, 4, false);
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{ .elapsed_s = 1.0, .launched = 4, .end_rate = 100, .end_window_s = 1.0 });
     const out = alloc.written();
 
     // Spot-check structure and key fields.
@@ -391,7 +476,8 @@ test "writeJson reports target_rate as achieved under --closed" {
     defer alloc.deinit();
     var cfg = testConfig();
     cfg.closed = true; // cfg.rate is still the unrelated default 1000
-    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, 1.0, 4, false);
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{ .elapsed_s = 1.0, .launched = 4, .end_rate = 500, .end_window_s = 1.0 });
+    // --closed cannot ramp, so achieved_rate stays the whole-run average here.
     const out = alloc.written();
 
     try testing.expect(std.mem.indexOf(u8, out, "\"closed\": true") != null);
@@ -403,6 +489,213 @@ test "writeJson reports target_rate as achieved under --closed" {
     try testing.expect(std.mem.indexOf(u8, out, "\"target_rate\": 500,") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"target_rate_end\": 500,") != null);
     try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate_end\": 500.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio_end\": 1.0000") != null);
+}
+
+test "a ramp's achieved_rate is its tail, not its whole-run average" {
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+
+    // A 10s -R100:1000 ramp that kept its schedule exactly: 5500 requests, so
+    // the whole run averages 550 — the midpoint of the offered range, and a
+    // number the target never served for a moment.
+    snap.counters.completed = 5500;
+    snap.counters.bytes = 220_000;
+    snap.counters.recordStatus(200);
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var cfg = testConfig();
+    cfg.rate = 100;
+    cfg.rate_end = 1000;
+    cfg.duration_ns = 10 * std.time.ns_per_s;
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{
+        .elapsed_s = 10.0,
+        .launched = 4,
+        // The final second of that ramp offers 910..1000, averaging 955 — so a
+        // target that held the schedule to the top reports 955, not 1000.
+        .end_rate = 955,
+        .end_bytes_per_sec = 38_200,
+        .end_window_s = 1.0,
+    });
+    const out = alloc.written();
+
+    // The config section carries both ends of `-R`, so a consumer can see what
+    // was asked for without re-parsing the command line.
+    try testing.expect(std.mem.indexOf(u8, out, "\"target_rate\": 100, \"target_rate_end\": 1000,") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"interval_s\": 1.000") != null);
+
+    // The headline throughput is the tail. `rate_ratio` holds it against the
+    // load offered over that same second (955), not against the ramp's endpoint
+    // (1000) — an endpoint comparison would report 0.955 for a run that missed
+    // nothing.
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 955.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"bytes_per_sec\": 38200.00") != null);
+    // The average is emphatically not the headline, but stays recoverable from
+    // the two fields it is the quotient of.
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 550") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"requests\": 5500") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"duration_s\": 10.000") != null);
+
+    // The unconditional tail keys mirror them under a ramp.
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate_end\": 955.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio_end\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"end_window_s\": 1.000") != null);
+}
+
+test "an interrupted ramp is judged where its window actually sat" {
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+    snap.counters.completed = 1000;
+    snap.counters.recordStatus(200);
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var cfg = testConfig();
+    cfg.rate = 100;
+    cfg.rate_end = 1000;
+    cfg.duration_ns = 60 * std.time.ns_per_s;
+    cfg.interval_ns = 5 * std.time.ns_per_s;
+
+    // Ctrl-C at t=24s, 4s after the last progress row: a signal raises no row
+    // of its own, so the tail window is [15s, 20s] while `elapsed_s` is 24.
+    // Over that window the ramp offered 325..400, averaging 362.5 — which the
+    // client served exactly. Anchoring on `elapsed_s` instead would read the
+    // schedule at 21.5s (~423) and book a kept ramp at 0.857.
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{
+        .elapsed_s = 24.0,
+        .launched = 4,
+        .interrupted = true,
+        .end_rate = 362.5,
+        .end_bytes_per_sec = 14_500,
+        .end_window_s = 5.0,
+        .end_window_at_s = 20.0,
+    });
+    const out = alloc.written();
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"interrupted\": true") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 362.50") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio_end\": 1.0000") != null);
+}
+
+test "writeJson stands the whole run in for a Run that reports no window" {
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+    snap.counters.completed = 5500;
+    snap.counters.bytes = 220_000;
+    snap.counters.recordStatus(200);
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var cfg = testConfig();
+    cfg.rate = 100;
+    cfg.rate_end = 1000;
+    cfg.duration_ns = 10 * std.time.ns_per_s;
+
+    // What an embedder building `Run` by hand gets — the library docs show only
+    // `elapsed_s` and `launched`. Without the fallback a ramp's headline rate
+    // would be the zero default rather than merely coarse.
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{
+        .elapsed_s = 10.0,
+        .launched = 4,
+    });
+    const out = alloc.written();
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 550.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"bytes_per_sec\": 22000.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"end_window_s\": 10.000") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 0.00") == null);
+
+    // Same for --closed, whose documented ratios are unconditionally 1.0.
+    var closed_out = Io.Writer.Allocating.init(testing.allocator);
+    defer closed_out.deinit();
+    var closed = testConfig();
+    closed.closed = true;
+    try writeJson(testing.allocator, &closed_out.writer, &closed, &snap, .{
+        .elapsed_s = 10.0,
+        .launched = 4,
+    });
+    try testing.expect(std.mem.indexOf(u8, closed_out.written(), "\"rate_ratio\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, closed_out.written(), "\"rate_ratio_end\": 1.0000") != null);
+    try testing.expect(std.mem.indexOf(u8, closed_out.written(), "\"target_rate_end\": 550,") != null);
+}
+
+test "a ramp's time-series rows offer the load averaged across each window" {
+    var cfg = testConfig();
+    cfg.rate = 100;
+    cfg.rate_end = 1000;
+    cfg.duration_ns = 10 * std.time.ns_per_s;
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var ts = try TimeSeries.init(testing.allocator, &alloc.writer, &cfg);
+    defer ts.deinit();
+
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+
+    // A client keeping the schedule exactly: the second ending at t=2 is
+    // offered 190..280, so it serves 235. `target_rate` has to be that same
+    // 235 average, not the 280 the schedule reads at the closing instant —
+    // otherwise `jplot achieved_rate+target_rate` draws a standing gap for a
+    // run that missed nothing.
+    snap.hist.record(1000);
+    snap.counters.completed = 145;
+    try ts.record(&snap, 1.0);
+    snap.counters.completed = 145 + 235;
+    try ts.record(&snap, 2.0);
+
+    var it = std.mem.splitScalar(u8, std.mem.trimEnd(u8, alloc.written(), "\n"), '\n');
+    try testing.expect(std.mem.indexOf(u8, it.next().?, "\"target_rate\":145.0,\"achieved_rate\":145.0,") != null);
+    try testing.expect(std.mem.indexOf(u8, it.next().?, "\"target_rate\":235.0,\"achieved_rate\":235.0,") != null);
+}
+
+test "constant load keeps the whole-run average as achieved_rate" {
+    var snap: stats.Snapshot = .{
+        .hist = try stats.newHistogram(testing.allocator),
+        .counters = .{},
+    };
+    defer snap.deinit();
+
+    // 10s at a flat 1000 req/s, but the last second only managed 400: the run
+    // average stays the headline (there is no ramp to make it misleading),
+    // while the tail keys are what expose the late collapse.
+    snap.counters.completed = 9400;
+    snap.counters.bytes = 376_000;
+    snap.counters.recordStatus(200);
+
+    var alloc = Io.Writer.Allocating.init(testing.allocator);
+    defer alloc.deinit();
+    var cfg = testConfig(); // constant -R 1000
+    cfg.duration_ns = 10 * std.time.ns_per_s;
+    try writeJson(testing.allocator, &alloc.writer, &cfg, &snap, .{
+        .elapsed_s = 10.0,
+        .launched = 4,
+        .end_rate = 400,
+        .end_bytes_per_sec = 16_000,
+        .end_window_s = 1.0,
+    });
+    const out = alloc.written();
+
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate\": 940.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio\": 0.9400") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"bytes_per_sec\": 37600.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"achieved_rate_end\": 400.00") != null);
+    try testing.expect(std.mem.indexOf(u8, out, "\"rate_ratio_end\": 0.4000") != null);
 }
 
 test "time series row carries the interval HDR blob when enabled" {

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -27,7 +27,33 @@ pub const Report = struct {
     /// on these numbers (an SLO check, a regression baseline) must not treat an
     /// interrupted run as a completed one.
     interrupted: bool = false,
+    /// Throughput (req/s) over the run's *final* window — the last `--interval`
+    /// or so, measured the same way a `--timeseries` row is.
+    ///
+    /// `snapshot.counters.completed / elapsed_s` is the whole-run average: the
+    /// right number under constant load, and a misleading one under a ramp,
+    /// where `-R100:1000` averages ~550 no matter what the target sustained at
+    /// the top. This is the tail — what the target was actually serving when
+    /// the run ended. Falls back to the whole-run average for a run too short
+    /// to hold a window.
+    end_rate: f64 = 0,
+    /// Bytes/second over that same window, so the two stay proportional: a
+    /// consumer dividing one by the other gets bytes-per-request either way.
+    end_bytes_per_sec: f64 = 0,
+    /// Wall-clock length of the window `end_rate` was measured over. Equal to
+    /// `elapsed_s` when the run was too short for a window of its own.
+    end_window_s: f64 = 0,
+    /// Elapsed time at which that window *closed*, which is not `elapsed_s`:
+    /// the window ends at the last progress row, while `elapsed_s` is measured
+    /// after the fleet is joined. An interrupt widens that gap to most of an
+    /// `--interval` (a signal raises no row of its own), and a consumer placing
+    /// the window on a ramp's schedule has to know where it actually sat.
+    end_window_at_s: f64 = 0,
 };
+
+/// One published counter reading at a progress-row boundary. Kept so `run` can
+/// difference the last window out of the run (see `Report.end_rate`).
+const RowSample = struct { ns: i128, completed: u64, bytes: u64 };
 
 /// Which consumers a progress callback is for. The dashboard redraws on the
 /// (faster) `--refresh` cadence; `--timeseries` rows and `--plain` lines keep
@@ -185,6 +211,12 @@ pub fn run(
     var next_row: i128 = start.nanoseconds + row_ns;
     var next_frame: i128 = start.nanoseconds + frame_ns;
     var interrupted = false;
+    // Row-boundary counter readings, for the tail window computed after the
+    // loop. Four is enough to always hold one sample a full `--interval` back:
+    // rows land on the interval cadence, and only the last one (the flush at
+    // `end`) can sit a fraction of an interval after its predecessor.
+    var rows: [4]RowSample = undefined;
+    var row_count: usize = 0;
     while (true) {
         const before = Io.Timestamp.now(io, .awake);
         if (before.nanoseconds >= end.nanoseconds) break;
@@ -233,6 +265,14 @@ pub fn run(
         if (progress) |callback| {
             callback(progress_context, &snap, t.nanoseconds, elapsed_s, total_s, tick);
         }
+        if (tick.row) {
+            rows[row_count % rows.len] = .{
+                .ns = t.nanoseconds,
+                .completed = snap.counters.completed,
+                .bytes = snap.counters.bytes,
+            };
+            row_count += 1;
+        }
         if (at_end or interrupted) break;
     }
 
@@ -245,11 +285,81 @@ pub fn run(
     const elapsed = start.durationTo(Io.Timestamp.now(io, .awake));
     const elapsed_s: f64 = @as(f64, @floatFromInt(elapsed.nanoseconds)) / std.time.ns_per_s;
     fleet.readFinal(&snap);
+
+    const tail = tailWindow(rows[0..], row_count, cfg.interval_ns);
     return .{
         .snapshot = snap,
         .elapsed_s = elapsed_s,
         .launched = launched,
         .interrupted = interrupted,
+        .end_rate = if (tail) |t| t.rate else perSecond(snap.counters.completed, elapsed_s),
+        .end_bytes_per_sec = if (tail) |t| t.bytes_per_sec else perSecond(snap.counters.bytes, elapsed_s),
+        .end_window_s = if (tail) |t| t.seconds else elapsed_s,
+        .end_window_at_s = if (tail) |t|
+            @as(f64, @floatFromInt(t.end_ns - start.nanoseconds)) / std.time.ns_per_s
+        else
+            elapsed_s,
+    };
+}
+
+fn perSecond(count: u64, seconds: f64) f64 {
+    if (seconds <= 0) return 0;
+    return @as(f64, @floatFromInt(count)) / seconds;
+}
+
+/// Difference the run's last window out of the row-boundary ring: the earlier
+/// sample whose distance to the final one is closest to a whole `--interval`,
+/// against that final one. Null when fewer than two rows landed (a run shorter
+/// than a single window).
+///
+/// Closest-to-an-interval rather than the plainer "newest sample at least an
+/// interval back", because neither end of the run lands on the grid exactly.
+/// Rows fire a wake-latency after their deadline while the end-of-run flush
+/// fires at `end` on the dot, so the last gap is a hair *under* an interval
+/// about as often as it is over — an at-least rule would reach a whole extra
+/// interval back on a coin flip, and the reported window would flip between one
+/// and two intervals across identical runs. It also declines to measure the
+/// sliver left by a duration that isn't a whole number of intervals (`-d 10.05s
+/// --interval 1s` ends with a 50ms row), preferring the 1.05s window over it.
+///
+/// Both ends come from *published* snapshots on purpose. A connection publishes
+/// its counters on its own cadence, so any snapshot lags reality by up to one
+/// publish interval; differencing two of them cancels that lag, while
+/// differencing the last row against the post-join live counters would charge
+/// every connection's unpublished backlog to this one window and overstate it.
+/// It also makes the number identical to the last `--timeseries` row whenever
+/// that row covers a full interval.
+fn tailWindow(ring: []const RowSample, count: usize, interval_ns: u64) ?struct {
+    rate: f64,
+    bytes_per_sec: f64,
+    seconds: f64,
+    /// Timestamp the window closed on, in the ring's own clock.
+    end_ns: i128,
+} {
+    if (count < 2) return null;
+    const last = ring[(count - 1) % ring.len];
+    const want: i128 = @intCast(interval_ns);
+
+    var base: ?RowSample = null;
+    var best_miss: i128 = 0;
+    var i = count -| ring.len;
+    while (i + 1 < count) : (i += 1) {
+        const s = ring[i % ring.len];
+        const span = last.ns - s.ns;
+        if (span <= 0) continue;
+        const miss = @max(span - want, want - span);
+        if (base == null or miss < best_miss) {
+            base = s;
+            best_miss = miss;
+        }
+    }
+    const b = base orelse return null;
+    const seconds = @as(f64, @floatFromInt(last.ns - b.ns)) / std.time.ns_per_s;
+    return .{
+        .rate = perSecond(last.completed -| b.completed, seconds),
+        .bytes_per_sec = perSecond(last.bytes -| b.bytes, seconds),
+        .seconds = seconds,
+        .end_ns = last.ns,
     };
 }
 
@@ -308,6 +418,80 @@ fn testServe(io: Io, server: *net.Server) void {
     }
 }
 
+test "tailWindow measures the last full interval, not the last partial row" {
+    const s_ns: i128 = std.time.ns_per_s;
+    const interval: u64 = std.time.ns_per_s;
+
+    // Rows on a 1s grid, then the end-of-run flush 0.2s past the last one — the
+    // shape of any duration that isn't a whole number of intervals. That sliver
+    // holds 200 requests, so measuring it alone would claim 1000 req/s off a
+    // fifth of a second; the window has to reach back past the 4s row to the 3s
+    // one, where the true 800-over-1.2s shows.
+    var ring: [4]RowSample = .{
+        .{ .ns = 2 * s_ns, .completed = 2000, .bytes = 80000 },
+        .{ .ns = 3 * s_ns, .completed = 3000, .bytes = 120000 },
+        .{ .ns = 4 * s_ns, .completed = 3600, .bytes = 144000 },
+        .{ .ns = 4 * s_ns + s_ns / 5, .completed = 3800, .bytes = 152000 },
+    };
+    const partial = tailWindow(&ring, 4, interval).?;
+    try testing.expectApproxEqAbs(@as(f64, 1.2), partial.seconds, 1e-9);
+    try testing.expectApproxEqAbs(@as(f64, 800.0 / 1.2), partial.rate, 1e-6);
+
+    // Rows landing exactly on the grid: one interval back is the whole window,
+    // and no further — reaching back two would blend the previous second in.
+    ring[3] = .{ .ns = 5 * s_ns, .completed = 4500, .bytes = 180000 };
+    const aligned = tailWindow(&ring, 4, interval).?;
+    try testing.expectApproxEqAbs(@as(f64, 1.0), aligned.seconds, 1e-9);
+    try testing.expectApproxEqAbs(@as(f64, 900), aligned.rate, 1e-6);
+
+    // Rows fire a wake-latency late, the end-of-run flush fires on the dot, so
+    // the last gap comes in a hair *under* an interval as often as over. Both
+    // sides of that coin flip must report the same one-interval window.
+    ring = .{
+        .{ .ns = 1 * s_ns + 200_000, .completed = 1000, .bytes = 40000 },
+        .{ .ns = 2 * s_ns + 300_000, .completed = 2000, .bytes = 80000 },
+        .{ .ns = 3 * s_ns + 400_000, .completed = 3000, .bytes = 120000 },
+        .{ .ns = 4 * s_ns, .completed = 3900, .bytes = 156000 },
+    };
+    const jittered = tailWindow(&ring, 4, interval).?;
+    try testing.expectApproxEqAbs(@as(f64, 0.9996), jittered.seconds, 1e-6);
+    try testing.expect(jittered.rate > 890 and jittered.rate < 910);
+
+    // A duration that isn't a whole number of intervals ends on a sliver:
+    // `-d 4.05s --interval 1s` flushes 50ms after the 4s row. 50ms of traffic
+    // is not a throughput measurement, so the window before it wins.
+    ring = .{
+        .{ .ns = 1 * s_ns, .completed = 1000, .bytes = 40000 },
+        .{ .ns = 2 * s_ns, .completed = 2000, .bytes = 80000 },
+        .{ .ns = 3 * s_ns, .completed = 3000, .bytes = 120000 },
+        .{ .ns = 4 * s_ns + s_ns / 20, .completed = 4050, .bytes = 162000 },
+    };
+    const sliver = tailWindow(&ring, 4, interval).?;
+    try testing.expectApproxEqAbs(@as(f64, 1.05), sliver.seconds, 1e-6);
+    try testing.expectApproxEqAbs(@as(f64, 1050.0 / 1.05), sliver.rate, 1e-6);
+
+    // A run too short to hold two rows has no window of its own; the caller
+    // falls back to the whole-run average.
+    try testing.expect(tailWindow(&ring, 1, interval) == null);
+    try testing.expect(tailWindow(&ring, 0, interval) == null);
+}
+
+test "tailWindow reads a ramp's tail, not its average" {
+    // 4s of a ramp sampled once a second: 100, 300, 500 and 700 requests per
+    // second. The whole-run average (1600/4 = 400) describes no second of it;
+    // the tail is the 700 the ramp actually reached.
+    const s_ns: i128 = std.time.ns_per_s;
+    const ring: [4]RowSample = .{
+        .{ .ns = 1 * s_ns, .completed = 100, .bytes = 4000 },
+        .{ .ns = 2 * s_ns, .completed = 400, .bytes = 16000 },
+        .{ .ns = 3 * s_ns, .completed = 900, .bytes = 36000 },
+        .{ .ns = 4 * s_ns, .completed = 1600, .bytes = 64000 },
+    };
+    const tail = tailWindow(&ring, 4, std.time.ns_per_s).?;
+    try testing.expectApproxEqAbs(@as(f64, 700), tail.rate, 1e-6);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), tail.seconds, 1e-9);
+}
+
 test "run's elapsed time tracks the duration, not the interval grid" {
     var rt = try zio.Runtime.init(testing.allocator, .{});
     defer rt.deinit();
@@ -347,6 +531,14 @@ test "run's elapsed time tracks the duration, not the interval grid" {
     // the quantization regression would report >= 1.0s.
     try testing.expect(result.elapsed_s >= 0.29);
     try testing.expect(result.elapsed_s < 0.9);
+    // Shorter than one --interval, so there is no tail window to difference:
+    // `end_rate` falls back to the whole-run average rather than reporting 0.
+    try testing.expectApproxEqAbs(result.end_window_s, result.elapsed_s, 1e-9);
+    try testing.expectApproxEqAbs(
+        @as(f64, @floatFromInt(result.snapshot.counters.completed)) / result.elapsed_s,
+        result.end_rate,
+        1e-6,
+    );
 }
 
 test "an interrupted run keeps its measurement and says it was cut short" {

--- a/src/tui.zig
+++ b/src/tui.zig
@@ -16,6 +16,7 @@ const cli = @import("cli.zig");
 const hdr = @import("hdr.zig");
 const connection = @import("connection.zig");
 const stats = @import("stats.zig");
+const report = @import("report.zig");
 
 /// Live latency spectrogram geometry. The waterfall keeps the last
 /// `spec_rows_max` per-interval distributions (newest at the bottom), each
@@ -134,6 +135,17 @@ pub const Dashboard = struct {
     const Sample = struct { ns: i128, completed: u64, bytes: u64 };
     const rate_ring_len = 128;
 
+    /// The measurement a frame renders: throughput over `seconds` of run,
+    /// ending `at_s` into it. The four travel together because they only mean
+    /// anything together — `rate` next to an offered load sampled from a
+    /// different span is the comparison this panel exists to get right.
+    const Window = struct {
+        rate: f64 = 0,
+        bps: f64 = 0,
+        seconds: f64 = 0,
+        at_s: f64 = 0,
+    };
+
     pub fn init(io: Io, cfg: *const cli.Config, environ: std.process.Environ, buffer: []u8) Dashboard {
         const file = Io.File.stdout();
         const is_tty = file.isTty(io) catch false;
@@ -186,18 +198,22 @@ pub const Dashboard = struct {
         // window is thus independent of the redraw cadence; the first frames
         // fall back to the whole run so far (otherwise a run with a single
         // frame reports 0 despite traffic).
-        var rate: f64 = 0;
-        var bps: f64 = 0;
+        // The span matters as much as the rates: under a ramp the offered
+        // schedule moves *within* the window, so `offered` has to be averaged
+        // over the same span to be comparable.
+        var win: Window = .{ .seconds = elapsed_s, .at_s = elapsed_s };
         if (self.windowSample(now_ns)) |base| {
             const d_s: f64 = @as(f64, @floatFromInt(now_ns - base.ns)) / std.time.ns_per_s;
             if (d_s > 0) {
-                rate = @as(f64, @floatFromInt(snap.counters.completed -| base.completed)) / d_s;
-                bps = @as(f64, @floatFromInt(snap.counters.bytes -| base.bytes)) / d_s;
+                win.rate = @as(f64, @floatFromInt(snap.counters.completed -| base.completed)) / d_s;
+                win.bps = @as(f64, @floatFromInt(snap.counters.bytes -| base.bytes)) / d_s;
+                win.seconds = d_s;
             }
         } else if (elapsed_s > 0) {
-            rate = @as(f64, @floatFromInt(snap.counters.completed)) / elapsed_s;
-            bps = @as(f64, @floatFromInt(snap.counters.bytes)) / elapsed_s;
+            win.rate = @as(f64, @floatFromInt(snap.counters.completed)) / elapsed_s;
+            win.bps = @as(f64, @floatFromInt(snap.counters.bytes)) / elapsed_s;
         }
+        const rate = win.rate;
         self.samples[self.sample_count % rate_ring_len] = .{
             .ns = now_ns,
             .completed = snap.counters.completed,
@@ -219,11 +235,11 @@ pub const Dashboard = struct {
             // that rewraps old lines can leave artifacts for one frame; the
             // next repaint absorbs them.)
             self.term_cols = termWidth(self.file);
-            try self.repaint(w, snap, rate, bps, elapsed_s, total_s, false);
+            try self.repaint(w, snap, win, elapsed_s, total_s, false);
         } else {
             try w.print("[{d:6.1}s] {d:8.0} req/s {f}/s  p50={f} p99={f} p99.9={f} max={f}  errs={d}\n", .{
                 elapsed_s,                               rate,
-                Bytes.of(bps),                           Dur.of(snap.hist.valueAtPercentile(50)),
+                Bytes.of(win.bps),                       Dur.of(snap.hist.valueAtPercentile(50)),
                 Dur.of(snap.hist.valueAtPercentile(99)), Dur.of(snap.hist.valueAtPercentile(99.9)),
                 Dur.of(snap.hist.max()),                 snap.counters.socketErrors() + snap.counters.status_errors + snap.counters.deadline_errors,
             });
@@ -238,7 +254,7 @@ pub const Dashboard = struct {
     ///
     /// `term_cols` is the caller's to refresh: both call sites re-read it from
     /// the terminal first, which leaves tests free to pin a width.
-    fn repaint(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, rate: f64, bps: f64, elapsed_s: f64, total_s: f64, finished: bool) !void {
+    fn repaint(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, win: Window, elapsed_s: f64, total_s: f64, finished: bool) !void {
         try w.writeAll(sync_begin);
         // A frame that dies between the two sequences leaves the terminal
         // holding its display with nothing left to release it — that reads as a
@@ -250,7 +266,7 @@ pub const Dashboard = struct {
         // breaks these too, and there is no better move left either way.
         errdefer closeSync(w);
         if (self.prev_lines > 0) try w.print("\r\x1b[{d}A\x1b[J", .{self.prev_lines});
-        self.prev_lines = try self.drawPanel(w, snap, rate, bps, elapsed_s, total_s, finished);
+        self.prev_lines = try self.drawPanel(w, snap, win, elapsed_s, total_s, finished);
         try w.writeAll(sync_end);
     }
 
@@ -273,7 +289,7 @@ pub const Dashboard = struct {
     /// the next frame knows how far to repaint. Config the launching command
     /// already shows (URL, -c, a ramp's A:B) is not repeated here — it sits
     /// right above in scrollback.
-    fn drawPanel(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, rate: f64, bps: f64, elapsed_s: f64, total_s: f64, finished: bool) !usize {
+    fn drawPanel(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, win: Window, elapsed_s: f64, total_s: f64, finished: bool) !usize {
         const c = snap.counters;
         const k = self.colors;
         var lines: usize = 0;
@@ -287,17 +303,22 @@ pub const Dashboard = struct {
         const v_time = clock(&vbuf[0], elapsed_s);
         const v_total = clock(&vbuf[1], total_s);
 
-        // Offered load right now — for a ramp, the interpolated schedule.
-        // Meaningless in --closed mode, which has no offered rate to show.
-        const r0: f64 = @floatFromInt(self.cfg.rate);
-        const offered_now: f64 = if (self.cfg.rate_end) |e| blk: {
-            const frac = if (total_s > 0) @min(elapsed_s / total_s, 1.0) else 1.0;
-            break :blk r0 + (@as(f64, @floatFromInt(e)) - r0) * frac;
-        } else r0;
+        // Offered load over the same window `achieved` was measured over — the
+        // schedule at its midpoint, since the ramp is linear in time. Not the
+        // schedule *right now*: `achieved` is an average across the window, and
+        // a ramp climbs while the window runs, so comparing it to the instant's
+        // offered rate books every healthy ramp as half a window of slope
+        // behind. At -R100:1000 over 30s with a 1s window that is a standing 15
+        // req/s gap; over 4s it is 110, enough to paint a run that missed
+        // nothing red from start to finish. Anchored on `win.at_s` rather than
+        // `elapsed_s` because the final paint's window closed at the last
+        // progress row, which an interrupt can leave most of an --interval
+        // behind. Meaningless in --closed mode, which has no offered rate.
+        const offered_now = report.offeredRate(self.cfg, win.at_s - win.seconds / 2);
         const v_offered = std.fmt.bufPrint(&vbuf[2], "{d:.0} req/s", .{offered_now}) catch "?";
-        const v_achieved = std.fmt.bufPrint(&vbuf[3], "{d:.0} req/s", .{rate}) catch "?";
+        const v_achieved = std.fmt.bufPrint(&vbuf[3], "{d:.0} req/s", .{win.rate}) catch "?";
         const v_transfer = std.fmt.bufPrint(&vbuf[4], "{f} ({f}/s)", .{
-            Bytes.of(@floatFromInt(c.bytes)), Bytes.of(bps),
+            Bytes.of(@floatFromInt(c.bytes)), Bytes.of(win.bps),
         }) catch "?";
         const v_2xx = std.fmt.bufPrint(&vbuf[5], "{d}", .{c.status_class[2]}) catch "?";
 
@@ -305,7 +326,7 @@ pub const Dashboard = struct {
         // (rate_ratio / Little's law): paint the achieved rate red. Skip the
         // first seconds while the fleet is still connecting. Never applies in
         // --closed mode, which has no schedule to fall behind.
-        const behind = !self.cfg.closed and elapsed_s >= 2 and rate < 0.95 * offered_now;
+        const behind = !self.cfg.closed and elapsed_s >= 2 and win.rate < 0.95 * offered_now;
 
         // A fixed three-line status, all indented to `stat_col`: the clock
         // lives alone in the left gutter (above the pXX labels) so its widening
@@ -661,17 +682,30 @@ pub const Dashboard = struct {
     /// dot, then left on screen as the run's record — no separate summary. Without
     /// a TUI (--plain, a pipe, non-tty) a compact plain-text summary is printed
     /// instead. Aggregates should come from `Fleet.readFinal` (post-join).
-    pub fn final(self: *Dashboard, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+    pub fn final(self: *Dashboard, snap: *const stats.Snapshot, run: report.Run) !void {
         const w = self.writer();
         if (self.tui) {
-            const c = snap.counters;
-            const rate: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.completed)) / elapsed_s else 0;
-            const bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
+            const elapsed_s = run.elapsed_s;
             const total_s: f64 = @as(f64, @floatFromInt(self.cfg.duration_ns)) / std.time.ns_per_s;
             self.term_cols = termWidth(self.file);
-            try self.repaint(w, snap, rate, bps, elapsed_s, total_s, true);
+            // Every value keeps meaning what it meant in each live frame — the
+            // last window's — rather than switching to whole-run averages for
+            // this one paint. The panel sets `achieved` beside `offered`, and
+            // under a ramp the run average is half the offered rate by
+            // construction, so the swap painted a healthy `-R100:1000` run's
+            // last frame red for falling behind a schedule it had in fact kept.
+            // Transfer comes from the same window for the same reason: paired
+            // with a whole-run byte rate, the panel's own two numbers divide
+            // out to a bytes-per-request that was never true. The whole-run
+            // averages are the summary's `req/s`, where they are labelled.
+            try self.repaint(w, snap, .{
+                .rate = run.end_rate,
+                .bps = run.end_bytes_per_sec,
+                .seconds = run.end_window_s,
+                .at_s = run.end_window_at_s,
+            }, elapsed_s, total_s, true);
         } else {
-            try self.writeFinalSummary(w, snap, elapsed_s);
+            try self.writeFinalSummary(w, snap, run);
         }
         try self.fw.interface.flush();
     }
@@ -696,8 +730,9 @@ pub const Dashboard = struct {
     /// the `--output` file). No colors and no wrk2-style framing — just the totals
     /// the live panel would have shown, in the panel's own vocabulary. Does not
     /// flush. Aggregates should come from `Fleet.readFinal` (post-join).
-    pub fn writeFinalSummary(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, elapsed_s: f64) !void {
+    pub fn writeFinalSummary(self: *Dashboard, w: *Io.Writer, snap: *const stats.Snapshot, run: report.Run) !void {
         const c = snap.counters;
+        const elapsed_s = run.elapsed_s;
         const rps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.completed)) / elapsed_s else 0;
         const bps: f64 = if (elapsed_s > 0) @as(f64, @floatFromInt(c.bytes)) / elapsed_s else 0;
 
@@ -706,6 +741,16 @@ pub const Dashboard = struct {
         try w.print(" read  ·  {d:.0} req/s  ·  ", .{rps});
         try writeBytes(w, bps);
         try w.writeAll("/s\n");
+        // The line above is `requests / duration`, which under a ramp is the
+        // midpoint of the offered range and nothing more: it reads the same
+        // whether the target held the end rate or fell over halfway up. So a
+        // ramp gets a second line with the number the ramp was run to find —
+        // the same one `--format json` reports as `achieved_rate`.
+        if (self.cfg.rate_end) |end| {
+            try w.print("  ramp {d} → {d} req/s  ·  {d:.0} req/s over the final {d:.1}s\n", .{
+                self.cfg.rate, end, run.end_rate, run.end_window_s,
+            });
+        }
 
         if (self.cfg.closed) {
             try w.writeAll("  latency (closed-loop round-trip)\n");
@@ -858,7 +903,7 @@ test "writeFinalSummary renders the compact plain summary to any writer" {
 
     var out = Io.Writer.Allocating.init(testing.allocator);
     defer out.deinit();
-    try dash.writeFinalSummary(&out.writer, &snap, 2.0);
+    try dash.writeFinalSummary(&out.writer, &snap, .{ .elapsed_s = 2.0, .launched = 1, .end_rate = 500, .end_window_s = 1.0 });
     const text = out.written();
 
     try testing.expect(std.mem.indexOf(u8, text, "latency (coordinated-omission corrected)") != null);
@@ -872,6 +917,84 @@ test "writeFinalSummary renders the compact plain summary to any writer" {
     // No deadline mode here, so neither overload line appears.
     try testing.expect(std.mem.indexOf(u8, text, "deadline misses") == null);
     try testing.expect(std.mem.indexOf(u8, text, "peak schedule lag") == null);
+    // Constant load: the average is the whole story, so no ramp line.
+    try testing.expect(std.mem.indexOf(u8, text, "ramp") == null);
+}
+
+test "a ramp's summary reports the rate it ended at, not just the average" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const cfg = cli.Config{
+        .rate = 100,
+        .rate_end = 1000,
+        .url = try cli.parseUrl("http://127.0.0.1:8080/"),
+    };
+    var dash_buf: [1024]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, .empty, &dash_buf);
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 5500; // 10s of a perfect 100->1000 ramp
+    snap.counters.recordStatus(200);
+
+    var out = Io.Writer.Allocating.init(testing.allocator);
+    defer out.deinit();
+    try dash.writeFinalSummary(&out.writer, &snap, .{ .elapsed_s = 10.0, .launched = 8, .end_rate = 955, .end_window_s = 1.0 });
+    const text = out.written();
+
+    // The first line stays `requests / duration` — 550, the ramp's midpoint,
+    // which would read as a failure against a 1000 req/s target. The second
+    // line carries the tail, and says the ramp was in fact kept.
+    try testing.expect(std.mem.indexOf(u8, text, "5500 requests in 10.00s") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "550 req/s") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "ramp 100 \u{2192} 1000 req/s") != null);
+    try testing.expect(std.mem.indexOf(u8, text, "955 req/s over the final 1.0s") != null);
+}
+
+test "a kept ramp is not painted as falling behind its schedule" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    // -R100:1000 over 4s: the schedule climbs 225 req/s every second, so the
+    // second ending at t=4 offers 887.5 on average while standing at 1000 the
+    // instant it closes. A client that served exactly 888 of them missed
+    // nothing — comparing it against the instant would call it 11% short and
+    // paint the panel red for a run that kept its schedule perfectly.
+    const cfg = cli.Config{
+        .rate = 100,
+        .rate_end = 1000,
+        .duration_ns = 4 * std.time.ns_per_s,
+        .url = try cli.parseUrl("http://127.0.0.1/"),
+    };
+    var dash_buf: [64]u8 = undefined;
+    var dash = Dashboard.init(io, &cfg, .empty, &dash_buf);
+    dash.colors = .enabled; // the red is the assertion, so force color on
+    dash.term_cols = 120;
+
+    var snap: stats.Snapshot = .{ .hist = try stats.newHistogram(testing.allocator), .counters = .{} };
+    defer snap.deinit();
+    snap.hist.record(1000);
+    snap.counters.completed = 2200;
+    snap.counters.recordStatus(200);
+
+    var kept = Io.Writer.Allocating.init(testing.allocator);
+    defer kept.deinit();
+    _ = try dash.drawPanel(&kept.writer, &snap, .{ .rate = 888, .bps = 1000, .seconds = 1.0, .at_s = 4.0 }, 4.0, 4.0, true);
+    // Both halves of the line read 888: the same window, measured two ways.
+    try testing.expectEqual(@as(usize, 2), std.mem.count(u8, kept.written(), "888 req/s"));
+    try testing.expect(std.mem.indexOf(u8, kept.written(), "offered ") != null);
+    try testing.expect(std.mem.indexOf(u8, kept.written(), "achieved ") != null);
+    try testing.expect(std.mem.indexOf(u8, kept.written(), Colors.enabled.red ++ "888 req/s") == null);
+
+    // A target that genuinely couldn't hold the top of the ramp still goes red.
+    var behind = Io.Writer.Allocating.init(testing.allocator);
+    defer behind.deinit();
+    _ = try dash.drawPanel(&behind.writer, &snap, .{ .rate = 400, .bps = 1000, .seconds = 1.0, .at_s = 4.0 }, 4.0, 4.0, true);
+    try testing.expect(std.mem.indexOf(u8, behind.written(), Colors.enabled.red ++ "400 req/s") != null);
 }
 
 test "a requested stop shows on the panel without breaking its line accounting" {
@@ -900,14 +1023,14 @@ test "a requested stop shows on the panel without breaking its line accounting" 
     // what the old stderr stop notice did, from outside the panel entirely.
     var running = Io.Writer.Allocating.init(testing.allocator);
     defer running.deinit();
-    const live = try dash.drawPanel(&running.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    const live = try dash.drawPanel(&running.writer, &snap, .{ .rate = 100, .bps = 1000, .seconds = 1.0, .at_s = 1.0 }, 1.0, 30.0, false);
     try testing.expectEqual(std.mem.count(u8, running.written(), "\n"), live);
     try testing.expect(std.mem.indexOf(u8, running.written(), "✕") == null);
 
     stop.store(true, .monotonic);
     var stopping = Io.Writer.Allocating.init(testing.allocator);
     defer stopping.deinit();
-    const cut = try dash.drawPanel(&stopping.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    const cut = try dash.drawPanel(&stopping.writer, &snap, .{ .rate = 100, .bps = 1000, .seconds = 1.0, .at_s = 1.0 }, 1.0, 30.0, false);
     try testing.expectEqual(std.mem.count(u8, stopping.written(), "\n"), cut);
     // The recording dot gives way to a cross, and the notice lands inside the
     // panel — one line taller than the same frame with no stop pending.
@@ -920,7 +1043,7 @@ test "a requested stop shows on the panel without breaking its line accounting" 
     // the hint gives way to what the numbers mean.
     var final_out = Io.Writer.Allocating.init(testing.allocator);
     defer final_out.deinit();
-    const done = try dash.drawPanel(&final_out.writer, &snap, 100, 1000, 1.0, 30.0, true);
+    const done = try dash.drawPanel(&final_out.writer, &snap, .{ .rate = 100, .bps = 1000, .seconds = 1.0, .at_s = 1.0 }, 1.0, 30.0, true);
     try testing.expectEqual(std.mem.count(u8, final_out.written(), "\n"), done);
     try testing.expect(std.mem.indexOf(u8, final_out.written(), "✕") != null);
     try testing.expect(std.mem.indexOf(u8, final_out.written(), "signal again") == null);
@@ -946,7 +1069,7 @@ test "a live repaint is bracketed by exactly one synchronized update" {
 
     var first = Io.Writer.Allocating.init(testing.allocator);
     defer first.deinit();
-    try dash.repaint(&first.writer, &snap, 100, 1000, 1.0, 30.0, false);
+    try dash.repaint(&first.writer, &snap, .{ .rate = 100, .bps = 1000, .seconds = 1.0, .at_s = 1.0 }, 1.0, 30.0, false);
     const f = first.written();
 
     // The whole frame sits inside the update: opened before anything is drawn
@@ -968,7 +1091,7 @@ test "a live repaint is bracketed by exactly one synchronized update" {
     var second = Io.Writer.Allocating.init(testing.allocator);
     defer second.deinit();
     const before = dash.prev_lines;
-    try dash.repaint(&second.writer, &snap, 100, 1000, 2.0, 30.0, false);
+    try dash.repaint(&second.writer, &snap, .{ .rate = 100, .bps = 1000, .seconds = 1.0, .at_s = 2.0 }, 2.0, 30.0, false);
     const g = second.written();
 
     var cursor_up_buf: [16]u8 = undefined;
@@ -1186,7 +1309,7 @@ test "writeFinalSummary surfaces deadline misses and peak schedule lag" {
 
     var out = Io.Writer.Allocating.init(testing.allocator);
     defer out.deinit();
-    try dash.writeFinalSummary(&out.writer, &snap, 2.0);
+    try dash.writeFinalSummary(&out.writer, &snap, .{ .elapsed_s = 2.0, .launched = 1, .end_rate = 500, .end_window_s = 1.0 });
     const text = out.written();
 
     try testing.expect(std.mem.indexOf(u8, text, "deadline misses: 42") != null);


### PR DESCRIPTION
Closes #69.

`achieved_rate` was `requests / duration_s` in every mode. Under a ramp that is
the midpoint of the offered range and describes no part of the run: `-R100:1000`
reports ~550 whether the server held 1000 all the way up or fell over at 200.
The rate a ramp exists to find was only recoverable from the last `--timeseries`
row, which meant writing a file to read one number out of it.

## What changes

A ramp's `achieved_rate` is now its **tail** — the rate served over the last
`--interval` — and `bytes_per_sec` covers the same window so the two stay
proportional. Constant load and `--closed` (which cannot ramp) keep the
whole-run average, and it is still `requests / duration_s` for anyone who wants
it.

`rate_ratio` divides by the load offered *across* that window, never by
`target_rate_end`. `achieved_rate` is an average over a window in which the ramp
keeps climbing, while `target_rate_end` is the schedule at the final instant;
dividing one by the other books a perfectly kept ramp as short by half a window
of slope.

| run (local server) | `achieved_rate` | `rate_ratio` |
| --- | --- | --- |
| `-c8 -d6s -R100:1000`, schedule kept | 924.93 | 0.9999 |
| `-c64 -d5s -R1000:200000`, saturated | 58476 | 0.3247 |
| `-c8 -d3s -R2000` constant | 1999.57 | 0.9998 |
| `-c8 -d3s --closed` | 58188 | 1.0000 |

The saturating row is the case from
the-benchmarker/web-frameworks#9421: the headline is the max sustained rate, and
the ratio says how far up the ramp the target actually got.

## The same bias, two more places

- **The live panel** compared a windowed `achieved` against the schedule at the
  instant, so a healthy ramp was painted red the whole way up — not only on the
  final frame the issue screenshots. Both sides now come from one window.
- **`--timeseries` rows** carried `target_rate` at the closing instant beside a
  window-averaged `achieved_rate`, so the README's `jplot` pipeline drew a
  standing gap for a run that missed nothing. `docs/output.md` already described
  that field as the window's offered rate; now it is.

Windows are anchored on when they *closed* rather than on `elapsed_s`: the two
differ by the fleet join, and by most of an `--interval` when a signal cuts the
run between rows. A ramp interrupted 4s past its last row was judged 4s further
up the schedule — 0.86 for a ramp that missed nothing; it now reports 0.9998.

## New fields

Both wanted by the web-frameworks harness: `config.target_rate_end` (the `-R`
endpoints as given, which the config section never carried) and
`config.interval_s`, plus `achieved_rate_end` / `rate_ratio_end` /
`end_window_s` — unconditionally the tail, so a consumer can read one key
without first working out whether a ramp was configured.

Additive otherwise: every previously emitted field keeps its name and type. Only
`achieved_rate` and `bytes_per_sec` change meaning, and only under `-R A:B`.

For embedders, `runner.Report` gains `end_rate` / `end_bytes_per_sec` /
`end_window_s` / `end_window_at_s`; `writeJson` takes them as a `report.Run`,
and a `Run` built by hand with no window stands the whole run in rather than
reporting `0.00`.

## Testing

142 tests pass (8 new), `zig fmt` clean. Verified end to end against a local
server: ramp, saturating ramp, constant, `--closed`, an odd duration, a real
`SIGINT` mid-window, and the TUI panel under a pty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
