### PR TITLE
feat: add -s/--streams, HTTP/2 multiplexing per connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Usage: zrk [options] <url>
 Options:
   -t, --threads     <N>     Total number of threads to execute load (default 2)
   -c, --connections <N>     Total connections to keep open (default 10)
+  -s, --streams     <N>     HTTP/2 streams in flight per connection
+                            (default 1). A depth knob only: -R still
+                            splits across -c, so -c 10 -s 10 offers the
+                            same rate as -c 10, not as -c 100. Requires
+                            --http2
   -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
   -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
                             linearly from A to B over the run (default 1000)
@@ -176,6 +181,7 @@ zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
 | | |
 |---|---|
 | [Coordinated omission](docs/coordinated-omission.md) | Why the correction exists, when `--closed` is the right tool, and how zrk's clock differs from wrk2's. |
+| [HTTP/2 multiplexing](docs/multiplexing.md) | What `-c` and `-s` mean once a connection carries several requests, and why `-c 10 -s 10` is not `-c 100`. |
 | [`--timeout` vs `--deadline`](docs/deadlines.md) | Bounding the latency tail under overload, and the backlog gauge. |
 | [Machine-readable output](docs/output.md) | The JSON summary, `--hdr`, `--timeseries` NDJSON, and piping rows into a live plotter. |
 | [Interrupting a run](docs/signals.md) | What SIGINT/SIGTERM report, and what supervisors should know. |

--- a/docs/multiplexing.md
+++ b/docs/multiplexing.md
@@ -1,10 +1,9 @@
 # HTTP/2 multiplexing: what `-c` and `-s` mean
 
-> **Status: settled design, not yet shipped.** `-s/--streams` does not exist
-> yet; zrk today keeps exactly one request in flight per connection. This is
-> the decision [#50](https://github.com/zoxy-io/zrk/issues/50) gates its
-> implementation on, written down first so the semantics aren't settled by
-> whichever patch lands first.
+`-s/--streams` sets how many HTTP/2 streams one connection keeps in flight.
+The semantics below were settled before the implementation, per
+[#50](https://github.com/zoxy-io/zrk/issues/50), so that they were not decided
+by whichever patch happened to land first.
 
 ## The decision
 
@@ -12,17 +11,18 @@
 
 - `-R` still splits evenly across `-c` connections, and each connection still
   owns one send schedule with one request index. `-c` is the number you compare
-  across runs, exactly as it is today.
+  across runs, exactly as it was before `-s` existed.
 - `-s` bounds how many of *that connection's already-scheduled* sends may be on
   the wire at once. It never changes what is scheduled or when.
-- `-s 1` is the current behaviour, byte for byte. It stays the default.
+- `-s 1` is the pre-multiplexing behaviour, down to which code path runs. It is
+  the default.
 
 The consequence to state up front, because it is the thing users will assume
 otherwise: **`-c 10 -s 10` is not `-c 100`.** Both put up to 100 requests in
 flight, but the first offers ten connections each paced at `R/10`, and the
 second offers a hundred each paced at `R/100`. Same aggregate rate, different
 per-connection rate, different transport behaviour. They are not interchangeable
-and zrk will not pretend they are.
+and zrk does not pretend they are. The numbers below say how far apart.
 
 ## Why not h2load's `-c × -m`
 
@@ -30,7 +30,8 @@ h2load spells concurrency `-c` connections × `-m` streams, so `-c 10 -m 10` and
 `-c 100` both mean "100 in flight". Adopting that would mean splitting `-R`
 across the *product* and moving the send schedule to a (connection, stream)
 pair — and it would buy comparability with a measurement that cannot see the
-thing being compared.
+thing being compared — and, as the numbers below show, comparability that does
+not exist in the first place.
 
 In h2load the per-request clock starts in nghttp2's `before_frame_send`
 callback, which fires when HEADERS is serialised **onto the wire**. Its
@@ -84,31 +85,87 @@ Use `-s` to model a client that genuinely multiplexes, or to let a connection
 hold its schedule. Use `-c` to add independent transport. When in doubt about a
 number you are going to compare across runs, change `-c`.
 
+## What the numbers actually say
+
+Against `nghttpd` on loopback, closed loop, five seconds each — the two layouts
+that both hold 100 requests in flight:
+
+| layout | in flight | req/s | p50 | p99 |
+| --- | ---: | ---: | ---: | ---: |
+| `-c 10 -s 1` | 10 | 250,990 | 38 µs | 67 µs |
+| `-c 10 -s 10` | 100 | 524,942 | 165 µs | 235 µs |
+| `-c 100 -s 1` | 100 | 186,608 | 522 µs | 1.04 ms |
+| `-c 100 -s 10` | 1000 | 433,818 | 2.21 ms | 3.77 ms |
+
+`-c 10 -s 10` and `-c 100 -s 1` are the same "100 concurrent requests" and
+nothing else: **2.8× apart on throughput and 3.2× apart on p50**. h2load, asked
+the same two questions on the same server, splits the same way (857k req/s at
+`-c 10 -m 10` against 285k at `-c 100 -m 1`) — so this is a property of the load
+layout, not of either tool.
+
+Which way the gap points is worth noticing: on loopback, multiplexing *wins*,
+because a hundred sockets cost a hundred sockets' worth of syscalls and
+scheduling and ten do not. That is the argument for `-s` existing. It is also
+the argument for never quoting a `-s` number against a `-c` number: the two
+differ by whatever the client's own transport costs on that machine, which is
+exactly the quantity a load generator is supposed to keep out of its results.
+
+Change `-c` when you want a number to compare. Change `-s` when you want to
+model a client that multiplexes.
+
+## Nagle
+
+zrk sets `TCP_NODELAY` on every connection it opens. This became necessary with
+`-s`, and the reason is worth recording because it cost real time to find.
+
+Nagle's algorithm holds a small write until the previous one has been
+acknowledged; Linux delays that acknowledgement by up to 40 ms. Serially the two
+can barely meet — nothing of ours is unacknowledged when the next request is
+written, because the response that acknowledged it is what released the send.
+Multiplexing makes them meet by design: writing a second request while the first
+is outstanding is the whole point, and Nagle answers it by parking that request
+until a delayed-ACK timer fires. Left on, it puts 40 ms of the client's own
+transport into the target's latency.
+
+It showed up first as an end-of-run artifact — the last response of a run
+arriving exactly 40 ms late, every time — which is the same bug wearing the one
+disguise that makes it look like a scheduling problem instead of a TCP one.
+
 ## Per-stream aborts
 
 With one request in flight, a timeout is aborted by shutting the socket down,
 because "abort this request" and "abort this connection" are the same act. With
-N streams open they stop being the same act: a timeout on one stream has to
-become `RST_STREAM` on that stream, and **every other in-flight stream's latency
-sample has to survive it**. That difference is the whole of the implementation
-risk, and h2load offers no precedent to copy — it has no per-stream timeout at
-all, only per-connection `-N`/`-T`, and `Client::timeout()` marks every
-in-flight stream timed out and disconnects.
+N streams open they stop being the same act, so a timeout on one stream becomes
+`RST_STREAM` on that stream and **every other in-flight stream's latency sample
+survives it**. That is the whole difference from the serial path and the place
+bugs would live, so it has a test of its own: one stream held open forever
+against a server that answers every other, asserting one timeout, one
+`RST_STREAM` seen by the server, zero connection errors, and the rest of the
+samples still arriving after it.
 
-`--deadline-abort` inherits the same change, and improves: today it resets the
-connection per miss, which is why the docs warn against it under saturation.
-Per-stream it becomes a `RST_STREAM` per miss, with no reconnect storm.
+h2load offered no precedent to copy here — it has no per-stream timeout at all,
+only per-connection `-N`/`-T`, and `Client::timeout()` marks every in-flight
+stream timed out and disconnects.
+
+`--deadline-abort` inherits the same change, and improves on it: serially it
+resets the connection per miss, which is why [deadlines.md](deadlines.md) warns
+against it under saturation. Per stream it is a `RST_STREAM` per miss, with no
+reconnect storm.
 
 ## `SETTINGS_MAX_CONCURRENT_STREAMS`
 
-The peer advertises a limit and zrk currently ignores it. A multiplexing client
-must honour it: the effective depth is `min(-s, peer limit)`, and a run that
-asked for more than the peer allows should say so rather than silently queue.
-h2load does not do this — its accounting runs against the requested `-m` while
-the surplus sits invisibly in nghttp2's queue — and that is a bug to avoid, not
-a behaviour to match.
+The peer advertises a limit and zrk honours it: the effective depth is
+`min(-s, peer limit)`, read from the SETTINGS that arrive during the handshake,
+so it is known before the first send rather than discovered by overshooting.
+h2load does not — its accounting runs against the requested `-m` while the
+surplus sits invisibly in nghttp2's queue, which means a client that believes it
+has N in flight against a peer allowing ten is timing its own queue and
+attributing it to the server.
 
-Flow control changes character too. `h2conn.open` raises the connection receive
-window to its 31-bit maximum once and never revisits it, which is sound while
-one reader consumes one response at a time. With N streams that single budget is
-shared, and the reasoning that made it free no longer applies unexamined.
+Flow control changed character too. `h2conn.open` raised the connection receive
+window to its 31-bit maximum once and never revisited it, which reads as "flow
+control off" and is not: that window is a budget for the connection's whole
+life, and every DATA octet spends it. One response at a time spends it slowly
+enough that short runs finish first; N streams share the same budget. zrk now
+credits the peer back at half, which is one WINDOW_UPDATE per gibibyte and makes
+the budget genuinely unbounded.

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -7,6 +7,11 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+// For `streams_max` only: the `--streams` ceiling is a property of the slot
+// table that lives on a connection's frame, so it is declared where that table
+// is rather than restated here.
+const connection = @import("connection.zig");
+
 /// zrk version string, surfaced by `--version` and embedded in JSON reports.
 /// Single-sourced from build.zig.zon via the build's options module.
 pub const version: []const u8 = @import("build_info").version;
@@ -112,12 +117,19 @@ pub const Config = struct {
     /// declines `h2` fails the connection rather than being benchmarked over a
     /// protocol nobody asked for.
     ///
-    /// One request is in flight per connection either way, so `-c`, the pacing,
-    /// and every latency number keep exactly their HTTP/1.1 meaning; only the
-    /// wire format changes. Multiplexing is a separate question about what
-    /// concurrency means for a coordinated-omission-corrected generator
-    /// (zoxy-io/zrk#21).
+    /// One request is in flight per connection unless `--streams` says
+    /// otherwise, so `-c`, the pacing, and every latency number keep exactly
+    /// their HTTP/1.1 meaning; only the wire format changes.
     http2: bool = false,
+    /// How many of a connection's scheduled sends may be on the wire at once
+    /// (`-s/--streams`). Requires `--http2`.
+    ///
+    /// A depth knob, not a second concurrency dial: `-c` still divides `-R`,
+    /// and `-c 10 -s 10` is deliberately *not* `-c 100` — same offered rate,
+    /// ten times the per-connection rate. What it removes is the client's own
+    /// serialisation, so a connection can hold its schedule instead of waiting
+    /// out each response. See docs/multiplexing.md.
+    streams: u32 = 1,
     /// Skip TLS certificate verification.
     insecure: bool = false,
     /// Emit append-only text lines instead of a redrawing TUI (for CI/pipes).
@@ -178,6 +190,9 @@ pub const ParseError = error{
     ClosedWithRamp,
     ClosedWithDeadline,
     KeepaliveWithHttp2,
+    ZeroStreams,
+    StreamsWithoutHttp2,
+    TooManyStreams,
     OutOfMemory,
 };
 
@@ -207,6 +222,11 @@ pub const usage =
     \\Options:
     \\  -t, --threads     <N>     Total number of threads to execute load (default 2)
     \\  -c, --connections <N>     Total connections to keep open (default 10)
+    \\  -s, --streams     <N>     HTTP/2 streams in flight per connection
+    \\                            (default 1). A depth knob only: -R still
+    \\                            splits across -c, so -c 10 -s 10 offers the
+    \\                            same rate as -c 10, not as -c 100. Requires
+    \\                            --http2
     \\  -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
     \\  -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
     \\                            linearly from A to B over the run (default 1000)
@@ -270,7 +290,7 @@ pub const usage =
 ;
 
 /// Short options that take a value, so `-c100` can be split into `-c 100`.
-const value_short_opts = "tcdRHmbo";
+const value_short_opts = "tcsdRHmbo";
 
 /// Parse argv (excluding the program name). Header slices and the header array
 /// are allocated from `arena`; string values point into `args` (borrowed).
@@ -334,6 +354,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.max_error_rate = try parseErrorRate(try nextValue(tokens, &i));
         } else if (eq(arg, "-t") or eq(arg, "--threads")) {
             cfg.threads = try parseU8(try nextValue(tokens, &i));
+        } else if (eq(arg, "-s") or eq(arg, "--streams")) {
+            cfg.streams = try parseU32(try nextValue(tokens, &i));
         } else if (eq(arg, "-c") or eq(arg, "--connections")) {
             cfg.connections = try parseU32(try nextValue(tokens, &i));
         } else if (eq(arg, "-d") or eq(arg, "--duration")) {
@@ -399,6 +421,15 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
     // `buildRequestBlock` omits it), and one stream per connection would
     // measure the handshake rather than the protocol.
     if (cfg.disable_keepalive and cfg.http2) return error.KeepaliveWithHttp2;
+    if (cfg.streams == 0) return error.ZeroStreams;
+    // HTTP/1.1 has no second stream to open. h2load spends `-m` on pipelining
+    // there; zrk will not, because a pipelined depth cannot be aborted per
+    // request — a timeout on one request abandons the whole pipeline behind
+    // it, which is the very thing `--streams` exists to avoid.
+    if (cfg.streams > 1 and !cfg.http2) return error.StreamsWithoutHttp2;
+    // The slot table lives on the connection's own frame; see
+    // `connection.streams_max`.
+    if (cfg.streams > connection.streams_max) return error.TooManyStreams;
 
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
@@ -640,6 +671,46 @@ test "closed flag parses; rejects ramp and deadline" {
     // not rejected) since a scalar -R can't be told apart from the default.
     const with_rate = (try parse(a, &[_][]const u8{ "--closed", "-R", "5000", "http://x/" })).config;
     try testing.expect(with_rate.closed);
+}
+
+test "streams flag parses; requires --http2 and a sane depth" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    // One in flight per connection unless asked otherwise — the pre-
+    // multiplexing behaviour, and the only default that keeps `-c` meaning
+    // what every earlier release made it mean.
+    const default = (try parse(a, &[_][]const u8{"http://x/"})).config;
+    try testing.expectEqual(@as(u32, 1), default.streams);
+
+    const cfg = (try parse(a, &[_][]const u8{ "--http2", "-s", "16", "http://x/" })).config;
+    try testing.expectEqual(@as(u32, 16), cfg.streams);
+
+    // wrk-style attached short option, like every other value-taking one.
+    const attached = (try parse(a, &[_][]const u8{ "--http2", "-s8", "http://x/" })).config;
+    try testing.expectEqual(@as(u32, 8), attached.streams);
+
+    // `-s 1` is the default, so it needs no --http2 to be meaningful.
+    const explicit_one = (try parse(a, &[_][]const u8{ "-s", "1", "http://x/" })).config;
+    try testing.expectEqual(@as(u32, 1), explicit_one.streams);
+
+    // A second stream needs a protocol that has one. HTTP/1.1 pipelining is not
+    // the fallback: a pipelined request cannot be abandoned without abandoning
+    // everything queued behind it, which is the one thing --streams is for.
+    try testing.expectError(error.StreamsWithoutHttp2, parse(a, &[_][]const u8{ "-s", "2", "http://x/" }));
+    // Validation runs after the whole command line, so flag order is free.
+    const reversed = (try parse(a, &[_][]const u8{ "-s", "2", "--http2", "http://x/" })).config;
+    try testing.expectEqual(@as(u32, 2), reversed.streams);
+
+    try testing.expectError(error.ZeroStreams, parse(a, &[_][]const u8{ "--http2", "-s", "0", "http://x/" }));
+    try testing.expectError(error.TooManyStreams, parse(a, &[_][]const u8{ "--http2", "-s", "100000", "http://x/" }));
+
+    // Orthogonal to the pacing mode: a closed loop of depth N per connection is
+    // exactly h2load's default shape, and a legitimate thing to ask for.
+    const with_closed = (try parse(a, &[_][]const u8{ "--closed", "--http2", "-s", "4", "http://x/" })).config;
+    try testing.expect(with_closed.closed);
+    try testing.expectEqual(@as(u32, 4), with_closed.streams);
 }
 
 test "disable-keepalive flag parses; rejects --http2" {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -118,13 +118,18 @@ pub const Params = struct {
     /// case, where the header block carries END_STREAM itself.
     body: []const u8 = &.{},
     /// Speak HTTP/2 with prior knowledge instead of HTTP/1.1.
-    ///
-    /// One request is in flight either way, so nothing else in this file
-    /// changes meaning: the pacing, the coordinated-omission correction, the
-    /// deadline shedding, and `watchTimer`'s abort-by-shutdown all work on the
-    /// same terms. That equivalence is exactly what stops holding the moment a
-    /// second stream is opened, which is why multiplexing is its own slice.
     http2: bool = false,
+    /// How many of this connection's scheduled sends may be on the wire at
+    /// once (`--streams`). Requires `http2`.
+    ///
+    /// It is a depth knob and nothing more: `schedule` and `send_index` are
+    /// untouched by it, so the connection offers exactly the same load at any
+    /// `streams`. What changes is whether a send that is *due* has to wait for
+    /// the previous response before it can go out. At 1 — the default — this
+    /// file behaves exactly as it did before multiplexing existed, down to
+    /// which code path runs. See docs/multiplexing.md for why `-c` and not this
+    /// is the number to compare across runs.
+    streams: u32 = 1,
     /// Framing classification of the request method (HEAD responses have no
     /// body); see `http.RequestMethod`.
     method: httpmod.RequestMethod = .other,
@@ -219,6 +224,7 @@ pub fn run(p: *Params) void {
             io.sleep(Io.Duration.fromMilliseconds(5), .awake) catch return;
             continue;
         };
+        disableNagle(stream);
 
         // Establish the transport (plaintext, or a TLS session over the stream)
         // and obtain the reader/writer the HTTP layer talks to.
@@ -291,6 +297,16 @@ pub fn run(p: *Params) void {
                 io.sleep(Io.Duration.fromMilliseconds(5), .awake) catch return;
                 continue;
             };
+        }
+
+        // Multiplexing takes over the whole connection from here: the request
+        // loop below is the serial one, and its two load-bearing assumptions —
+        // one watchdog for the connection, one `send_index` consumed in place
+        // — are exactly what a second open stream breaks.
+        if (p.http2 and p.streams > 1) {
+            runMultiplexed(p, io, &h2_session, &anchor, &send_index);
+            stream.close(io);
+            continue;
         }
 
         var conn_open = true;
@@ -540,6 +556,530 @@ fn watchTimer(
     stream.shutdown(io, .both) catch {};
 }
 
+// ── Multiplexing ────────────────────────────────────────────────────────────
+//
+// Three coroutines share one connection: `muxSend` (which runs on the
+// connection's own coroutine), `muxReceive`, and `muxWatch`. They exist because
+// the serial path's shape does not survive a second open stream. `performWork`
+// blocks until the response arrives, so it cannot pace a send while one is
+// outstanding; and one connection-wide `Watchdog` cannot time N requests that
+// started at N different moments.
+//
+// What does *not* change is the measurement. `send_index` is still consumed
+// once per send by one sender, the schedule is still solved from it, and every
+// latency sample is still measured from `scheduled`. `--streams` only decides
+// whether a send that is due has to wait for the previous response first.
+// docs/multiplexing.md has the reasoning; `--streams 1` reaches none of this.
+
+/// The most streams one connection will open at once.
+///
+/// A ceiling rather than an allocation: the slot table lives on the
+/// connection's own frame, next to the read and write buffers, which is what
+/// keeps a connection allocation-free for its whole life. Well past any real
+/// `--streams` — servers advertise limits an order of magnitude below it — and
+/// `cli.zig` refuses anything larger.
+pub const streams_max: u32 = 128;
+
+/// One in-flight request on a multiplexed connection.
+const Slot = struct {
+    /// Claimed by the sender, whether or not its stream is open yet. The gap
+    /// between the two is deliberate: the slot is claimed and its identifier
+    /// published *before* the HEADERS is written, so there is no window in
+    /// which a response arrives for a stream this table does not know.
+    busy: bool = false,
+    /// The stream carrying the request; 0 until it is opened.
+    stream: u31 = 0,
+    /// When this request was *supposed* to go out. The only clock its latency
+    /// is measured against — the coordinated-omission correction, unchanged.
+    scheduled: Io.Timestamp = .zero,
+    /// `:status`, once the response's field block has arrived.
+    status: ?u16 = null,
+    /// Response octets seen so far, field block included.
+    bytes: u64 = 0,
+    /// Absolute monotonic-ns deadline for this stream (0 = none), and whether
+    /// it came from the CO abort bound rather than the wire timeout — the same
+    /// collapse of two bounds into one that `Watchdog` does, per stream.
+    deadline_ns: u64 = 0,
+    deadline_co: bool = false,
+};
+
+/// State shared by one connection's three coroutines.
+const Mux = struct {
+    io: Io,
+    p: *Params,
+    session: *h2conn.Session,
+    slots: []Slot,
+
+    /// Guards `slots` and the three flags below — and `p.histogram` and
+    /// `p.counters`, which stop being the sender's private property the moment
+    /// the receiver is the one that knows a request finished.
+    state: Io.Mutex = .init,
+    /// Signaled whenever a slot frees or the connection ends: the two things a
+    /// sender with nowhere to put a request cares about.
+    slot_free: Io.Condition = .init,
+    /// Serializes the writer across all three: request HEADERS from the sender,
+    /// SETTINGS and PING acks and WINDOW_UPDATE from the receiver, RST_STREAM
+    /// from the watchdog.
+    ///
+    /// Separate from `state` so no I/O ever runs under the state lock — a flush
+    /// into a full socket buffer would otherwise stall the receiver. `send` is
+    /// the one place both are held, and it takes this one first; nothing takes
+    /// them the other way round.
+    write: Io.Mutex = .init,
+
+    /// Slots claimed, free or not.
+    active: u32 = 0,
+    /// GOAWAY seen: finish what is open, start nothing new.
+    no_new_streams: bool = false,
+    /// The connection is finished, for any reason.
+    dead: bool = false,
+    /// Being retired on our own terms — end of run, or a drained GOAWAY.
+    /// Streams still open then are dropped rather than counted: their requests
+    /// went out but the run stopped waiting, which is not a target failure. The
+    /// same judgement `noteError` makes about everything after `stop`.
+    retiring: bool = false,
+
+    /// Take a free slot, waiting if every stream is busy. Null means the sender
+    /// is done: the connection died, the peer said no new streams, or the wait
+    /// was canceled.
+    fn acquire(mux: *Mux) ?*Slot {
+        mux.state.lockUncancelable(mux.io);
+        defer mux.state.unlock(mux.io);
+        while (true) {
+            if (mux.dead or mux.no_new_streams) return null;
+            for (mux.slots) |*slot| {
+                if (slot.busy) continue;
+                slot.* = .{ .busy = true };
+                mux.active += 1;
+                return slot;
+            }
+            mux.slot_free.wait(mux.io, &mux.state) catch return null;
+        }
+    }
+
+    /// Free a slot and wake a sender waiting for one. Caller holds `state`.
+    fn release(mux: *Mux, slot: *Slot) void {
+        slot.* = .{};
+        mux.active -= 1;
+        mux.slot_free.signal(mux.io);
+    }
+
+    /// The slot carrying `stream`, or null if it has already been retired.
+    /// Caller holds `state`.
+    ///
+    /// An optional rather than an error because a late frame for a completed,
+    /// timed-out or reset stream is expected, not exceptional: identifiers are
+    /// never reused, so a frame naming one this table has forgotten is simply
+    /// past.
+    fn find(mux: *Mux, stream: u31) ?*Slot {
+        if (stream == 0) return null;
+        for (mux.slots) |*slot| {
+            if (slot.stream == stream) return slot;
+        }
+        return null;
+    }
+
+    /// Record a finished response and free its slot. Caller holds `state`.
+    fn complete(mux: *Mux, slot: *Slot) void {
+        const p = mux.p;
+        const done = now(mux.io);
+        // A stream that ended without `:status` is malformed (RFC 9113 section
+        // 8.3.2), and there is no honest latency sample for a request that
+        // never answered — the same call `finish` makes on the serial path.
+        const status = slot.status orelse {
+            mux.release(slot);
+            noteError(p, .read);
+            return;
+        };
+        // Coordinated-omission-corrected latency: from the time the request
+        // *should* have been sent, not when it actually went out.
+        const latency_ns = done.nanoseconds - slot.scheduled.nanoseconds;
+        const latency_us: u64 = if (latency_ns > 0) @intCast(@divTrunc(latency_ns, std.time.ns_per_us)) else 0;
+        p.histogram.record(latency_us);
+        p.counters.completed += 1;
+        p.counters.bytes += slot.bytes;
+        p.counters.recordStatus(status);
+        mux.release(slot);
+        maybePublish(p, done.nanoseconds);
+    }
+
+    /// The connection is finished. Every stream still open loses its request
+    /// with it: the serial path counts exactly one error for the one request it
+    /// had in flight, and N streams means N.
+    fn fail(mux: *Mux, kind: ErrorKind) void {
+        mux.state.lockUncancelable(mux.io);
+        defer mux.state.unlock(mux.io);
+        if (!mux.retiring) {
+            for (mux.slots) |*slot| {
+                if (!slot.busy) continue;
+                mux.release(slot);
+                noteError(mux.p, kind);
+            }
+        }
+        mux.dead = true;
+        mux.slot_free.broadcast(mux.io);
+    }
+
+    /// Stop on our own terms; see `retiring`.
+    fn retire(mux: *Mux) void {
+        mux.state.lockUncancelable(mux.io);
+        defer mux.state.unlock(mux.io);
+        mux.retiring = true;
+        mux.dead = true;
+        mux.slot_free.broadcast(mux.io);
+    }
+
+    /// Charge this send's schedule lag, and shed it if `--deadline` is already
+    /// blown. Verbatim the serial path's rule: a request staler than the
+    /// deadline can never meet it, so it is failed here without touching the
+    /// wire, which drains backlog instead of serializing through it.
+    fn shed(mux: *Mux, scheduled: Io.Timestamp, t: Io.Timestamp, send_index: *u64) bool {
+        const p = mux.p;
+        mux.state.lockUncancelable(mux.io);
+        defer mux.state.unlock(mux.io);
+        const behind_ns: i128 = t.nanoseconds - scheduled.nanoseconds;
+        if (behind_ns > 0) p.counters.noteBehind(@intCast(behind_ns));
+        if (p.deadline_ns == 0 or behind_ns <= p.deadline_ns) return false;
+        noteDeadline(p);
+        send_index.* += 1;
+        return true;
+    }
+
+    /// Publish the stream, arm its deadline, and write the request on it.
+    /// False when the connection can carry nothing more.
+    fn send(mux: *Mux, slot: *Slot, send_index: *u64) bool {
+        const p = mux.p;
+        const io = mux.io;
+
+        // Held across the registration as well as the write. The receiver needs
+        // `state` to act on a frame, and `state` is taken here before the
+        // HEADERS leaves — so the response to this stream cannot be read back
+        // before the table knows whose it is.
+        mux.write.lockUncancelable(io);
+        defer mux.write.unlock(io);
+
+        const sent = now(io);
+        {
+            mux.state.lockUncancelable(io);
+            defer mux.state.unlock(io);
+            slot.stream = mux.session.peekStream();
+            // Both bounds are absolute timestamps — the wire timeout from the
+            // actual send, the CO abort from `scheduled` — so the earlier one
+            // binds and the two collapse into a single deadline.
+            const wire: u64 = if (p.timeout_ns != 0)
+                @as(u64, @intCast(sent.nanoseconds)) + p.timeout_ns
+            else
+                0;
+            const co: u64 = if (p.deadline_abort and p.deadline_ns != 0)
+                @as(u64, @intCast(slot.scheduled.nanoseconds)) + p.deadline_ns
+            else
+                0;
+            slot.deadline_co = co != 0 and (wire == 0 or co <= wire);
+            slot.deadline_ns = if (slot.deadline_co) co else wire;
+        }
+
+        send_index.* += 1;
+
+        _ = mux.session.beginStream(p.request_block, p.body) catch |err| {
+            mux.state.lockUncancelable(io);
+            defer mux.state.unlock(io);
+            // The stream never opened, so nothing will ever close it. A refusal
+            // to open one (GOAWAY, or identifiers exhausted) sent no request
+            // and is not a failure to report; a write that broke is.
+            mux.release(slot);
+            if (err != error.Closed and !mux.retiring) noteError(p, .write);
+            mux.dead = true;
+            mux.slot_free.broadcast(io);
+            return false;
+        };
+        return true;
+    }
+};
+
+/// Drive one multiplexed connection until it dies or the run ends.
+///
+/// `anchor` and `send_index` are the connection's, not this call's: they
+/// survive a reconnect so a stall is caught up rather than reset, exactly as
+/// they do around the serial loop.
+fn runMultiplexed(
+    p: *Params,
+    io: Io,
+    session: *h2conn.Session,
+    anchor: *?Io.Timestamp,
+    send_index: *u64,
+) void {
+    // The peer's SETTINGS arrived during `open`, so its concurrency limit is
+    // known before the first send instead of discovered by overshooting it.
+    // Honouring it is not politeness: streams past the limit do not fail, they
+    // queue inside the connection, and a client that believes it has N in
+    // flight while the peer allows ten is timing its own queue and calling it
+    // the server's. (h2load does not honour it; see docs/multiplexing.md.)
+    const depth = @min(@min(p.streams, streams_max), @max(session.peer_max_concurrent_streams, 1));
+
+    var slot_storage: [streams_max]Slot = @splat(.{});
+    var mux: Mux = .{
+        .io = io,
+        .p = p,
+        .session = session,
+        .slots = slot_storage[0..depth],
+    };
+
+    var group: Io.Group = .init;
+    defer group.cancel(io);
+    // Without a receiver nothing can ever complete, so a connection that cannot
+    // start one is not worth sending on.
+    group.concurrent(io, muxReceive, .{&mux}) catch return;
+    // No bound to enforce, no watcher.
+    if (p.timeout_ns != 0 or (p.deadline_abort and p.deadline_ns != 0))
+        group.concurrent(io, muxWatch, .{&mux}) catch {};
+
+    muxSend(&mux, anchor, send_index);
+
+    // Stop sending, then let what is already on the wire land. Every open
+    // stream ends one of three ways — a response, its wire timeout, or its CO
+    // deadline — so this terminates on its own. The run's own teardown cancels
+    // it sooner, and the few streams still open then are dropped; see
+    // `Mux.retiring`.
+    {
+        while (true) {
+            {
+                mux.state.lockUncancelable(io);
+                defer mux.state.unlock(io);
+                if (mux.active == 0 or mux.dead) break;
+            }
+            io.sleep(Io.Duration.fromMicroseconds(200), .awake) catch break;
+        }
+    }
+    mux.retire();
+}
+
+/// The sender: solve the schedule, pace to it, and put the request on a stream.
+///
+/// Structurally the serial request loop with the blocking exchange taken out of
+/// the middle. Every step it shares with that loop — anchoring, the closed-form
+/// offset, the lag gauge, deadline shedding, the pacing sleep — means what it
+/// meant there.
+fn muxSend(mux: *Mux, anchor: *?Io.Timestamp, send_index: *u64) void {
+    const p = mux.p;
+    const io = mux.io;
+
+    while (!p.stop.load(.monotonic)) {
+        const t = now(io);
+        if (t.nanoseconds >= p.end.nanoseconds) return;
+
+        // Closed loop has no schedule to solve: the send is intended for
+        // whenever a stream frees, so the slot is taken first and `scheduled`
+        // read off the clock after. That degenerately zeroes the pacing wait,
+        // the deadline check and the CO correction, leaving genuine round-trip
+        // latency — the same trick the serial path plays, now with N loops per
+        // connection instead of one.
+        if (p.schedule == .closed) {
+            const slot = mux.acquire() orelse return;
+            slot.scheduled = now(io);
+            if (!mux.send(slot, send_index)) return;
+            continue;
+        }
+
+        // Anchor on the first send; each send's intended time is a closed-form
+        // function of its index (constant or ramp), never of any response.
+        if (anchor.* == null) anchor.* = t;
+        const offset = p.schedule.offsetNs(send_index.*, p.phase);
+        const scheduled = anchor.*.?.addDuration(Io.Duration.fromNanoseconds(@intCast(offset)));
+
+        if (mux.shed(scheduled, t, send_index)) continue;
+
+        // Pace: ahead of schedule, wait; behind, fire immediately.
+        if (scheduled.nanoseconds > t.nanoseconds) {
+            const wait = Io.Duration.fromNanoseconds(scheduled.nanoseconds - t.nanoseconds);
+            io.sleep(wait, .awake) catch return;
+        }
+
+        const slot = mux.acquire() orelse return;
+
+        // Waiting for a stream is itself schedule lag, and it is precisely the
+        // lag `--streams` exists to remove: at 1 every send waits for the
+        // previous response, at N only a connection already N deep waits at
+        // all. Charge it, and re-test the deadline against it — a request that
+        // spent its whole deadline queued here is shed rather than sent stale.
+        if (mux.shed(scheduled, now(io), send_index)) {
+            mux.state.lockUncancelable(io);
+            defer mux.state.unlock(io);
+            mux.release(slot);
+            continue;
+        }
+
+        slot.scheduled = scheduled;
+        if (!mux.send(slot, send_index)) return;
+    }
+}
+
+/// The receiver: read every frame the peer sends and fold it into the stream it
+/// belongs to. The only coroutine that touches the reader.
+fn muxReceive(mux: *Mux) void {
+    const io = mux.io;
+    const session = mux.session;
+
+    // The connection-level replacement for `frames_per_exchange_max`: this loop
+    // never finishes, so what it bounds is frames that finish *nothing*. An
+    // endless SETTINGS or PING flood is the case it exists for.
+    var idle_frames: u32 = 0;
+
+    while (idle_frames < h2conn.frames_without_progress_max) {
+        const incoming = session.receive() catch {
+            mux.fail(.read);
+            return;
+        };
+
+        const progressed = switch (incoming) {
+            .headers => |head| deliverToSlot(mux, head.stream, head.status, head.bytes, head.end_stream),
+            .data => |data| deliverToSlot(mux, data.stream, null, data.bytes, data.end_stream),
+            .reset => |stream| blk: {
+                resetOneSlot(mux, stream);
+                break :blk true;
+            },
+            .reply => |owed| blk: {
+                mux.write.lockUncancelable(io);
+                defer mux.write.unlock(io);
+                session.reply(owed) catch {
+                    mux.fail(.write);
+                    return;
+                };
+                break :blk false;
+            },
+            // Open streams may still finish; the sender stops opening new ones.
+            .going_away => blk: {
+                mux.state.lockUncancelable(io);
+                defer mux.state.unlock(io);
+                mux.no_new_streams = true;
+                mux.slot_free.broadcast(io);
+                break :blk false;
+            },
+            .idle => false,
+        };
+        idle_frames = if (progressed) 0 else idle_frames + 1;
+
+        // Give the connection window back before the budget runs out. Outside
+        // the state lock, and outside the read that produced the debt.
+        if (session.windowDue()) {
+            mux.write.lockUncancelable(io);
+            defer mux.write.unlock(io);
+            session.replenishWindow() catch {
+                mux.fail(.write);
+                return;
+            };
+        }
+    }
+    mux.fail(.read);
+}
+
+/// The watchdog: abandon each stream that outlives its bound, and *only* that
+/// stream.
+///
+/// This is the whole difference from the serial path. There, a timeout is a
+/// `stream.shutdown` — abandoning the request and the connection in one act,
+/// which is exact when they hold one request between them. Here the same act
+/// would take every other in-flight sample with it, so the bound is spent on a
+/// RST_STREAM instead and the other N − 1 responses go on arriving.
+fn muxWatch(mux: *Mux) void {
+    const io = mux.io;
+    const p = mux.p;
+
+    // How long to wait before re-checking with nothing on the wire. A quarter
+    // of the shortest bound this watcher can be asked to enforce, so an idle
+    // stretch can never oversleep a deadline armed just after it began.
+    const bound = if (p.timeout_ns != 0) p.timeout_ns else p.deadline_ns;
+    const idle_slice_ns: u64 = @max(bound / 4, std.time.ns_per_ms);
+
+    var expired: [streams_max]u31 = undefined;
+
+    while (true) {
+        var earliest: u64 = 0;
+        {
+            mux.state.lockUncancelable(io);
+            defer mux.state.unlock(io);
+            if (mux.dead) return;
+            for (mux.slots) |*slot| {
+                if (slot.stream == 0 or slot.deadline_ns == 0) continue;
+                if (earliest == 0 or slot.deadline_ns < earliest) earliest = slot.deadline_ns;
+            }
+        }
+
+        const t = now(io);
+        const wait_ns: u64 = if (earliest == 0)
+            idle_slice_ns
+        else if (@as(i128, earliest) > t.nanoseconds)
+            @intCast(@as(i128, earliest) - t.nanoseconds)
+        else
+            0;
+        if (wait_ns > 0) io.sleep(Io.Duration.fromNanoseconds(wait_ns), .awake) catch return;
+
+        var count: usize = 0;
+        {
+            mux.state.lockUncancelable(io);
+            defer mux.state.unlock(io);
+            if (mux.dead) return;
+            const at = now(io).nanoseconds;
+            for (mux.slots) |*slot| {
+                if (slot.stream == 0 or slot.deadline_ns == 0) continue;
+                if (@as(i128, slot.deadline_ns) > at) continue;
+                expired[count] = slot.stream;
+                count += 1;
+                // Freed before the reset goes out, which is what keeps the
+                // other samples intact: the receiver carries on delivering
+                // their frames, and this stream's own late frames now find no
+                // slot and are ignored.
+                const scheduled = slot.scheduled;
+                const co = slot.deadline_co;
+                mux.release(slot);
+                if (co) noteDeadline(p) else noteTimeout(p, io, scheduled);
+            }
+        }
+
+        for (expired[0..count]) |stream| {
+            mux.write.lockUncancelable(io);
+            defer mux.write.unlock(io);
+            mux.session.resetStream(stream) catch {
+                mux.fail(.write);
+                return;
+            };
+        }
+    }
+}
+
+/// Fold one frame into the stream it belongs to. Returns whether it finished a
+/// request, which is what `muxReceive`'s no-progress bound counts.
+fn deliverToSlot(mux: *Mux, stream: u31, status: ?u16, bytes: u64, end_stream: bool) bool {
+    mux.state.lockUncancelable(mux.io);
+    defer mux.state.unlock(mux.io);
+    const slot = mux.find(stream) orelse return false;
+    if (status) |code| {
+        // A second field block on a stream that already has a status is
+        // trailers, and trailers carry none (RFC 9113 section 8.1).
+        if (slot.status != null) {
+            mux.release(slot);
+            noteError(mux.p, .read);
+            return true;
+        }
+        slot.status = code;
+    }
+    slot.bytes += bytes;
+    if (!end_stream) return false;
+    mux.complete(slot);
+    return true;
+}
+
+/// The peer reset one stream (section 6.4). That request is lost; the
+/// connection and every other stream on it are not — which is the difference
+/// from the serial path, where the same frame ends the connection because there
+/// is nothing else on it to keep.
+fn resetOneSlot(mux: *Mux, stream: u31) void {
+    mux.state.lockUncancelable(mux.io);
+    defer mux.state.unlock(mux.io);
+    const slot = mux.find(stream) orelse return;
+    mux.release(slot);
+    noteError(mux.p, .read);
+}
+
 /// Send the fixed request and parse one response; touches only the
 /// transport, never the shared counters.
 fn performWork(
@@ -589,11 +1129,16 @@ fn now(io: Io) Io.Timestamp {
     return Io.Timestamp.now(io, .awake);
 }
 
+/// Which socket-level counter a failure lands in. Named rather than anonymous
+/// because the multiplexed path decides the kind in one place and reports it in
+/// another.
+const ErrorKind = enum { connect, write, read };
+
 /// Record a socket error, unless we are shutting down — errors caused by
 /// cancelling in-flight I/O at end-of-test are artifacts, not real failures.
 /// Publishes so the live dashboard sees error-only periods (a total outage
 /// produces no successful responses to publish through).
-fn noteError(p: *Params, kind: enum { connect, write, read }) void {
+fn noteError(p: *Params, kind: ErrorKind) void {
     if (p.stop.load(.monotonic)) return;
     switch (kind) {
         .connect => p.counters.connect_errors += 1,
@@ -662,6 +1207,30 @@ fn deadlineBoundedTimeout(wire_timeout_ns: u64, remaining_ns: u64) u64 {
     return remaining_ns;
 }
 
+/// Turn Nagle's algorithm off on a socket zrk measures through.
+///
+/// Nagle holds a small write back until the previous one has been
+/// acknowledged, and Linux delays that acknowledgement by up to 40 ms. With one
+/// request in flight the two can barely collide: nothing of ours is
+/// unacknowledged at the moment the next request is written, because the
+/// response that acknowledged it is what released the next send. Multiplexing
+/// makes them collide by design — a second request written while the first is
+/// still outstanding is the entire point of `--streams` — and Nagle answers it
+/// by parking that request until a delayed-ACK timer expires. Left on, it puts
+/// 40 ms of the client's own transport behaviour into the target's latency,
+/// which is the exact failure this tool exists not to have.
+///
+/// Best effort: a transport that will not take the option is not a reason to
+/// abandon the connection.
+fn disableNagle(stream: net.Stream) void {
+    std.posix.setsockopt(
+        stream.socket.handle,
+        std.posix.IPPROTO.TCP,
+        std.posix.TCP.NODELAY,
+        &std.mem.toBytes(@as(c_int, 1)),
+    ) catch {};
+}
+
 fn connect(io: Io, address: net.IpAddress, timeout_ns: u64) !net.Stream {
     // The response timeout is enforced per-request by `watchTimer`.
     const timeout: Io.Timeout = if (timeout_ns != 0) .{ .duration = .{ .raw = Io.Duration.fromNanoseconds(timeout_ns), .clock = .awake } } else .none;
@@ -718,6 +1287,7 @@ fn serveConn(io: Io, stream: *net.Stream) void {
 fn h2Serve(io: Io, server: *net.Server) void {
     var stream = server.accept(io) catch return;
     defer stream.close(io);
+    disableNagle(stream);
     var rbuf: [16 * 1024]u8 = undefined;
     var wbuf: [16 * 1024]u8 = undefined;
     var r = stream.reader(io, &rbuf);
@@ -869,6 +1439,306 @@ test "run drives HTTP/2 requests against a local h2c server" {
     // Two octets of body plus the response header block, per request.
     try testing.expect(counters.bytes >= counters.completed * 2);
     try testing.expectEqual(counters.completed, counters.status_class[2]);
+}
+
+/// Read the preface and answer SETTINGS, leaving the caller the frame loop.
+/// Shared by the three h2c test servers below.
+fn h2Greet(reader: *Io.Reader, writer: *Io.Writer) bool {
+    const magic = reader.take(h2conn.preface.len) catch return false;
+    if (!std.mem.eql(u8, magic, h2conn.preface)) return false;
+    // Our SETTINGS, empty: the defaults are fine for a test server.
+    writeTestFrame(writer, .settings, 0, 0, &.{}) catch return false;
+    writer.flush() catch return false;
+    return true;
+}
+
+/// Answer one stream with a 200 and two octets of body.
+fn h2Answer(writer: *Io.Writer, block: []const u8, stream: u31) bool {
+    writeTestFrame(writer, .headers, h2.frame.Flag.end_headers.bit(), stream, block) catch return false;
+    writeTestFrame(writer, .data, h2.frame.Flag.end_stream.bit(), stream, "hi") catch return false;
+    writer.flush() catch return false;
+    return true;
+}
+
+/// The 200 response block every test server sends, encoded once.
+fn h2ResponseBlock(buffer: []u8) []const u8 {
+    var storage: h2.hpack.Encoder.Storage(0) = .{};
+    var encoder = storage.encoder(.static_only);
+    const encoded = encoder.encode(buffer, &.{
+        .{ .name = ":status", .value = "200" },
+        .{ .name = "content-type", .value = "text/plain" },
+    });
+    return buffer[0..encoded.written];
+}
+
+/// An h2c server that answers request *k* only once request *k+1* has arrived.
+///
+/// A client that cannot hold two streams open at once therefore never gets a
+/// single response out of it: it sends, waits, and the answer it is waiting for
+/// is gated on a request it cannot send until the answer comes. That deadlock
+/// is the point — it makes "two requests really were in flight at once" a thing
+/// a test can assert without measuring time.
+fn h2LockstepServe(io: Io, server: *net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    disableNagle(stream);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    const reader = &r.interface;
+    const writer = &w.interface;
+    if (!h2Greet(reader, writer)) return;
+
+    var block_buf: [64]u8 = undefined;
+    const block = h2ResponseBlock(&block_buf);
+
+    var held: ?u31 = null;
+    while (true) {
+        const octets = reader.take(h2.frame.Header.octets) catch return;
+        const header = h2.frame.Header.parse(octets) catch return;
+        if (header.length > 0) _ = reader.take(header.length) catch return;
+
+        switch (header.frame_type) {
+            .settings => if (!header.has(.ack)) {
+                writeTestFrame(writer, .settings, h2.frame.Flag.ack.bit(), 0, &.{}) catch return;
+                writer.flush() catch return;
+            },
+            .headers => {
+                if (held) |earlier| {
+                    if (!h2Answer(writer, block, earlier)) return;
+                }
+                held = header.stream_identifier;
+            },
+            else => {},
+        }
+    }
+}
+
+/// An h2c server that answers every stream except the client's first, which it
+/// holds open forever — and counts the RST_STREAMs it is sent.
+///
+/// The multiplexed timeout path in one server. With one stream per connection
+/// the only way to abandon a stalled request is to drop the connection, and
+/// every other in-flight sample goes with it; the whole of what `--streams`
+/// changes here is that the bound is spent on a RST_STREAM instead.
+fn h2StallServe(io: Io, server: *net.Server, resets: *std.atomic.Value(u32)) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    disableNagle(stream);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    const reader = &r.interface;
+    const writer = &w.interface;
+    if (!h2Greet(reader, writer)) return;
+
+    var block_buf: [64]u8 = undefined;
+    const block = h2ResponseBlock(&block_buf);
+
+    while (true) {
+        const octets = reader.take(h2.frame.Header.octets) catch return;
+        const header = h2.frame.Header.parse(octets) catch return;
+        if (header.length > 0) _ = reader.take(header.length) catch return;
+
+        switch (header.frame_type) {
+            .settings => if (!header.has(.ack)) {
+                writeTestFrame(writer, .settings, h2.frame.Flag.ack.bit(), 0, &.{}) catch return;
+                writer.flush() catch return;
+            },
+            // Section 5.1.1: the client's first stream is 1. Held open, never
+            // answered, never reset from this side.
+            .headers => if (header.stream_identifier != 1) {
+                if (!h2Answer(writer, block, header.stream_identifier)) return;
+            },
+            .rst_stream => _ = resets.fetchAdd(1, .monotonic),
+            else => {},
+        }
+    }
+}
+
+/// The `Params` the multiplexed tests share, minus the parts each one varies.
+fn muxParams(
+    io: Io,
+    server_addr: net.IpAddress,
+    block: []const u8,
+    streams: u32,
+    end: Io.Timestamp,
+    timeout_ns: u64,
+    stop: *std.atomic.Value(bool),
+    histogram: *hdr.Histogram,
+    counters: *Counters,
+) Params {
+    return .{
+        .io = io,
+        .address = server_addr,
+        .host = "127.0.0.1",
+        .request = "",
+        .request_block = block,
+        .http2 = true,
+        .streams = streams,
+        .is_tls = false,
+        .insecure = false,
+        .schedule = .{ .constant = .{ .interval_ns = 2 * std.time.ns_per_ms } },
+        .timeout_ns = timeout_ns,
+        .end = end,
+        .stop = stop,
+        .histogram = histogram,
+        .counters = counters,
+    };
+}
+
+test "streams put more than one request on the wire at once" {
+    // The assertion is structural, not timed: `h2LockstepServe` will not answer
+    // a request until the *next* one has arrived, so a completed response is
+    // proof that two streams were open together. At `--streams 1` this same
+    // server produces nothing but timeouts, which is the case below it.
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    group.async(io, h2LockstepServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    var cfg: cli.Config = .{ .http2 = true };
+    cfg.url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" };
+    const block = try httpmod.buildRequestBlock(testing.allocator, &cfg);
+    defer testing.allocator.free(block);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(300));
+    var params = muxParams(io, server_addr, block, 4, end, 50 * std.time.ns_per_ms, &stop, &histogram, &counters);
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    try testing.expect(counters.completed > 1);
+    try testing.expectEqual(@as(u64, 0), counters.read_errors);
+    try testing.expectEqual(@as(u64, 0), counters.write_errors);
+    try testing.expectEqual(@as(u64, 0), counters.status_errors);
+    // The server holds one request back by construction, so the stream still
+    // open when the run ends has nothing to answer it: exactly one bound blows.
+    try testing.expect(counters.timeouts <= 1);
+    // The property #21 shipped and this slice had to keep. Timed-out requests
+    // are recorded too (`record_timeouts` defaults on), so they count here.
+    try testing.expectEqual(counters.completed + counters.timeouts, histogram.count());
+}
+
+test "a stalled stream is reset alone, leaving the other samples intact" {
+    // The whole difference between this slice and the serial one. `run` would
+    // answer a stalled request by shutting the socket down, which is exact when
+    // the connection holds one request and destroys N − 1 innocent samples when
+    // it holds N. Here the bound is spent on a RST_STREAM for the one stream
+    // that blew it, and the connection carries on measuring.
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var resets = std.atomic.Value(u32).init(0);
+    var group: Io.Group = .init;
+    group.async(io, h2StallServe, .{ io, &server, &resets });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    var cfg: cli.Config = .{ .http2 = true };
+    cfg.url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" };
+    const block = try httpmod.buildRequestBlock(testing.allocator, &cfg);
+    defer testing.allocator.free(block);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(400));
+    var params = muxParams(io, server_addr, block, 4, end, 40 * std.time.ns_per_ms, &stop, &histogram, &counters);
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Exactly one stream stalled, so exactly one bound blew.
+    try testing.expectEqual(@as(u64, 1), counters.timeouts);
+    // And it was abandoned by resetting that stream, not the connection: the
+    // server saw the RST_STREAM, and never had to re-accept.
+    try testing.expectEqual(@as(u32, 1), resets.load(.monotonic));
+    try testing.expectEqual(@as(u64, 0), counters.connect_errors);
+    try testing.expectEqual(@as(u64, 0), counters.read_errors);
+    try testing.expectEqual(@as(u64, 0), counters.write_errors);
+    // The samples that had nothing to do with it survived — many of them, and
+    // still arriving after the reset.
+    try testing.expect(counters.completed > 5);
+    // `record_timeouts` is on by default, so the abandoned request is a sample
+    // too; every other completion is one, and nothing else is.
+    try testing.expectEqual(counters.completed + counters.timeouts, histogram.count());
+}
+
+test "streams leave the offered load alone" {
+    // `--streams` is a depth knob: it changes whether a due send has to wait
+    // for the previous response, never what is due or when. Against a server
+    // that answers instantly there is nothing to wait for, so the same schedule
+    // must produce the same number of sends at any depth.
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    var completed: [2]u64 = undefined;
+    for ([_]u32{ 1, 8 }, 0..) |streams, index| {
+        const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+        var server = try bind_addr.listen(io, .{ .reuse_address = true });
+        const port = server.socket.address.getPort();
+        const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+        var group: Io.Group = .init;
+        group.async(io, h2Serve, .{ io, &server });
+
+        var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+        defer histogram.deinit();
+        var counters: Counters = .{};
+        var stop = std.atomic.Value(bool).init(false);
+
+        var cfg: cli.Config = .{ .http2 = true };
+        cfg.url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" };
+        const block = try httpmod.buildRequestBlock(testing.allocator, &cfg);
+        defer testing.allocator.free(block);
+
+        const start = Io.Timestamp.now(io, .awake);
+        const end = start.addDuration(Io.Duration.fromMilliseconds(200));
+        var params = muxParams(io, server_addr, block, streams, end, 50 * std.time.ns_per_ms, &stop, &histogram, &counters);
+        run(&params);
+
+        group.await(io) catch {};
+        server.deinit(io);
+
+        try testing.expect(counters.completed > 0);
+        try testing.expectEqual(counters.completed, histogram.count());
+        try testing.expectEqual(@as(u64, 0), counters.read_errors);
+        completed[index] = counters.completed;
+    }
+
+    // A 2 ms schedule over 200 ms is ~100 sends either way. Loose enough for a
+    // loaded CI box, tight enough that a depth knob quietly become a rate knob
+    // — the `-c × -s` reading this design rejected — would fail it.
+    const serial: f64 = @floatFromInt(completed[0]);
+    const deep: f64 = @floatFromInt(completed[1]);
+    try testing.expect(deep < serial * 1.5);
+    try testing.expect(deep > serial * 0.5);
 }
 
 test "run drives keep-alive requests against a local server" {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -633,11 +633,48 @@ const Mux = struct {
     no_new_streams: bool = false,
     /// The connection is finished, for any reason.
     dead: bool = false,
+    /// What the peer is owed but has not been sent yet. Touched only by the
+    /// receiver, so they need no lock. See `flushOwed`.
+    owed_settings_ack: bool = false,
+    owed_ping: ?h2conn.Reply = null,
+
     /// Being retired on our own terms — end of run, or a drained GOAWAY.
     /// Streams still open then are dropped rather than counted: their requests
     /// went out but the run stopped waiting, which is not a target failure. The
     /// same judgement `noteError` makes about everything after `stop`.
     retiring: bool = false,
+
+    /// Send whatever the peer is owed — SETTINGS and PING acks, and the
+    /// connection window — if the writer happens to be free. False on a write
+    /// that broke.
+    ///
+    /// Never waits for the writer, and that is the point. The sender holds
+    /// `write` across its flush, and a flush can park when the peer stops
+    /// reading. If the receiver then waited for `write`, it would stop reading
+    /// too — so the peer's send buffer fills, the peer stops reading, and the
+    /// sender's flush never returns. The cycle closes and the connection hangs
+    /// until teardown turns the rest of the run into timeouts. Reading is the
+    /// only way out of it, so the receiver gives up the writer instead of the
+    /// read and tries again after the next frame.
+    fn flushOwed(mux: *Mux) bool {
+        const window_due = mux.session.windowDue();
+        if (!mux.owed_settings_ack and mux.owed_ping == null and !window_due) return true;
+        if (!mux.write.tryLock()) return true;
+        defer mux.write.unlock(mux.io);
+
+        if (mux.owed_settings_ack) {
+            mux.session.reply(.settings_ack) catch return false;
+            mux.owed_settings_ack = false;
+        }
+        if (mux.owed_ping) |owed| {
+            mux.session.reply(owed) catch return false;
+            mux.owed_ping = null;
+        }
+        // Re-read rather than trusting `window_due`: a frame may have landed
+        // while the lock was being taken.
+        if (mux.session.windowDue()) mux.session.replenishWindow() catch return false;
+        return true;
+    }
 
     /// Take a free slot, waiting if every stream is busy. Null means the sender
     /// is done: the connection died, the peer said no new streams, or the wait
@@ -658,7 +695,14 @@ const Mux = struct {
     }
 
     /// Free a slot and wake a sender waiting for one. Caller holds `state`.
+    ///
+    /// Idempotent, and that is load-bearing rather than defensive: a connection
+    /// that dies while the sender is mid-`send` has its slot reclaimed by
+    /// `fail` — the sender is parked inside `beginStream`'s flush at the time —
+    /// and the sender then runs its own error path over the same slot. Without
+    /// the guard the second call takes `active` below zero.
     fn release(mux: *Mux, slot: *Slot) void {
+        if (!slot.busy) return;
         slot.* = .{};
         mux.active -= 1;
         mux.slot_free.signal(mux.io);
@@ -712,8 +756,12 @@ const Mux = struct {
         if (!mux.retiring) {
             for (mux.slots) |*slot| {
                 if (!slot.busy) continue;
+                // A slot claimed but not yet opened carries no request: the
+                // sender has it and has written nothing, so freeing it is right
+                // and charging it an error would invent a failure.
+                const carried = slot.stream != 0;
                 mux.release(slot);
-                noteError(mux.p, kind);
+                if (carried) noteError(mux.p, kind);
             }
         }
         mux.dead = true;
@@ -759,9 +807,14 @@ const Mux = struct {
         defer mux.write.unlock(io);
 
         const sent = now(io);
-        {
+        const stream = blk: {
             mux.state.lockUncancelable(io);
             defer mux.state.unlock(io);
+            // The connection can die between acquiring this slot and reaching
+            // here — `shed` yields, and `fail` reclaims every open slot. Then
+            // this slot is somebody else's (or nobody's) and must not be
+            // written into.
+            if (!slot.busy or mux.dead) break :blk 0;
             slot.stream = mux.session.peekStream();
             // Both bounds are absolute timestamps — the wire timeout from the
             // actual send, the CO abort from `scheduled` — so the earlier one
@@ -776,18 +829,27 @@ const Mux = struct {
                 0;
             slot.deadline_co = co != 0 and (wire == 0 or co <= wire);
             slot.deadline_ns = if (slot.deadline_co) co else wire;
-        }
+            break :blk slot.stream;
+        };
+        // Nothing was sent and no index was consumed, so the schedule simply
+        // resumes here on the next connection.
+        if (stream == 0) return false;
 
         send_index.* += 1;
 
         _ = mux.session.beginStream(p.request_block, p.body) catch |err| {
             mux.state.lockUncancelable(io);
             defer mux.state.unlock(io);
-            // The stream never opened, so nothing will ever close it. A refusal
-            // to open one (GOAWAY, or identifiers exhausted) sent no request
-            // and is not a failure to report; a write that broke is.
-            mux.release(slot);
-            if (err != error.Closed and !mux.retiring) noteError(p, .write);
+            // The stream never opened, so nothing will ever close it — unless
+            // `fail` already reclaimed the slot while this write was parked, in
+            // which case the request has been charged once already and charging
+            // it again would double-count one send as two errors.
+            if (slot.busy and slot.stream == stream) {
+                // A refusal to open (GOAWAY, or identifiers exhausted) sent no
+                // request and is not a failure to report; a broken write is.
+                mux.release(slot);
+                if (err != error.Closed and !mux.retiring) noteError(p, .write);
+            }
             mux.dead = true;
             mux.slot_free.broadcast(io);
             return false;
@@ -937,13 +999,13 @@ fn muxReceive(mux: *Mux) void {
                 resetOneSlot(mux, stream);
                 break :blk true;
             },
+            // Recorded, not sent: `flushOwed` below decides whether the
+            // writer can be had without stalling the read.
             .reply => |owed| blk: {
-                mux.write.lockUncancelable(io);
-                defer mux.write.unlock(io);
-                session.reply(owed) catch {
-                    mux.fail(.write);
-                    return;
-                };
+                switch (owed) {
+                    .settings_ack => mux.owed_settings_ack = true,
+                    .ping_ack => mux.owed_ping = owed,
+                }
                 break :blk false;
             },
             // Open streams may still finish; the sender stops opening new ones.
@@ -958,15 +1020,12 @@ fn muxReceive(mux: *Mux) void {
         };
         idle_frames = if (progressed) 0 else idle_frames + 1;
 
-        // Give the connection window back before the budget runs out. Outside
-        // the state lock, and outside the read that produced the debt.
-        if (session.windowDue()) {
-            mux.write.lockUncancelable(io);
-            defer mux.write.unlock(io);
-            session.replenishWindow() catch {
-                mux.fail(.write);
-                return;
-            };
+        // Acks the peer is waiting on, and the connection window before its
+        // budget runs out. Outside the state lock, and outside the read that
+        // produced the debt.
+        if (!mux.flushOwed()) {
+            mux.fail(.write);
+            return;
         }
     }
     mux.fail(.read);
@@ -986,8 +1045,18 @@ fn muxWatch(mux: *Mux) void {
 
     // How long to wait before re-checking with nothing on the wire. A quarter
     // of the shortest bound this watcher can be asked to enforce, so an idle
-    // stretch can never oversleep a deadline armed just after it began.
-    const bound = if (p.timeout_ns != 0) p.timeout_ns else p.deadline_ns;
+    // stretch can never oversleep a deadline armed just after it began. Taking
+    // the wire timeout alone would not do: `--timeout 30s --deadline 100ms
+    // --deadline-abort` would idle for 7.5 s and overshoot the bound it is
+    // there to hold by seventy-five times.
+    const wire_bound = p.timeout_ns;
+    const co_bound = if (p.deadline_abort) p.deadline_ns else 0;
+    const bound = if (wire_bound != 0 and co_bound != 0)
+        @min(wire_bound, co_bound)
+    else if (wire_bound != 0)
+        wire_bound
+    else
+        co_bound;
     const idle_slice_ns: u64 = @max(bound / 4, std.time.ns_per_ms);
 
     var expired: [streams_max]u31 = undefined;
@@ -1046,15 +1115,24 @@ fn muxWatch(mux: *Mux) void {
     }
 }
 
-/// Fold one frame into the stream it belongs to. Returns whether it finished a
-/// request, which is what `muxReceive`'s no-progress bound counts.
+/// Fold one frame into the stream it belongs to. Returns whether it belonged to
+/// a stream still open, which is what `muxReceive`'s no-progress bound counts.
+///
+/// Belonging, not finishing. A 16 KiB-framed response of any size is hundreds
+/// of DATA frames that end nothing, and counting only completions would make
+/// the bound scale as 1/depth: at `-s 8`, eight interleaved multi-megabyte
+/// responses reach it before any of them ends, and a healthy connection would
+/// be killed for being busy. What the bound is actually for is a peer that
+/// sends endlessly and delivers nothing — SETTINGS, PING, frames for streams
+/// long retired — and none of those land in a slot.
 fn deliverToSlot(mux: *Mux, stream: u31, status: ?u16, bytes: u64, end_stream: bool) bool {
     mux.state.lockUncancelable(mux.io);
     defer mux.state.unlock(mux.io);
     const slot = mux.find(stream) orelse return false;
     if (status) |code| {
-        // A second field block on a stream that already has a status is
-        // trailers, and trailers carry none (RFC 9113 section 8.1).
+        // Two blocks each carrying a `:status` is malformed (RFC 9113 section
+        // 8.3.2): one stream's request is lost, and only that one — the
+        // connection and every other stream on it are fine.
         if (slot.status != null) {
             mux.release(slot);
             noteError(mux.p, .read);
@@ -1063,8 +1141,7 @@ fn deliverToSlot(mux: *Mux, stream: u31, status: ?u16, bytes: u64, end_stream: b
         slot.status = code;
     }
     slot.bytes += bytes;
-    if (!end_stream) return false;
-    mux.complete(slot);
+    if (end_stream) mux.complete(slot);
     return true;
 }
 
@@ -1687,6 +1764,192 @@ test "a stalled stream is reset alone, leaving the other samples intact" {
     // `record_timeouts` is on by default, so the abandoned request is a sample
     // too; every other completion is one, and nothing else is.
     try testing.expectEqual(counters.completed + counters.timeouts, histogram.count());
+}
+
+/// An h2c server that ends every response with a trailers section.
+///
+/// Legal (RFC 9113 section 8.1) and routine — gRPC does nothing else — and the
+/// shape that used to be fatal: a second field block carries no `:status`, so
+/// decoding one as though it must have failed the whole connection and took
+/// every other in-flight stream's sample with it.
+fn h2TrailerServe(io: Io, server: *net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    disableNagle(stream);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    const reader = &r.interface;
+    const writer = &w.interface;
+    if (!h2Greet(reader, writer)) return;
+
+    var block_buf: [64]u8 = undefined;
+    const block = h2ResponseBlock(&block_buf);
+
+    var trailer_buf: [64]u8 = undefined;
+    var storage: h2.hpack.Encoder.Storage(0) = .{};
+    var encoder = storage.encoder(.static_only);
+    const encoded = encoder.encode(&trailer_buf, &.{
+        .{ .name = "grpc-status", .value = "0" },
+    });
+    const trailers = trailer_buf[0..encoded.written];
+
+    while (true) {
+        const octets = reader.take(h2.frame.Header.octets) catch return;
+        const header = h2.frame.Header.parse(octets) catch return;
+        if (header.length > 0) _ = reader.take(header.length) catch return;
+
+        switch (header.frame_type) {
+            .settings => if (!header.has(.ack)) {
+                writeTestFrame(writer, .settings, h2.frame.Flag.ack.bit(), 0, &.{}) catch return;
+                writer.flush() catch return;
+            },
+            .headers => {
+                const id = header.stream_identifier;
+                const end_headers = h2.frame.Flag.end_headers.bit();
+                writeTestFrame(writer, .headers, end_headers, id, block) catch return;
+                writeTestFrame(writer, .data, 0, id, "hi") catch return;
+                // The trailers section, ending the stream.
+                writeTestFrame(
+                    writer,
+                    .headers,
+                    end_headers | h2.frame.Flag.end_stream.bit(),
+                    id,
+                    trailers,
+                ) catch return;
+                writer.flush() catch return;
+            },
+            else => {},
+        }
+    }
+}
+
+test "a response ending in trailers completes, and takes no other stream down" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    group.async(io, h2TrailerServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    var cfg: cli.Config = .{ .http2 = true };
+    cfg.url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" };
+    const block = try httpmod.buildRequestBlock(testing.allocator, &cfg);
+    defer testing.allocator.free(block);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(200));
+    var params = muxParams(io, server_addr, block, 4, end, 50 * std.time.ns_per_ms, &stop, &histogram, &counters);
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Trailers end the stream normally: the status from the first block stands.
+    try testing.expect(counters.completed > 5);
+    try testing.expectEqual(counters.completed, counters.status_class[2]);
+    try testing.expectEqual(@as(u64, 0), counters.read_errors);
+    try testing.expectEqual(@as(u64, 0), counters.status_errors);
+    try testing.expectEqual(@as(u64, 0), counters.timeouts);
+    try testing.expectEqual(counters.completed, histogram.count());
+}
+
+/// An h2c server that answers a dozen requests and then drops the connection,
+/// serving one connection and returning.
+///
+/// Kills a connection with several streams open and the sender very likely
+/// parked inside a write, so the receiver's teardown and the sender's own error
+/// path race over the same slot. Getting that wrong takes `active` below zero
+/// (a panic under ReleaseSafe) or charges one send as two errors.
+///
+/// One connection and then return, rather than an accept loop: a coroutine
+/// parked in `accept` has to be cancelled to be joined, and a test that has to
+/// cancel its own server is a test that hangs when cancellation does not reach
+/// that far.
+fn h2DropServe(io: Io, server: *net.Server) void {
+    var stream = server.accept(io) catch return;
+    defer stream.close(io);
+    disableNagle(stream);
+    var rbuf: [16 * 1024]u8 = undefined;
+    var wbuf: [16 * 1024]u8 = undefined;
+    var r = stream.reader(io, &rbuf);
+    var w = stream.writer(io, &wbuf);
+    const reader = &r.interface;
+    const writer = &w.interface;
+    if (!h2Greet(reader, writer)) return;
+
+    var block_buf: [64]u8 = undefined;
+    const block = h2ResponseBlock(&block_buf);
+
+    var served: u32 = 0;
+    while (served < 12) {
+        const octets = reader.take(h2.frame.Header.octets) catch return;
+        const header = h2.frame.Header.parse(octets) catch return;
+        if (header.length > 0) _ = reader.take(header.length) catch return;
+        switch (header.frame_type) {
+            .settings => if (!header.has(.ack)) {
+                writeTestFrame(writer, .settings, h2.frame.Flag.ack.bit(), 0, &.{}) catch return;
+                writer.flush() catch return;
+            },
+            .headers => {
+                if (!h2Answer(writer, block, header.stream_identifier)) return;
+                served += 1;
+            },
+            else => {},
+        }
+    }
+}
+
+test "a connection dying with streams open charges each request once" {
+    var rt = try zio.Runtime.init(testing.allocator, .{});
+    defer rt.deinit();
+    const io = rt.io();
+
+    const bind_addr = try net.IpAddress.parse("127.0.0.1", 0);
+    var server = try bind_addr.listen(io, .{ .reuse_address = true });
+    const port = server.socket.address.getPort();
+    const server_addr = try net.IpAddress.parse("127.0.0.1", port);
+
+    var group: Io.Group = .init;
+    group.async(io, h2DropServe, .{ io, &server });
+
+    var histogram = try hdr.Histogram.init(testing.allocator, 1, 3_600_000_000, 3);
+    defer histogram.deinit();
+    var counters: Counters = .{};
+    var stop = std.atomic.Value(bool).init(false);
+
+    var cfg: cli.Config = .{ .http2 = true };
+    cfg.url = .{ .scheme = .http, .host = "127.0.0.1", .port = port, .target = "/" };
+    const block = try httpmod.buildRequestBlock(testing.allocator, &cfg);
+    defer testing.allocator.free(block);
+
+    const start = Io.Timestamp.now(io, .awake);
+    const end = start.addDuration(Io.Duration.fromMilliseconds(250));
+    var params = muxParams(io, server_addr, block, 8, end, 40 * std.time.ns_per_ms, &stop, &histogram, &counters);
+    run(&params);
+
+    group.await(io) catch {};
+    server.deinit(io);
+
+    // Reaching here at all is most of the assertion: releasing one slot twice
+    // takes `active` below zero, which panics under ReleaseSafe.
+    try testing.expect(counters.completed > 0);
+    try testing.expectEqual(counters.completed + counters.timeouts, histogram.count());
+    // The drop strands whatever was open, and each stranded request is charged
+    // once. More read errors than the connection could hold streams would mean
+    // the receiver and the sender both charged the same send.
+    try testing.expect(counters.read_errors <= 8);
 }
 
 test "streams leave the offered load alone" {

--- a/src/h2conn.zig
+++ b/src/h2conn.zig
@@ -113,6 +113,35 @@ comptime {
 /// — a 16 KiB-framed megabyte response is 64 DATA frames.
 const frames_per_exchange_max: u32 = 4096;
 
+/// The same bound, moved to the connection for a multiplexing caller.
+///
+/// `frames_per_exchange_max` works because a serial exchange either finishes or
+/// gives up. A receive loop that serves N streams never finishes, so what it
+/// bounds instead is frames *without progress*: an endless SETTINGS or PING
+/// flood completes no stream, and a connection that completes nothing after
+/// this many frames is not one worth measuring through.
+pub const frames_without_progress_max: u32 = frames_per_exchange_max;
+
+/// Connection-window debt at which we hand the peer its credit back.
+///
+/// `open` raises the connection window to the 31-bit maximum, which reads as
+/// "flow control off" and is what it amounts to for one response at a time. It
+/// is not: the window is a budget for the connection's *whole life*, and every
+/// DATA octet spends it. One reader taking one response at a time still spends
+/// it — just slowly enough that a short run finishes first — and N streams
+/// share the same budget. Replenishing at half keeps a WINDOW_UPDATE off the
+/// hot path (one per gibibyte) while making the budget genuinely unbounded.
+const window_replenish_at: u32 = window_max / 2;
+
+/// Section 6.7: a PING payload is eight octets.
+const ping_octets: usize = 8;
+
+/// Section 6.5.2's default for `SETTINGS_MAX_CONCURRENT_STREAMS`: no limit
+/// until the peer sends one. Sentinel rather than an optional because every
+/// caller wants the number, and "unlimited" is a number here — no run opens
+/// four billion streams on one connection.
+pub const concurrent_streams_unlimited: u32 = std.math.maxInt(u32);
+
 pub const Error = error{
     /// The peer spoke something that is not HTTP/2, or broke a rule this client
     /// is unwilling to continue past.
@@ -124,6 +153,38 @@ pub const Error = error{
     TooLarge,
     /// The transport failed.
     Io,
+};
+
+/// What one received frame means to a caller. See `Session.receive`.
+///
+/// Deliberately per-frame and per-stream rather than per-response: once several
+/// streams are open, "the response" is not something the connection layer can
+/// return — which stream belongs to which request is the caller's bookkeeping.
+/// What stays behind this seam is everything that needs connection-scoped state
+/// to decide: field-block assembly, HPACK, the peer's settings, flow control.
+pub const Incoming = union(enum) {
+    /// A complete field block ended on `stream`, carrying this `:status`.
+    /// `bytes` is the block's own size, counted like any other response octets.
+    headers: struct { stream: u31, status: u16, bytes: u64, end_stream: bool },
+    /// DATA arrived on `stream`.
+    data: struct { stream: u31, bytes: u64, end_stream: bool },
+    /// The peer reset `stream` (section 6.4). That stream is over; the
+    /// connection is not.
+    reset: u31,
+    /// The peer is owed an answer. Sent with `Session.reply` by whoever holds
+    /// the writer.
+    reply: Reply,
+    /// GOAWAY: no new stream may be opened. Open streams may still finish.
+    going_away,
+    /// Nothing a caller can act on — a field-block fragment mid-assembly, or a
+    /// frame the RFC says to ignore.
+    idle,
+};
+
+/// An answer the peer is owed, deferred to whoever owns the writer.
+pub const Reply = union(enum) {
+    settings_ack,
+    ping_ack: [ping_octets]u8,
 };
 
 /// Per-connection state, pinned by the caller for the connection's lifetime.
@@ -143,9 +204,38 @@ pub const Session = struct {
     /// Section 6.5.2's default until the peer says otherwise.
     peer_max_frame_size: u32 = frame.Header.max_frame_size_min,
 
+    /// The peer's `SETTINGS_MAX_CONCURRENT_STREAMS`. A multiplexing client has
+    /// to honour it — the effective depth is `min(--streams, this)` — and
+    /// ignoring it is not harmless: the surplus does not fail, it queues, and a
+    /// client that thinks it has N in flight while the peer allows ten is
+    /// measuring a queue it cannot see. (h2load ignores it; see
+    /// docs/multiplexing.md.)
+    peer_max_concurrent_streams: u32 = concurrent_streams_unlimited,
+
     /// Set when the peer has sent GOAWAY. The exchange in flight may still
     /// complete; no new stream may be opened.
     peer_going_away: bool = false,
+
+    /// DATA octets received since the last connection-level `WINDOW_UPDATE`.
+    /// See `window_replenish_at`.
+    window_debt: u32 = 0,
+
+    /// Field-block assembly and HPACK decoding, both connection-scoped.
+    ///
+    /// Per-connection rather than per-response because that is what the RFC
+    /// makes them. Section 6.10 forbids any frame between a HEADERS and its
+    /// CONTINUATIONs, on any stream, so at most one block is ever in flight and
+    /// one assembler serves every stream. The decoder's dynamic table is
+    /// per-connection by definition — ours is empty, since we advertise
+    /// `SETTINGS_HEADER_TABLE_SIZE = 0`, which is what lets it be sized zero
+    /// rather than what lets it be per-response.
+    ///
+    /// Both point into this struct's own buffers, so they are established by
+    /// `open` (where the session is pinned) rather than by `init` (which
+    /// returns by value and would hand back dangling pointers).
+    assembler: frame.BlockAssembler = undefined,
+    decoder: hpack.Decoder = undefined,
+    table_storage: hpack.DynamicTable.Storage(0) = .{},
 
     assembler_buffer: [block_buffer_size]u8 = undefined,
     field_buffer: [field_buffer_size]u8 = undefined,
@@ -166,6 +256,14 @@ pub const Session = struct {
     /// until it has seen one SETTINGS from the peer, acknowledging it, which is
     /// the first thing any conforming server sends.
     pub fn open(session: *Session) Error!void {
+        // The session is pinned from here on, so the two buffer-borrowing
+        // pieces of state can finally be built. See their declarations.
+        session.assembler = .init(
+            &session.assembler_buffer,
+            frame.BlockAssembler.frames_max_default,
+        );
+        session.decoder = .init(session.table_storage.table(), header_list_max);
+
         session.writer.writeAll(preface) catch return error.Io;
         try session.writeSettings();
         // Raise the connection-level window as far as it goes. `SETTINGS`
@@ -185,7 +283,7 @@ pub const Session = struct {
                 session.writer.flush() catch return error.Io;
                 return;
             }
-            try session.handleConnectionFrame(header);
+            try session.answer(try session.classify(header));
         }
         return error.Protocol;
     }
@@ -199,6 +297,17 @@ pub const Session = struct {
     /// replayed byte-identically on every stream. That guarantee is why this
     /// function takes bytes rather than fields.
     pub fn exchange(session: *Session, block: []const u8, body: []const u8) Error!httpmod.Response {
+        return session.readResponse(try session.beginStream(block, body));
+    }
+
+    /// Open one stream and send the request on it, without waiting for the
+    /// response. Returns the stream identifier the answer will arrive on.
+    ///
+    /// Split out of `exchange` for the multiplexing caller, which has to be
+    /// able to send while earlier streams are still open. Writes and flushes,
+    /// so a caller sharing the writer with a receive loop holds its write lock
+    /// across this.
+    pub fn beginStream(session: *Session, block: []const u8, body: []const u8) Error!u31 {
         if (session.peer_going_away) return error.Closed;
 
         const stream = session.next_stream;
@@ -212,72 +321,184 @@ pub const Session = struct {
         try session.writeHeaders(stream, block, body.len == 0);
         if (body.len > 0) try session.writeData(stream, body);
         session.writer.flush() catch return error.Io;
+        return stream;
+    }
 
-        return session.readResponse(stream);
+    /// The identifier `beginStream` will use next.
+    ///
+    /// For a caller that must publish a stream in its own bookkeeping *before*
+    /// the HEADERS is on the wire: without it there is a window in which the
+    /// response arrives for a stream nobody has claimed, and its latency sample
+    /// is lost. Valid only while the caller holds whatever serializes
+    /// `beginStream`.
+    pub fn peekStream(session: *const Session) u31 {
+        return session.next_stream;
+    }
+
+    /// Abandon one stream without touching the connection (section 6.4).
+    ///
+    /// This is the whole of what multiplexing changes about aborting a request.
+    /// With one stream open, "abort this request" and "abort this connection"
+    /// are the same act, and `connection.zig` implements the first as the
+    /// second by shutting the socket down. With N open, that would take N − 1
+    /// innocent latency samples with it, so a timeout has to be spent here
+    /// instead.
+    pub fn resetStream(session: *Session, stream: u31) Error!void {
+        var payload: [4]u8 = undefined;
+        std.mem.writeInt(u32, &payload, @intFromEnum(frame.ErrorCode.cancel), .big);
+        try session.writeFrame(.rst_stream, 0, stream, &payload);
+        session.writer.flush() catch return error.Io;
+    }
+
+    /// Read one frame and say what it means, without writing anything.
+    ///
+    /// The no-writing part is the point: a multiplexing caller reads on one
+    /// coroutine and sends on another, so a frame the peer is owed an answer to
+    /// comes back as `Incoming.reply` for the caller to send once it holds the
+    /// write lock, rather than being answered from under a blocking read.
+    pub fn receive(session: *Session) Error!Incoming {
+        return session.classify(try session.readHeader());
+    }
+
+    /// Send an answer `receive` reported as owed.
+    pub fn reply(session: *Session, owed: Reply) Error!void {
+        switch (owed) {
+            // Section 6.5.3: acknowledged whether or not we act on it.
+            .settings_ack => try session.writeFrame(.settings, frame.Flag.ack.bit(), 0, &.{}),
+            // Section 6.7: a PING we did not send must be echoed with ACK.
+            .ping_ack => |data| try session.writeFrame(.ping, frame.Flag.ack.bit(), 0, &data),
+        }
+        session.writer.flush() catch return error.Io;
+    }
+
+    /// Whether enough DATA has arrived to be worth giving the connection window
+    /// back. See `window_replenish_at`.
+    pub fn windowDue(session: *const Session) bool {
+        return session.window_debt >= window_replenish_at;
+    }
+
+    /// Credit the peer with every DATA octet consumed since the last call.
+    /// Writes, so the same write-lock rule as `beginStream` applies.
+    pub fn replenishWindow(session: *Session) Error!void {
+        const debt = session.window_debt;
+        if (debt == 0) return;
+        session.window_debt = 0;
+        try session.writeWindowUpdate(0, debt);
+        session.writer.flush() catch return error.Io;
+    }
+
+    /// Perform whatever `incoming` obliges us to, for a caller that owns the
+    /// writer outright. The single-threaded paths — `open`, `readResponse` —
+    /// answer inline; a multiplexing caller takes its write lock instead.
+    fn answer(session: *Session, incoming: Incoming) Error!void {
+        switch (incoming) {
+            .reply => |owed| try session.reply(owed),
+            else => {},
+        }
     }
 
     /// Read frames until `stream` carries END_STREAM, handling everything else
     /// the connection may interleave.
+    ///
+    /// The serial half of the client: one stream is open, so every frame naming
+    /// another stream is a late one from a stream already finished, and
+    /// ignorable rather than fatal.
     fn readResponse(session: *Session, stream: u31) Error!httpmod.Response {
-        var assembler: frame.BlockAssembler = .init(
-            &session.assembler_buffer,
-            frame.BlockAssembler.frames_max_default,
-        );
-        // `SETTINGS_HEADER_TABLE_SIZE = 0` is what makes this correct with no
-        // arena: we forbade the peer the dynamic table, so a decoder with an
-        // empty one is not a shortcut, it is the configuration we advertised.
-        // A peer that indexes into it anyway gets a decode error, which is the
-        // right answer.
-        var table_storage: hpack.DynamicTable.Storage(0) = .{};
-        var decoder: hpack.Decoder = .init(table_storage.table(), header_list_max);
-
         var status: ?u16 = null;
         var bytes: u64 = 0;
         var frames: u32 = 0;
 
         while (frames < frames_per_exchange_max) : (frames += 1) {
-            const header = try session.readHeader();
-
-            // Another stream's frame, or a connection-level one. With one
-            // request in flight the only streams that can appear are this one
-            // and ones we have already finished, whose late frames are
-            // ignorable rather than fatal.
-            if (header.stream_identifier != stream) {
-                try session.handleConnectionFrame(header);
-                continue;
-            }
-
-            const payload_bytes = try session.readPayload(header);
-            const payload = frame.payload.parse(header, payload_bytes) catch return error.Protocol;
-
-            // The CONTINUATION state machine's refusals are all reasons to stop
-            // using this connection: an interleaved frame or an unbounded block
-            // means the peer is not framing the way section 6.10 requires.
-            const accepted = assembler.accept(header, &payload) catch return error.Protocol;
-            switch (accepted) {
-                .fragment => continue,
-                .block => |complete| {
+            if (session.windowDue()) try session.replenishWindow();
+            switch (try session.receive()) {
+                .headers => |head| {
+                    if (head.stream != stream) continue;
                     if (status != null) return error.Protocol; // trailers carry no status
-                    status = try decodeStatus(&decoder, &session.field_buffer, complete.fragment);
-                    bytes += complete.fragment.len;
-                    if (complete.end_stream) return finish(status, bytes);
-                    continue;
+                    status = head.status;
+                    bytes += head.bytes;
+                    if (head.end_stream) return finish(status, bytes);
                 },
-                .passthrough => {},
-            }
-
-            switch (payload) {
                 .data => |data| {
-                    bytes += data.data.len;
-                    // Consumed the moment it arrives, so the window we opened in
-                    // `open` is the only flow control this client needs.
-                    if (header.has(.end_stream)) return finish(status, bytes);
+                    if (data.stream != stream) continue;
+                    bytes += data.bytes;
+                    if (data.end_stream) return finish(status, bytes);
                 },
-                .rst_stream => return error.Closed,
-                else => return error.Protocol,
+                .reset => |reset| if (reset == stream) return error.Closed,
+                .reply => |owed| try session.reply(owed),
+                // Recorded on the session; the exchange in flight may finish.
+                .going_away, .idle => {},
             }
         }
         return error.Protocol;
+    }
+
+    /// What one frame means, once the connection-scoped state — field-block
+    /// assembly, HPACK, the peer's settings, the flow-control debt — has had
+    /// its say. Reads the payload; writes nothing.
+    fn classify(session: *Session, header: frame.Header) Error!Incoming {
+        const payload_bytes = try session.readPayload(header);
+        const payload = frame.payload.parse(header, payload_bytes) catch return error.Protocol;
+
+        // Before the assembler, which would otherwise assemble a PUSH_PROMISE's
+        // field block as if it were a response. We advertised
+        // `SETTINGS_ENABLE_PUSH = 0`; section 8.4 makes one a connection error,
+        // and there is no honest latency sample for a stream nobody scheduled.
+        if (payload == .push_promise) return error.Protocol;
+
+        // The CONTINUATION state machine's refusals are all reasons to stop
+        // using this connection: an interleaved frame or an unbounded block
+        // means the peer is not framing the way section 6.10 requires.
+        const accepted = session.assembler.accept(header, &payload) catch return error.Protocol;
+        switch (accepted) {
+            .fragment => return .idle,
+            .block => |complete| return .{ .headers = .{
+                .stream = header.stream_identifier,
+                .status = try decodeStatus(&session.decoder, &session.field_buffer, complete.fragment),
+                .bytes = complete.fragment.len,
+                .end_stream = complete.end_stream,
+            } },
+            .passthrough => {},
+        }
+
+        switch (payload) {
+            .data => |data| {
+                // Consumed the moment it arrives — this client never stalls a
+                // reader — so the only flow control left is giving the
+                // connection window back before the budget runs out.
+                session.window_debt +|= @intCast(data.data.len);
+                return .{ .data = .{
+                    .stream = header.stream_identifier,
+                    .bytes = data.data.len,
+                    .end_stream = header.has(.end_stream),
+                } };
+            },
+            .rst_stream => return .{ .reset = header.stream_identifier },
+            // Section 6.5: take what we are told, and acknowledge.
+            .settings => {
+                if (header.has(.ack)) return .idle;
+                try session.takeSettings(payload);
+                return .{ .reply = .settings_ack };
+            },
+            .ping => |ping| {
+                if (header.has(.ack)) return .idle;
+                return .{ .reply = .{ .ping_ack = ping.opaque_data.* } };
+            },
+            // Section 6.8: no new stream after this. Streams already open may
+            // still finish, so this is recorded rather than raised.
+            .goaway => {
+                session.peer_going_away = true;
+                return .going_away;
+            },
+            // Window updates only matter to a sender, and the only thing this
+            // client sends is a request block. Ignorable rather than tracked.
+            .window_update => return .idle,
+            // Section 5.3.1 allows PRIORITY on any stream at any time, and
+            // section 4.1 says to skip an unknown type by its length — which
+            // the payload read already did.
+            .priority, .unknown => return .idle,
+            // Rejected above; field-block frames never reach here.
+            .push_promise, .headers, .continuation => return .idle,
+        }
     }
 
     fn readHeader(session: *Session) Error!frame.Header {
@@ -286,43 +507,6 @@ pub const Session = struct {
 
     fn readPayload(session: *Session, header: frame.Header) Error![]const u8 {
         return readPayloadImpl(session, header);
-    }
-
-    /// Everything that is not this exchange's stream.
-    ///
-    /// A load generator has to answer only three of these. The rest are either
-    /// ignorable by the RFC or a reason to stop using the connection, and
-    /// saying which is which in one place is what keeps `readResponse` about
-    /// the response.
-    fn handleConnectionFrame(session: *Session, header: frame.Header) Error!void {
-        const payload_bytes = try session.readPayload(header);
-        const payload = frame.payload.parse(header, payload_bytes) catch return error.Protocol;
-        switch (payload) {
-            // Section 6.5: acknowledge, and take what we are told.
-            .settings => if (!header.has(.ack)) {
-                try session.applySettingsPayload(payload);
-                session.writer.flush() catch return error.Io;
-            },
-            // Section 6.7: a PING we did not send must be echoed with ACK.
-            .ping => |ping| if (!header.has(.ack)) {
-                try session.writeFrame(.ping, frame.Flag.ack.bit(), 0, ping.opaque_data);
-                session.writer.flush() catch return error.Io;
-            },
-            // Section 6.8: no new stream after this. The exchange in flight may
-            // still finish, so this is recorded rather than raised.
-            .goaway => session.peer_going_away = true,
-            // We advertised `SETTINGS_ENABLE_PUSH = 0`; section 8.4 makes a
-            // PUSH_PROMISE after that a connection error, and there is no
-            // honest latency sample for a stream nobody scheduled.
-            .push_promise => return error.Protocol,
-            // Window updates only matter to a sender, and this client sends a
-            // request block and nothing more. Ignorable rather than tracked.
-            .window_update => {},
-            // A stream we already finished, ending late.
-            .rst_stream, .data, .headers, .continuation => {},
-            .priority => {},
-            .unknown => {}, // Section 4.1: skip by length, which the read did.
-        }
     }
 
     fn writeSettings(session: *Session) Error!void {
@@ -347,17 +531,20 @@ pub const Session = struct {
     fn applySettings(session: *Session, header: frame.Header) Error!void {
         const payload_bytes = try session.readPayload(header);
         const payload = frame.payload.parse(header, payload_bytes) catch return error.Protocol;
-        try session.applySettingsPayload(payload);
+        try session.takeSettings(payload);
+        try session.reply(.settings_ack);
     }
 
-    /// Take the peer's settings, and acknowledge them.
+    /// Take the peer's settings. Acknowledging them is the caller's, via
+    /// `Incoming.reply` — see `receive` for why that is not done here.
     ///
-    /// Only `SETTINGS_MAX_FRAME_SIZE` changes what this client does — it bounds
-    /// what we may send, and our one send is a header block that could exceed
-    /// the default if a caller passes enough `-H`. The rest describe limits on
-    /// a sender we are not: we open one stream at a time and send no body large
-    /// enough to meet a window.
-    fn applySettingsPayload(session: *Session, payload: frame.Payload) Error!void {
+    /// Two of them change what this client does. `SETTINGS_MAX_FRAME_SIZE`
+    /// bounds what we may send, and our send is a header block that could
+    /// exceed the default if a caller passes enough `-H`.
+    /// `SETTINGS_MAX_CONCURRENT_STREAMS` bounds how many streams `--streams`
+    /// may actually open. The rest describe limits on a sender we are not: we
+    /// send no body large enough to meet a window.
+    fn takeSettings(session: *Session, payload: frame.Payload) Error!void {
         var entries = payload.settings.iterate();
         while (entries.next()) |entry| {
             // Section 6.5.2: an identifier we do not know must be ignored, not
@@ -368,13 +555,13 @@ pub const Session = struct {
                     if (entry.value > frame.Header.max_frame_size_max) return error.Protocol;
                     session.peer_max_frame_size = entry.value;
                 },
+                .max_concurrent_streams => session.peer_max_concurrent_streams = entry.value,
                 // Section 6.5.3: acknowledged whether or not we act on it, and
                 // section 6.5.2 requires an unrecognized identifier to be
                 // ignored rather than refused.
                 else => {},
             }
         }
-        try session.writeFrame(.settings, frame.Flag.ack.bit(), 0, &.{});
     }
 
     fn writeWindowUpdate(session: *Session, stream: u31, increment: u32) Error!void {

--- a/src/h2conn.zig
+++ b/src/h2conn.zig
@@ -163,9 +163,12 @@ pub const Error = error{
 /// What stays behind this seam is everything that needs connection-scoped state
 /// to decide: field-block assembly, HPACK, the peer's settings, flow control.
 pub const Incoming = union(enum) {
-    /// A complete field block ended on `stream`, carrying this `:status`.
-    /// `bytes` is the block's own size, counted like any other response octets.
-    headers: struct { stream: u31, status: u16, bytes: u64, end_stream: bool },
+    /// A complete field block ended on `stream`. `status` is its `:status`, or
+    /// null for a block that carries none — a trailers section (RFC 9113
+    /// section 8.1), which is legal and routine for gRPC and for any response
+    /// declaring `Trailer`. `bytes` is the block's own size, counted like any
+    /// other response octets.
+    headers: struct { stream: u31, status: ?u16, bytes: u64, end_stream: bool },
     /// DATA arrived on `stream`.
     data: struct { stream: u31, bytes: u64, end_stream: bool },
     /// The peer reset `stream` (section 6.4). That stream is over; the
@@ -413,8 +416,13 @@ pub const Session = struct {
             switch (try session.receive()) {
                 .headers => |head| {
                     if (head.stream != stream) continue;
-                    if (status != null) return error.Protocol; // trailers carry no status
-                    status = head.status;
+                    if (head.status) |code| {
+                        // Two blocks each carrying a `:status` is malformed
+                        // (RFC 9113 section 8.3.2). A second block *without*
+                        // one is trailers, and just adds its octets.
+                        if (status != null) return error.Protocol;
+                        status = code;
+                    }
                     bytes += head.bytes;
                     if (head.end_stream) return finish(status, bytes);
                 },
@@ -658,11 +666,16 @@ fn finish(status: ?u16, bytes: u64) Error!httpmod.Response {
 /// Pull one field block's `:status` out, and check the rest is a well-formed
 /// response while we are already walking it.
 ///
+/// Null when the block has no `:status`. That is not an error here: a response
+/// may end with a trailers section, which carries no pseudo-headers at all.
+/// Whether a *first* block without one is malformed is the caller's to decide,
+/// and `finish` is where it is decided.
+///
 /// The validation is not ceremony: `h2.fields` is the package's answer to RFC
 /// 9113 section 8.2, and a load generator that reported a 200 for a response
 /// carrying a CR in a header value would be reporting a success the target
 /// should have been failed for.
-fn decodeStatus(decoder: *hpack.Decoder, buffer: []u8, block: []const u8) Error!u16 {
+fn decodeStatus(decoder: *hpack.Decoder, buffer: []u8, block: []const u8) Error!?u16 {
     var validator: h2.fields.MessageValidator = .init(.{
         .kind = .response,
         // The floor of section 8.2.1 rather than RFC 9110's full grammar. zrk
@@ -681,8 +694,14 @@ fn decodeStatus(decoder: *hpack.Decoder, buffer: []u8, block: []const u8) Error!
         if (status != null) return error.Protocol;
         status = std.fmt.parseInt(u16, field.value, 10) catch return error.Protocol;
     }
+    // No `:status` means this is a trailer section (section 8.3), and the
+    // response validator's one closing rule is that a response must have one.
+    // Every per-field rule it applied above holds for a trailer section too —
+    // section 8.3 constrains it further, not less — so stopping short of
+    // `finish` here validates exactly what `Kind.trailer` would.
+    if (status == null) return null;
     validator.finish() catch return error.Protocol;
-    return status orelse error.Protocol;
+    return status;
 }
 
 /// Read the nine octets of a frame header and check what they alone decide.

--- a/src/main.zig
+++ b/src/main.zig
@@ -423,6 +423,9 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.ClosedWithRamp => "zrk: --closed is incompatible with a ramp (-R A:B)\n\n",
         error.ClosedWithDeadline => "zrk: --closed is incompatible with --deadline\n\n",
         error.KeepaliveWithHttp2 => "zrk: --disable-keepalive is incompatible with --http2\n\n",
+        error.ZeroStreams => "zrk: streams (-s) must be greater than 0\n\n",
+        error.StreamsWithoutHttp2 => "zrk: streams (-s) requires --http2; HTTP/1.1 has no second stream to open\n\n",
+        error.TooManyStreams => "zrk: streams (-s) exceeds the per-connection maximum\n\n",
         error.OutOfMemory => "zrk: out of memory\n\n",
     };
     try writeAll(io, .stderr(), msg);

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -158,6 +158,7 @@ pub fn run(
         .request_block = request_block,
         .body = cfg.body,
         .http2 = cfg.http2,
+        .streams = cfg.streams,
         .method = .of(cfg.method),
         .is_tls = cfg.url.isTls(),
         .insecure = cfg.insecure,


### PR DESCRIPTION
Closes #50, on the semantics [docs/multiplexing.md](docs/multiplexing.md) settled first (landed separately in c4d2d2b): **`-c` does not change meaning, `-s` is a depth knob.** `-R` still splits across `-c` connections, each connection keeps one schedule and one `send_index`, and `-s` only bounds how many of that connection's *already-scheduled* sends may be on the wire at once. `-s 1` is the pre-multiplexing behaviour down to which code path runs, and is the default.

## Why the serial loop couldn't carry it

`performWork` blocks until the response lands, so it cannot pace a send while one is outstanding, and one connection-wide `Watchdog` cannot time N requests that began at N different moments.

Above `--streams 1` a connection runs three coroutines — the sender on the connection's own coroutine, a receiver that owns the reader, a watchdog that owns per-stream deadlines — over a slot table on the connection's frame, so a connection stays allocation-free for its whole life. Two mutexes, never nested the other way: one for state (and the counters and histogram, which stop being the sender's private property once the receiver is what knows a request finished), one for the writer. A stream is published in the table *before* its HEADERS is written, so a response can never arrive for a stream nobody has claimed.

`h2conn` stops assuming one stream: `receive()` reads a frame and says what it means without writing, deferring SETTINGS and PING acks to whoever holds the write lock; field-block assembly and HPACK move to the connection, which is what RFC 9113 §6.10 makes them. The serial `readResponse` is rebuilt on the same primitives, so both paths speak one implementation.

## The issue's gates

- **A timeout on one stream is `RST_STREAM` on that stream**, not a socket shutdown that would take N−1 innocent samples with it. Tested against a server that holds one stream open forever and answers every other: one timeout, one `RST_STREAM` observed server-side, zero connection errors, and the rest of the samples still arriving after it. `--deadline-abort` inherits this and improves — a reset per miss instead of a reconnect per miss.
- **`SETTINGS_MAX_CONCURRENT_STREAMS` is honoured**; effective depth is `min(-s, peer)`. h2load ignores it, and the surplus does not fail, it *queues* — so a client that believes it has N in flight against a peer allowing ten is timing its own queue.
- **The connection receive window is credited back at half** rather than opened once to the 31-bit maximum and forgotten. That window is a budget for the whole connection, not per response; N streams share it.
- **`frames_per_exchange_max` becomes a no-progress bound** on the receive loop, since a loop serving N streams never finishes.
- **`completed == histogram.count()` still holds**, asserted in every new test.

## TCP_NODELAY

Not incidental. Nagle holds a small write until the previous one is acknowledged, and Linux delays that acknowledgement by up to 40 ms. Serially the two barely meet — nothing of ours is unacknowledged when the next request is written, because the response that acknowledged it is what released the send. Multiplexing makes them meet by design, and Nagle answers by parking the request until a delayed-ACK timer fires: 40 ms of the client's own transport, charged to the target. It surfaced as the last response of every run arriving exactly 40 ms late, which is the one disguise that makes a TCP problem look like a scheduling one.

## Are `-c 10 -s 10` and `-c 100` comparable? No — measured

Against `nghttpd` on loopback, closed loop, 5 s each:

| layout | in flight | req/s | p50 | p99 |
| --- | ---: | ---: | ---: | ---: |
| `-c 10 -s 1` | 10 | 250,990 | 38 µs | 67 µs |
| `-c 10 -s 10` | 100 | 524,942 | 165 µs | 235 µs |
| `-c 100 -s 1` | 100 | 186,608 | 522 µs | 1.04 ms |
| `-c 100 -s 10` | 1000 | 433,818 | 2.21 ms | 3.77 ms |

The two layouts that both hold 100 requests in flight are **2.8× apart on throughput and 3.2× apart on p50**. h2load splits the same way on the same server (857k req/s at `-c 10 -m 10` against 285k at `-c 100 -m 1`), so it is the layout, not the tool. The table is in `docs/multiplexing.md` next to the flag rather than in an issue nobody reads, and it is why `-c` stays the number to compare across runs.

## Verification

`zig build test` (291 tests, three consecutive runs), `zig build bench`, and `zig fmt --check` all pass. `-c 8 -s 128` holds 50k req/s against nghttpd at p50 26 µs with no errors.

**Not covered:** no TLS/ALPN multiplexed run; no server advertising a low `SETTINGS_MAX_CONCURRENT_STREAMS`, so the clamp is exercised by construction rather than observation; and no slow-server test — concurrency is proven structurally (a lockstep server that deadlocks at depth 1) rather than by timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)