### PR TITLE
feat: prototype HTTP/3 over QUIC behind --http3 (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,17 @@ number from it:
   than letting a run believe otherwise. QUIC needs a TLS engine that speaks RFC
   9001's handshake rather than a record layer, and zssl declines QUIC, so this
   path uses its own small client (`src/quic_tls.zig`) which parses the
-  certificate chain only far enough to keep the transcript honest. Closing that
-  is bounded, known work, and the file says exactly what is missing.
-- **One datagram per syscall.** No GSO/GRO batching yet, which is the thing
-  [#74](https://github.com/zoxy-io/zrk/issues/74) names as deciding whether an
-  HTTP/3 load generator can saturate a link. `std.Io.net.Socket` already
-  exposes the batched calls and zio implements them, so this is measurement
-  work rather than plumbing.
+  certificate chain only far enough to keep the transcript honest. Deliberate
+  rather than pending: a load generator is pointed at a target its operator
+  chose. HTTP/1.1 and HTTP/2 still verify by default, and `-k` there is still
+  opt-in, so the case where that is not enough is covered on the transports
+  that can cover it.
+- **One datagram per syscall**, which bounds throughput per core and nothing
+  else. [#76](https://github.com/zoxy-io/zrk/issues/76) is the work, and it is
+  larger than the API surface suggests: `std.Io.net.Socket` has `sendMany` and
+  `receiveManyTimeout`, but zio implements the first as a loop over `sendmsg`
+  and the second one `recvmsg` at a time, and nothing in the stack exposes
+  `UDP_SEGMENT` or `UDP_GRO`. The batched API is there; the batching is not.
 
 Everything else carries over: `--closed`, ramps, `--timeseries`, the JSON
 summary and the CI gates all work unchanged.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
 ([#74](https://github.com/zoxy-io/zrk/issues/74)). It works, and the latency it
 reports means what every other transport's does — the coordinated-omission
 correction, `--deadline` shedding and the backlog gauge are the same code
-reading the same clock — but three things are worth knowing before quoting a
+reading the same clock — but two things are worth knowing before quoting a
 number from it:
 
 - **It does not verify certificates**, so it requires `-k/--insecure` rather
@@ -187,13 +187,6 @@ number from it:
   path uses its own small client (`src/quic_tls.zig`) which parses the
   certificate chain only far enough to keep the transcript honest. Closing that
   is bounded, known work, and the file says exactly what is missing.
-- **`--streams` needs h3 at or past the acknowledgement-report fix.** Soaking
-  this path found a defect upstream that stranded streams once the congestion
-  window grew — a multiplexed connection ran at full rate for about a second and
-  then went to zero req/s with no errors. It is fixed; `src/h3conn.zig`'s module
-  comment has the diagnosis, and against a fixed h3 a `-c 16 -s 16 --closed`
-  soak runs 296,866 requests at 14.8k req/s with no errors where it previously
-  managed 1,642.
 - **One datagram per syscall.** No GSO/GRO batching yet, which is the thing
   [#74](https://github.com/zoxy-io/zrk/issues/74) names as deciding whether an
   HTTP/3 load generator can saturate a link. `std.Io.net.Socket` already
@@ -202,6 +195,15 @@ number from it:
 
 Everything else carries over: `--closed`, ramps, `--timeseries`, the JSON
 summary and the CI gates all work unchanged.
+
+`--streams` works here as it does under `--http2`, and getting it there found a
+defect in h3: a multiplexed connection ran at full rate for about a second and
+then went to zero req/s, reporting no errors, because acknowledged packet
+contexts were truncated at thirty-two and the streams past that were never
+settled. It is fixed, and `build.zig.zon` pins the commit that fixes it —
+`src/h3conn.zig`'s module comment has the diagnosis. A `-c 16 -s 16 --closed`
+soak now runs 296,866 requests at 14.8k req/s where it previously managed
+1,642 before stalling.
 
 ### Exit codes
 

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Usage: zrk [options] <url>
 Options:
   -t, --threads     <N>     Total number of threads to execute load (default 2)
   -c, --connections <N>     Total connections to keep open (default 10)
-  -s, --streams     <N>     HTTP/2 streams in flight per connection
-                            (default 1). A depth knob only: -R still
-                            splits across -c, so -c 10 -s 10 offers the
-                            same rate as -c 10, not as -c 100. Requires
-                            --http2
+  -s, --streams     <N>     HTTP/2 or HTTP/3 streams in flight per
+                            connection (default 1). A depth knob only:
+                            -R still splits across -c, so -c 10 -s 10
+                            offers the same rate as -c 10, not as
+                            -c 100. Requires --http2 or --http3
   -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
   -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
                             linearly from A to B over the run (default 1000)
@@ -98,6 +98,9 @@ Options:
       --http2               Speak HTTP/2. Cleartext uses prior knowledge
                             (h2c); https negotiates it over ALPN and
                             fails the connection if the server declines
+      --http3               Speak HTTP/3 over QUIC (https only).
+                            Prototype: the QUIC TLS engine does not
+                            verify certificates yet, so it requires -k
   -k, --insecure            Skip TLS certificate verification
       --plain               Append-only output instead of a live dashboard
 
@@ -149,6 +152,9 @@ zrk -c20 -d1m -R500 --latency https://api.example.com/health
 zrk -c10 -R100 -m POST -b '{"ping":1}' \
     -H 'Content-Type: application/json' http://127.0.0.1:8080/echo
 
+# HTTP/3 over QUIC (prototype — see "HTTP/3" below for what that costs you)
+zrk --http3 -k -c10 -R500 -d30s https://127.0.0.1:4433/
+
 # CI-friendly, no redrawing dashboard
 zrk -c50 -R1000 -d20s --plain http://127.0.0.1:8080/ | tee run.log
 
@@ -164,6 +170,38 @@ zrk -c50 -R1000 -d20s --format json -o result.json \
 zrk -c50 -R1000 -d5m --timeseries - http://127.0.0.1:8080/ \
   | jplot achieved_rate+target_rate latency_us.p50+latency_us.p90+latency_us.p99 error_rate
 ```
+
+### HTTP/3
+
+`--http3` speaks HTTP/3 over QUIC through
+[h3](https://github.com/zoxy-io/h3), and is a **prototype**
+([#74](https://github.com/zoxy-io/zrk/issues/74)). It works, and the latency it
+reports means what every other transport's does — the coordinated-omission
+correction, `--deadline` shedding and the backlog gauge are the same code
+reading the same clock — but three things are worth knowing before quoting a
+number from it:
+
+- **It does not verify certificates**, so it requires `-k/--insecure` rather
+  than letting a run believe otherwise. QUIC needs a TLS engine that speaks RFC
+  9001's handshake rather than a record layer, and zssl declines QUIC, so this
+  path uses its own small client (`src/quic_tls.zig`) which parses the
+  certificate chain only far enough to keep the transcript honest. Closing that
+  is bounded, known work, and the file says exactly what is missing.
+- **`--streams` needs h3 at or past the acknowledgement-report fix.** Soaking
+  this path found a defect upstream that stranded streams once the congestion
+  window grew — a multiplexed connection ran at full rate for about a second and
+  then went to zero req/s with no errors. It is fixed; `src/h3conn.zig`'s module
+  comment has the diagnosis, and against a fixed h3 a `-c 16 -s 16 --closed`
+  soak runs 296,866 requests at 14.8k req/s with no errors where it previously
+  managed 1,642.
+- **One datagram per syscall.** No GSO/GRO batching yet, which is the thing
+  [#74](https://github.com/zoxy-io/zrk/issues/74) names as deciding whether an
+  HTTP/3 load generator can saturate a link. `std.Io.net.Socket` already
+  exposes the batched calls and zio implements them, so this is measurement
+  work rather than plumbing.
+
+Everything else carries over: `--closed`, ramps, `--timeseries`, the JSON
+summary and the CI gates all work unchanged.
 
 ### Exit codes
 

--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,16 @@ pub fn build(b: *std.Build) void {
     });
     const zssl_module = zssl.module("zssl");
 
+    // QUIC, QPACK and HTTP/3. `assertions = false` for the same reason h2 gets
+    // it above: h3's checks are on by default because zoxy points that code at
+    // the open internet, and zrk is a latency-measuring tool whose pitch is not
+    // injecting client-side noise into the measurement.
+    const h3 = b.dependency("h3", .{
+        .target = target,
+        .optimize = optimize,
+        .assertions = false,
+    });
+
     // Hung off each runnable artifact below rather than off the dependency,
     // so `zig build check` keeps working without a C toolchain.
     const libc_guard = nativeLibcGuard(b, target);
@@ -108,6 +118,7 @@ pub fn build(b: *std.Build) void {
             .{ .name = "h2", .module = h2.module("h2") },
             .{ .name = "zurl", .module = zurl.module("zurl") },
             .{ .name = "zssl", .module = zssl_module },
+            .{ .name = "h3", .module = h3.module("h3") },
         },
     });
     // `cli.zig` checks the README's usage block against the real help text.
@@ -145,6 +156,7 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "h2", .module = h2.module("h2") },
                 .{ .name = "zurl", .module = zurl.module("zurl") },
                 .{ .name = "zssl", .module = zssl_module },
+                .{ .name = "h3", .module = h3.module("h3") },
             },
         }),
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -44,6 +44,16 @@
             .url = "git+https://github.com/zoxy-io/zssl#b6a65537b394931b80dbdfa25ec7763b5837b7ae",
             .hash = "zssl-0.0.1-5ocyiNy-DgCb3DwVFeLhGK8x9olBEfyuRarEMDuMcIl8",
         },
+        // QUIC, QPACK and HTTP/3 — sans-I/O, like h2 and zssl. It opens no
+        // socket, reads no clock, draws no entropy and runs no TLS handshake:
+        // `src/h3conn.zig` supplies all four, and `src/quic_tls.zig` is the
+        // fourth because zssl declines QUIC (see its README, "Out, for now").
+        //
+        // A local path while this is a prototype. It becomes a pinned git URL
+        // the moment the shape stops moving.
+        .h3 = .{
+            .path = "../h3",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -49,10 +49,14 @@
         // `src/h3conn.zig` supplies all four, and `src/quic_tls.zig` is the
         // fourth because zssl declines QUIC (see its README, "Out, for now").
         //
-        // A local path while this is a prototype. It becomes a pinned git URL
-        // the moment the shape stops moving.
+        // Pinned at the commit that fixes the acknowledgement-report
+        // truncation this prototype found: below it, a connection carrying
+        // more than one stream strands them once the congestion window grows
+        // past thirty-two packets. `src/h3conn.zig` has the diagnosis.
+        //
         .h3 = .{
-            .path = "../h3",
+            .url = "git+https://github.com/zoxy-io/h3#3accaf4b8d35d299315927296c0bc49b5f5ffc3a",
+            .hash = "h3-0.0.0-RBkp8tYDFwAKtZHosUA5okrC2lg9y6gFkh4BZvmtvZSI",
         },
     },
     .paths = .{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 // table that lives on a connection's frame, so it is declared where that table
 // is rather than restated here.
 const connection = @import("connection.zig");
+const h3conn = @import("h3conn.zig");
 
 /// zrk version string, surfaced by `--version` and embedded in JSON reports.
 /// Single-sourced from build.zig.zon via the build's options module.
@@ -121,8 +122,20 @@ pub const Config = struct {
     /// otherwise, so `-c`, the pacing, and every latency number keep exactly
     /// their HTTP/1.1 meaning; only the wire format changes.
     http2: bool = false,
+    /// Speak HTTP/3 over QUIC instead of HTTP/1.1 or HTTP/2.
+    ///
+    /// Always TLS — QUIC has no cleartext mode — and always ALPN `h3`. `-c`,
+    /// the pacing and every latency number keep exactly their meaning from the
+    /// other two transports; `--streams` means what it means under `--http2`,
+    /// and is bounded by `h3conn.requests_max` rather than by
+    /// `connection.streams_max`.
+    ///
+    /// A prototype (zoxy-io/zrk#74). It requires `--insecure` because the QUIC
+    /// TLS engine does not verify certificates yet; see `src/quic_tls.zig` for
+    /// what is missing and how much of it there is.
+    http3: bool = false,
     /// How many of a connection's scheduled sends may be on the wire at once
-    /// (`-s/--streams`). Requires `--http2`.
+    /// (`-s/--streams`). Requires `--http2` or `--http3`.
     ///
     /// A depth knob, not a second concurrency dial: `-c` still divides `-R`,
     /// and `-c 10 -s 10` is deliberately *not* `-c 100` — same offered rate,
@@ -193,6 +206,10 @@ pub const ParseError = error{
     ZeroStreams,
     StreamsWithoutHttp2,
     TooManyStreams,
+    Http3WithHttp2,
+    Http3WithoutTls,
+    Http3WithoutInsecure,
+    Http3BodyTooLarge,
     OutOfMemory,
 };
 
@@ -222,11 +239,11 @@ pub const usage =
     \\Options:
     \\  -t, --threads     <N>     Total number of threads to execute load (default 2)
     \\  -c, --connections <N>     Total connections to keep open (default 10)
-    \\  -s, --streams     <N>     HTTP/2 streams in flight per connection
-    \\                            (default 1). A depth knob only: -R still
-    \\                            splits across -c, so -c 10 -s 10 offers the
-    \\                            same rate as -c 10, not as -c 100. Requires
-    \\                            --http2
+    \\  -s, --streams     <N>     HTTP/2 or HTTP/3 streams in flight per
+    \\                            connection (default 1). A depth knob only:
+    \\                            -R still splits across -c, so -c 10 -s 10
+    \\                            offers the same rate as -c 10, not as
+    \\                            -c 100. Requires --http2 or --http3
     \\  -d, --duration    <T>     Test duration, e.g. 30s, 2m    (default 10s)
     \\  -R, --rate      <N|A:B>   Target requests/second (total); A:B ramps
     \\                            linearly from A to B over the run (default 1000)
@@ -261,6 +278,9 @@ pub const usage =
     \\      --http2               Speak HTTP/2. Cleartext uses prior knowledge
     \\                            (h2c); https negotiates it over ALPN and
     \\                            fails the connection if the server declines
+    \\      --http3               Speak HTTP/3 over QUIC (https only).
+    \\                            Prototype: the QUIC TLS engine does not
+    \\                            verify certificates yet, so it requires -k
     \\  -k, --insecure            Skip TLS certificate verification
     \\      --plain               Append-only output instead of a live dashboard
     \\
@@ -326,6 +346,8 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
             cfg.latency = true;
         } else if (eq(arg, "--http2") or eq(arg, "--h2c")) {
             cfg.http2 = true;
+        } else if (eq(arg, "--http3") or eq(arg, "--h3")) {
+            cfg.http3 = true;
         } else if (eq(arg, "-k") or eq(arg, "--insecure")) {
             cfg.insecure = true;
         } else if (eq(arg, "--plain") or eq(arg, "--no-tui")) {
@@ -420,19 +442,42 @@ pub fn parse(arena: Allocator, args: []const []const u8) ParseError!Parsed {
     // malformed field in h2 (RFC 9113 section 8.2.2 — which is why
     // `buildRequestBlock` omits it), and one stream per connection would
     // measure the handshake rather than the protocol.
-    if (cfg.disable_keepalive and cfg.http2) return error.KeepaliveWithHttp2;
+    if (cfg.disable_keepalive and (cfg.http2 or cfg.http3)) return error.KeepaliveWithHttp2;
+    // One wire format per run. They are not layered — HTTP/3 is a different
+    // transport, not a different framing over the same socket — so a run that
+    // asked for both asked for a comparison, and the way to get one is two runs.
+    if (cfg.http2 and cfg.http3) return error.Http3WithHttp2;
     if (cfg.streams == 0) return error.ZeroStreams;
     // HTTP/1.1 has no second stream to open. h2load spends `-m` on pipelining
     // there; zrk will not, because a pipelined depth cannot be aborted per
     // request — a timeout on one request abandons the whole pipeline behind
     // it, which is the very thing `--streams` exists to avoid.
-    if (cfg.streams > 1 and !cfg.http2) return error.StreamsWithoutHttp2;
+    if (cfg.streams > 1 and !cfg.http2 and !cfg.http3) return error.StreamsWithoutHttp2;
     // The slot table lives on the connection's own frame; see
-    // `connection.streams_max`.
-    if (cfg.streams > connection.streams_max) return error.TooManyStreams;
+    // `connection.streams_max`. Under HTTP/3 it is `h3conn`'s, and the smaller
+    // of the two, because a QUIC stream costs two flow-control windows sized at
+    // comptime where an HTTP/2 stream costs a `Slot`.
+    const streams_ceiling = if (cfg.http3) h3conn.requests_max else connection.streams_max;
+    if (cfg.streams > streams_ceiling) return error.TooManyStreams;
 
     const raw_url = url_arg orelse return error.MissingUrl;
     cfg.url = try parseUrl(raw_url);
+
+    if (cfg.http3) {
+        // QUIC has no cleartext mode: RFC 9114 §3.1 reaches an origin over TLS
+        // or not at all, so an `http://` target is a request this transport
+        // cannot answer rather than one it declines to.
+        if (!cfg.url.isTls()) return error.Http3WithoutTls;
+        // The prototype's one hard gate. `quic_tls.zig` proves the peer speaks
+        // QUIC, not who it is, and a load generator that silently skipped
+        // verification would be a worse thing than one that says so.
+        if (!cfg.insecure) return error.Http3WithoutInsecure;
+        // The request has to fit one `Connection.write`, because a short write
+        // is a failed request rather than one this file resumes. Checked here,
+        // against the real bound, so an oversized `--body` is a usage error
+        // before the run rather than a wall of write errors during it.
+        if (cfg.body.len >= h3conn.request_octets_max) return error.Http3BodyTooLarge;
+    }
 
     cfg.headers = try headers.toOwnedSlice(arena);
     return .{ .config = cfg };
@@ -713,6 +758,66 @@ test "streams flag parses; requires --http2 and a sane depth" {
     try testing.expectEqual(@as(u32, 4), with_closed.streams);
 }
 
+test "http3 parses, and its three preconditions are usage errors" {
+    var arena_state: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const cfg = (try parse(a, &[_][]const u8{ "--http3", "-k", "https://x/" })).config;
+    try testing.expect(cfg.http3);
+    try testing.expect(!cfg.http2);
+    // `--h3` is the short spelling, the way `--h2c` is HTTP/2's.
+    const short = (try parse(a, &[_][]const u8{ "--h3", "-k", "https://x/" })).config;
+    try testing.expect(short.http3);
+
+    // QUIC has no cleartext mode, so an http:// target is refused rather than
+    // silently downgraded.
+    try testing.expectError(error.Http3WithoutTls, parse(a, &[_][]const u8{ "--http3", "-k", "http://x/" }));
+    // The prototype's certificate gap, made impossible to run into unknowingly.
+    try testing.expectError(error.Http3WithoutInsecure, parse(a, &[_][]const u8{ "--http3", "https://x/" }));
+    // One wire format per run.
+    try testing.expectError(error.Http3WithHttp2, parse(a, &[_][]const u8{ "--http3", "--http2", "-k", "https://x/" }));
+}
+
+test "http3 takes --streams up to its own ceiling, which is not http2's" {
+    var arena_state: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const cfg = (try parse(a, &[_][]const u8{ "--http3", "-k", "-s", "8", "https://x/" })).config;
+    try testing.expectEqual(@as(u32, 8), cfg.streams);
+
+    // A QUIC stream costs two comptime-sized flow control windows where an
+    // HTTP/2 stream costs a slot, so the two ceilings are different numbers and
+    // the check has to read the right one.
+    try testing.expect(h3conn.requests_max < connection.streams_max);
+    const at_ceiling = try std.fmt.allocPrint(a, "{d}", .{h3conn.requests_max});
+    _ = (try parse(a, &[_][]const u8{ "--http3", "-k", "-s", at_ceiling, "https://x/" })).config;
+    const past_ceiling = try std.fmt.allocPrint(a, "{d}", .{h3conn.requests_max + 1});
+    try testing.expectError(
+        error.TooManyStreams,
+        parse(a, &[_][]const u8{ "--http3", "-k", "-s", past_ceiling, "https://x/" }),
+    );
+}
+
+test "a body that cannot fit one QUIC stream write is a usage error, not a run of failures" {
+    var arena_state: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena_state.deinit();
+    const a = arena_state.allocator();
+
+    const body = try a.alloc(u8, h3conn.request_octets_max);
+    @memset(body, 'x');
+    try testing.expectError(error.Http3BodyTooLarge, parse(
+        a,
+        &[_][]const u8{ "--http3", "-k", "-m", "POST", "-b", body, "https://x/" },
+    ));
+    // The same body is fine on the transports that do not have to fit it in one
+    // write, which is what makes this a property of `--http3` rather than a cap
+    // on `--body`.
+    const over_http2 = (try parse(a, &[_][]const u8{ "--http2", "-m", "POST", "-b", body, "https://x/" })).config;
+    try testing.expectEqual(h3conn.request_octets_max, over_http2.body.len);
+}
+
 test "disable-keepalive flag parses; rejects --http2" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();
@@ -734,6 +839,12 @@ test "disable-keepalive flag parses; rejects --http2" {
     // h2 has no per-request connection to close, in either flag order.
     try testing.expectError(error.KeepaliveWithHttp2, parse(a, &[_][]const u8{ "--disable-keepalive", "--http2", "http://x/" }));
     try testing.expectError(error.KeepaliveWithHttp2, parse(a, &[_][]const u8{ "--http2", "--disable-keepalive", "http://x/" }));
+    // And HTTP/3, for the same reason: a stream is not a connection, so there
+    // is no per-request connection to close.
+    try testing.expectError(error.KeepaliveWithHttp2, parse(
+        a,
+        &[_][]const u8{ "--http3", "-k", "--disable-keepalive", "https://x/" },
+    ));
 }
 
 test "refresh flag parses and zero is rejected" {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -15,6 +15,7 @@ const hdr = @import("hdr.zig");
 const httpmod = @import("http.zig");
 const tlsmod = @import("tls.zig");
 const h2conn = @import("h2conn.zig");
+const h3conn = @import("h3conn.zig");
 const pace = @import("pace.zig");
 const StatusClass = httpmod.StatusClass;
 
@@ -119,6 +120,18 @@ pub const Params = struct {
     body: []const u8 = &.{},
     /// Speak HTTP/2 with prior knowledge instead of HTTP/1.1.
     http2: bool = false,
+    /// Speak HTTP/3 over QUIC. Mutually exclusive with `http2`, and nothing
+    /// below this line in the TCP path runs: `run` hands the whole connection
+    /// to `h3conn.run`, which owns its own UDP socket, its own TLS handshake
+    /// and its own event loop. See that file for why it cannot be a codec swap.
+    http3: bool = false,
+    /// The same request as one QPACK-encoded HEADERS frame, plus a DATA frame
+    /// when there is a body, when `http3` is set.
+    ///
+    /// Built once at startup against QPACK's static table alone, so it depends
+    /// on no encoder state and is replayed byte-identically on every stream —
+    /// the HTTP/3 half of the trade `request_block` makes for HTTP/2.
+    h3_request: []const u8 = &.{},
     /// How many of this connection's scheduled sends may be on the wire at
     /// once (`--streams`). Requires `http2`.
     ///
@@ -184,6 +197,10 @@ pub const Params = struct {
     allocator: std.mem.Allocator = undefined,
     /// Pinned per-connection TLS buffers/client; required when `is_tls`.
     tls_state: ?*tlsmod.State = null,
+    /// Pinned per-connection QUIC/HTTP-3 transport state; required when
+    /// `http3`. Megabytes rather than kilobytes, and allocated once for the
+    /// run rather than per reconnect, for the same reason `tls_state` is.
+    h3_state: ?*h3conn.State = null,
     /// Shared trust store; null means verification is skipped.
     ca_store: ?*tlsmod.CaStore = null,
 };
@@ -195,6 +212,13 @@ const write_buffer_size = 8 * 1024;
 /// failures are folded into `counters` and recovered from by reconnecting.
 pub fn run(p: *Params) void {
     const io = p.io;
+
+    // HTTP/3 is not a codec swap. Everything below — the TCP connect, the
+    // reader/writer pair, the watchdog that enforces a bound by shutting a
+    // socket down — assumes a stream transport somebody else is running. QUIC
+    // is the transport, so `h3conn` owns the socket, the handshake and the
+    // clock, and this function's only part in it is the dispatch.
+    if (p.http3) return h3conn.run(p);
 
     var read_buf: [read_buffer_size]u8 = undefined;
     var write_buf: [write_buffer_size]u8 = undefined;
@@ -1202,20 +1226,20 @@ fn alpnIs(selected: ?[]const u8, want: []const u8) bool {
     return std.mem.eql(u8, chosen, want);
 }
 
-fn now(io: Io) Io.Timestamp {
+pub fn now(io: Io) Io.Timestamp {
     return Io.Timestamp.now(io, .awake);
 }
 
 /// Which socket-level counter a failure lands in. Named rather than anonymous
 /// because the multiplexed path decides the kind in one place and reports it in
 /// another.
-const ErrorKind = enum { connect, write, read };
+pub const ErrorKind = enum { connect, write, read };
 
 /// Record a socket error, unless we are shutting down — errors caused by
 /// cancelling in-flight I/O at end-of-test are artifacts, not real failures.
 /// Publishes so the live dashboard sees error-only periods (a total outage
 /// produces no successful responses to publish through).
-fn noteError(p: *Params, kind: ErrorKind) void {
+pub fn noteError(p: *Params, kind: ErrorKind) void {
     if (p.stop.load(.monotonic)) return;
     switch (kind) {
         .connect => p.counters.connect_errors += 1,
@@ -1230,7 +1254,7 @@ fn noteError(p: *Params, kind: ErrorKind) void {
 /// sample measured from the scheduled send time, so the tail reflects the stall
 /// instead of dropping the worst samples. Skipped during shutdown, where a
 /// timeout is a teardown artifact rather than a real failure.
-fn noteTimeout(p: *Params, io: Io, scheduled: Io.Timestamp) void {
+pub fn noteTimeout(p: *Params, io: Io, scheduled: Io.Timestamp) void {
     if (p.stop.load(.monotonic)) return;
     p.counters.timeouts += 1;
     const done = now(io);
@@ -1250,7 +1274,7 @@ fn noteTimeout(p: *Params, io: Io, scheduled: Io.Timestamp) void {
 /// latency sample — the histogram stays the distribution of requests served
 /// within the deadline. Skipped during shutdown, where it would be a teardown
 /// artifact rather than a real miss.
-fn noteDeadline(p: *Params) void {
+pub fn noteDeadline(p: *Params) void {
     if (p.stop.load(.monotonic)) return;
     p.counters.deadline_errors += 1;
     maybePublish(p, now(p.io).nanoseconds);
@@ -1264,7 +1288,7 @@ fn noteDeadline(p: *Params) void {
 /// counts advance in conns-sized steps, a staircase in the throughput
 /// timeseries. The histogram copy — the expensive part — still happens at
 /// most once per publish interval.
-fn maybePublish(p: *Params, now_ns: i128) void {
+pub fn maybePublish(p: *Params, now_ns: i128) void {
     const pub_ptr = p.publish orelse return;
     pub_ptr.mutex.lockUncancelable(p.io);
     defer pub_ptr.mutex.unlock(p.io);

--- a/src/h3conn.zig
+++ b/src/h3conn.zig
@@ -1,0 +1,1205 @@
+//! One HTTP/3 connection, driven as a single-coroutine QUIC event loop.
+//!
+//! ## Why this is not `connection.zig` with a different codec
+//!
+//! The HTTP/1.1 and HTTP/2 paths share a shape: a `net.Stream`, a
+//! `*Io.Reader`/`*Io.Writer` pair, and a request loop that blocks on the read
+//! it is waiting for. Everything about that shape assumes the transport is
+//! somebody else's problem — the kernel's TCP, and zssl's TLS over it.
+//!
+//! QUIC is the transport. `h3` is sans-I/O in the same way h2 and zssl are, but
+//! what it declines is larger: it opens no socket, reads no clock, draws no
+//! randomness and runs no TLS handshake. That means this file owns the loss
+//! detector's timer, the acknowledgement schedule, and the deadline arithmetic
+//! that decides when to wake — and none of that can sit behind a blocking read,
+//! because a connection with nothing to receive still has to *send*: ACKs,
+//! probes, retransmissions. A blocked read is a stalled congestion controller.
+//!
+//! So the loop here is the inversion of `connection.zig`'s. Rather than
+//! blocking on a response and pacing between them, it computes the earliest of
+//!
+//!   * the next request's scheduled send time,
+//!   * the QUIC loss/PTO timer,
+//!   * the earliest in-flight request's `--timeout`/`--deadline` bound,
+//!   * the run's own end,
+//!
+//! and sleeps in `receiveTimeout` until then. One coroutine per connection,
+//! and no locks: unlike the HTTP/2 multiplexed path there is no second
+//! coroutine to race with, because the socket read and the pacing wait are the
+//! *same* wait.
+//!
+//! That is also why the numbers should be comparable. Every step the serial
+//! path takes — anchoring the schedule, the closed-form offset, the lag gauge,
+//! deadline shedding, the coordinated-omission correction measured from
+//! `scheduled` rather than from the actual send — means exactly what it means
+//! there, and is written here in the same order.
+//!
+//! ## What a prototype does not have yet
+//!
+//! * **No certificate verification.** `quic_tls.zig` says why, and `cli.zig`
+//!   makes `--http3` require `--insecure` so no run can believe otherwise.
+//! * **One datagram per syscall.** The issue that asked for HTTP/3
+//!   (zoxy-io/zrk#74) names GSO/GRO batching as the thing that decides whether
+//!   a load generator can saturate a link. `std.Io.net.Socket` has `sendMany`
+//!   and `receiveManyTimeout` and zio implements both, so the seam is there;
+//!   this file does not use it yet, and that is the first optimisation to
+//!   measure rather than assume.
+//! * **No connection migration, no 0-RTT, no session resumption.** A run that
+//!   reconnects pays a full handshake every time.
+//!
+//! And one thing that *was* a gap and is not any more, kept here because the
+//! symptom looked like this file's and was not: a multiplexed connection ran at
+//! full rate for about a second and then went to zero req/s, with no errors, for
+//! the rest of the run. `Connection.receiveAck` handed `Recovery` a fixed
+//! 32-entry array for the acknowledged packets' contexts while `Recovery` tracks
+//! `sent_max` of them and clamps its writes to the caller's slice, so an
+//! acknowledgement retiring more than 32 packets — routine once the congestion
+//! window has grown — reported a prefix. `Streams.acknowledge` was then never
+//! called for the streams that did not fit: their send half stayed in "Data
+//! Sent" for ever, they never retired, and since retirement walks a contiguous
+//! watermark, one stranded stream pinned every stream above it until the table
+//! was full. Fixed upstream by sizing the report from `sent_max`, which is the
+//! only number that can bound it; the regression test is
+//! `src/quic/Connection.zig`'s "one acknowledgement settles every stream it
+//! retires, not the first 32", and the row is docs/VERIFICATION.md §1.
+//! * **Fixed comptime limits.** `Connection` is a comptime-sized value —
+//!   `footprint_octets` below is what one costs — so `--streams` cannot exceed
+//!   `requests_max` and a request body cannot exceed the stream send buffer.
+//!   `cli.zig` enforces both rather than letting them fail on the wire.
+
+const std = @import("std");
+const Io = std.Io;
+const net = std.Io.net;
+const h3 = @import("h3");
+const quic = h3.quic;
+
+const cli = @import("cli.zig");
+const conn = @import("connection.zig");
+const httpmod = @import("http.zig");
+const quic_tls = @import("quic_tls.zig");
+
+/// Request streams this endpoint tracks at once, which is the ceiling on
+/// `--streams` for an HTTP/3 run.
+///
+/// A limit rather than a policy: `Connection` and `Http3` are comptime-sized
+/// values, so this number is spent whether or not a run uses it. See
+/// `footprint_octets`.
+pub const requests_max: u32 = 16;
+
+/// RFC 9114 §6.2 and RFC 9204 §4.2: a control stream and QPACK's two, each
+/// way, plus room for §6.2.3's reserved types to arrive without being an
+/// error.
+const unidirectional_max: u32 = 4;
+
+/// The QUIC stream table, which is **not** `requests_max` and is not `2 ×` it
+/// either.
+///
+/// Two things are being sized at once. RFC 9000 §3.2 makes an identifier at
+/// index N mean N+1 streams of that kind exist, so whatever this endpoint
+/// advertises is a claim the peer may make on the table all at once, and the
+/// same again for what it opens itself; a table smaller than that answers a
+/// conforming peer with `STREAM_LIMIT_ERROR`, which is this endpoint's sizing
+/// mistake reported as the peer's protocol error.
+///
+/// The other thing is retirement lag, and it is the one that bites. A stream
+/// leaves the table only when *both* halves are finished, and `Streams`
+/// retires in identifier order from a contiguous watermark — so a response
+/// that completed on stream 40 frees nothing while stream 4's own FIN is still
+/// waiting to be acknowledged. Under load the set of "finished but not yet
+/// retired" streams is several times the set of in-flight ones, and a table
+/// sized for the in-flight set alone fills, refuses every new request, and
+/// never drains: a 20-second soak at depth 32 collapsed from 60k req/s to zero
+/// in about a second, and stayed there.
+///
+/// Four times the request ceiling is that headroom. It is a bound, not a
+/// guarantee, which is why `issue` treats `TooManyStreams` as backpressure
+/// rather than as a failed request — the table filling is this endpoint
+/// running out of room, not the target doing anything wrong.
+const streams_max: u32 = 4 * requests_max + 2 * unidirectional_max;
+
+/// The two flow-control windows, per stream.
+///
+/// Deliberately smaller than `h3`'s own defaults (64 KiB and 16 KiB), because
+/// they are multiplied by `streams_max` and then by `-c`. A response larger
+/// than the receive window is not refused — the window slides as `consume`
+/// releases octets — it just takes more round trips, which is the right trade
+/// for a tool whose common case is a small response measured a million times.
+const stream_receive_octets: u32 = 16 * 1024;
+
+/// The send window is the hard one: a request has to *fit*, because zrk writes
+/// it in a single `write` and treats a short write as a failed request rather
+/// than resuming it. `cli.zig` bounds `--body` against `request_octets_max`
+/// below for that reason.
+const stream_send_octets: u32 = 4 * 1024;
+
+/// A certificate chain with an intermediate is comfortably past `h3`'s 8 KiB
+/// default, and RFC 9001 §4.4 makes running out of room a connection error
+/// rather than a stall — so a default that is too small fails as
+/// `CRYPTO_BUFFER_EXCEEDED` on the handshake of a server that did nothing wrong.
+const crypto_octets: u32 = 32 * 1024;
+
+const Connection = quic.Connection(.{
+    .crypto_octets = crypto_octets,
+    .streams_max = streams_max,
+    .stream_receive_octets = stream_receive_octets,
+    .stream_send_octets = stream_send_octets,
+    .connection_receive_octets = 1 << 20,
+    .sent_max = 256,
+});
+
+const Http3 = h3.Http3(.{
+    .requests_max = requests_max,
+    .unidirectional_max = unidirectional_max,
+});
+
+/// What one connection's transport state costs, exported so a `-c` that would
+/// not fit in memory can be refused before it is launched rather than after.
+pub const footprint_octets: usize = @sizeOf(State);
+
+/// The largest request this file can put on a stream: the QPACK HEADERS frame,
+/// and a DATA frame carrying `--body` after it, both of which have to fit in
+/// one `Connection.write`.
+pub const request_octets_max: usize = stream_send_octets;
+
+/// Datagrams built per flush before the loop goes back to the socket. A bound
+/// rather than "until `wantsSend` is false", because a connection that always
+/// wants to send is a bug this loop should not turn into a hang.
+const flush_datagrams_max: u32 = 32;
+
+/// Anything the path delivers, up to QUIC's own ceiling.
+const receive_octets: usize = 2048;
+
+/// Eight octets is what most implementations use and is well inside RFC 9000
+/// §17.2's twenty.
+const connection_id_octets: usize = 8;
+
+/// Events taken from `Http3.receive` per stream, per pass.
+const events_per_stream_max: usize = 16;
+
+/// Events taken from `Connection.poll` per pass. Larger than the connection's
+/// own queue, so a pass always empties it.
+const events_per_poll_max: u32 = 256;
+
+/// How long the loop may sleep with nothing else to wait for. Not a protocol
+/// bound: it is how often `stop` is re-read, so a `SIGINT` or a finished run
+/// is noticed promptly on an idle connection.
+const idle_slice_ns: u64 = 20 * std.time.ns_per_ms;
+
+/// A field section decodes to several times the octets it arrived as, and the
+/// buffer for that is the caller's — `Http3` holds no per-stream storage.
+/// Only `:status` is read out of it, but the decoder still needs room for the
+/// whole list.
+const field_buffer_octets: usize = 8 * 1024;
+
+/// `SETTINGS_MAX_FIELD_SECTION_SIZE`, offered to the peer and enforced here.
+const field_section_octets_max: u64 = 64 * 1024;
+
+/// How long the handshake is given before the connection is abandoned as a
+/// connect error, when no `--timeout` says otherwise. A server that answers
+/// nothing at all would otherwise hold the connection until the run ended.
+const handshake_deadline_ns: u64 = 10 * std.time.ns_per_s;
+
+/// How long an established connection may go without hearing anything from the
+/// peer before it is abandoned and rebuilt, as a multiple of `--timeout`.
+///
+/// Two rather than one, so that a single request outliving its bound does not
+/// retire a connection the peer is still answering on every other stream —
+/// which is the churn `--deadline-abort` is off by default to avoid.
+const progress_bound_multiple: u64 = 2;
+
+/// The two SHA-256 suites `quic_tls.zig` can negotiate, in preference order.
+const offered_suites = [_]quic_tls.CipherSuite{
+    .aes_128_gcm_sha256,
+    .chacha20_poly1305_sha256,
+};
+
+/// RFC 9000 §2.1: client-initiated unidirectional streams are 2, 6, 10. Fixed
+/// rather than allocated, because there are exactly three and their order is
+/// this endpoint's choice.
+const control_stream: u64 = 2;
+const qpack_encoder_stream: u64 = 6;
+const qpack_decoder_stream: u64 = 10;
+
+/// RFC 9114 §8.1's `H3_REQUEST_CANCELLED`, which is what a request abandoned
+/// on its own `--timeout` or `--deadline` is.
+const h3_request_cancelled: u64 = 0x010c;
+
+/// One request in flight on this connection.
+///
+/// Deliberately the same fields as `connection.Slot`, and for the same reasons:
+/// `scheduled` is the only clock a latency is measured against, and the two
+/// bounds collapse into one absolute deadline so a slot needs one comparison
+/// rather than two.
+const Slot = struct {
+    /// Claimed by the loop when the request goes out, freed when the response
+    /// completes or the slot's deadline passes.
+    busy: bool = false,
+    /// The bidirectional stream carrying it.
+    stream: u64 = 0,
+    /// When this request was *supposed* to go out.
+    scheduled: Io.Timestamp = .zero,
+    /// `:status`, once the response's field section has arrived.
+    status: ?u16 = null,
+    /// Response octets seen so far, field section included.
+    bytes: u64 = 0,
+    /// Absolute monotonic-ns deadline for this request (0 = none), and whether
+    /// it came from the coordinated-omission abort bound rather than the wire
+    /// timeout.
+    deadline_ns: u64 = 0,
+    deadline_co: bool = false,
+};
+
+/// Everything one connection needs that is too large for a coroutine stack.
+///
+/// Allocated once per connection by `stats.Fleet`, exactly like `tls.State`,
+/// and reused across every reconnect that connection makes. `Connection` is a
+/// fixed-size value whose buffers are sized at comptime, so this block is the
+/// whole of the transport's memory: there is no allocator below it.
+pub const State = struct {
+    connection: Connection = undefined,
+    http3: Http3 = undefined,
+    client: quic_tls.Client = undefined,
+
+    slots: [requests_max]Slot = @splat(.{}),
+    /// Streams the connection has reported data on, so a pass can drain each
+    /// of them once. A response arrives on a stream this endpoint opened, but
+    /// the peer's control stream is one only an event can announce.
+    readable: [streams_max]u64 = @splat(0),
+    readable_len: usize = 0,
+    /// The next client-initiated bidirectional identifier: 0, 4, 8, ...
+    next_stream: u64 = 0,
+    /// Whether this endpoint's control and QPACK streams have gone out.
+    http3_started: bool = false,
+
+    datagram: [Connection.datagram_octets]u8 = undefined,
+    incoming: [receive_octets]u8 = undefined,
+    fields: [field_buffer_octets]u8 = undefined,
+
+    /// The block arrives from `allocator.alloc` undefined, and nothing may read
+    /// a field before this runs.
+    pub fn init(self: *State) void {
+        self.* = .{};
+    }
+};
+
+/// The request as the octets that go on a stream: a QPACK HEADERS frame, and a
+/// DATA frame carrying the body when there is one.
+///
+/// Built once for the whole run and replayed byte-identically on every stream
+/// of every connection, which is the same trade `buildRequestBlock` makes for
+/// HTTP/2 and is legal for the same reason: this endpoint advertises
+/// `SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0`, so the encoding touches no dynamic
+/// table and depends on no encoder state.
+///
+/// The result is the caller's to free.
+pub fn buildRequest(allocator: std.mem.Allocator, cfg: *const cli.Config) ![]u8 {
+    var scratch: std.heap.ArenaAllocator = .init(allocator);
+    defer scratch.deinit();
+    const tmp = scratch.allocator();
+
+    const fields = try httpmod.buildRequestFields(tmp, cfg);
+    // Into h3's field type at the last moment; see `http.Field`.
+    const qpack_fields = try tmp.alloc(h3.qpack.Field, fields.len);
+    for (qpack_fields, fields) |*out, in| out.* = .{ .name = in.name, .value = in.value };
+
+    var buffer: [request_octets_max]u8 = undefined;
+    // `writeHeaders` reads nothing off the instance — it is a method only
+    // because the rest of the frame writers are — so a throwaway one encodes
+    // the block that every real connection will replay.
+    var encoder: Http3 = .init(.client);
+    var written = encoder.writeHeaders(&buffer, qpack_fields) catch return error.RequestTooLarge;
+
+    if (cfg.body.len > 0) {
+        const header = Http3.writeData(buffer[written..], cfg.body.len) catch
+            return error.RequestTooLarge;
+        written += header;
+        if (written + cfg.body.len > buffer.len) return error.RequestTooLarge;
+        @memcpy(buffer[written..][0..cfg.body.len], cfg.body);
+        written += cfg.body.len;
+    }
+
+    return allocator.dupe(u8, buffer[0..written]);
+}
+
+/// Run one HTTP/3 connection until `end` (or `stop`). Never returns an error:
+/// every failure is folded into `counters` and recovered from by reconnecting,
+/// exactly as `connection.run` does for TCP.
+pub fn run(p: *conn.Params) void {
+    const io = p.io;
+    const state = p.h3_state orelse {
+        // Unreachable through `runner.zig`, which allocates the block whenever
+        // `--http3` is set. Counted rather than asserted so a wiring mistake
+        // shows up as a run that failed instead of a process that died.
+        conn.noteError(p, .connect);
+        return;
+    };
+
+    // The schedule is the connection's, not the attempt's: `send_index` is the
+    // coordinated-omission-correct request counter, and it persists across
+    // reconnects so a stall is caught up rather than reset.
+    var anchor: ?Io.Timestamp = null;
+    var send_index: u64 = 0;
+
+    while (!p.stop.load(.monotonic) and conn.now(io).nanoseconds < p.end.nanoseconds) {
+        serve(p, state, &anchor, &send_index);
+        if (p.stop.load(.monotonic)) return;
+        if (conn.now(io).nanoseconds >= p.end.nanoseconds) return;
+        // Back off briefly so a target that refuses everything does not spin
+        // the CPU building handshakes.
+        io.sleep(Io.Duration.fromMilliseconds(5), .awake) catch return;
+    }
+}
+
+/// One connection attempt: bind, handshake, serve requests, close.
+fn serve(p: *conn.Params, state: *State, anchor: *?Io.Timestamp, send_index: *u64) void {
+    const io = p.io;
+
+    // A fresh ephemeral port per attempt. QUIC identifies a connection by its
+    // connection ID rather than its 4-tuple, so this is not required — but
+    // rebinding is what makes a reconnect unambiguous to a server that is still
+    // holding the old connection's state.
+    const any: net.IpAddress = switch (p.address) {
+        .ip4 => .{ .ip4 = .unspecified(0) },
+        .ip6 => .{ .ip6 = .unspecified(0) },
+    };
+    var socket = any.bind(io, .{ .mode = .dgram }) catch {
+        conn.noteError(p, .connect);
+        return;
+    };
+    defer socket.close(io);
+
+    // The clock. `h3` takes `now_ns` as a parameter and reads none, so this is
+    // the owner of one; the origin is this attempt's start, which keeps every
+    // value the transport sees inside a `u64` of nanoseconds.
+    const origin = conn.now(io);
+
+    if (!begin(p, state)) return;
+
+    // A handshake that never completes is a connect error, and it has to be
+    // bounded by something: a peer that answers no datagram at all would
+    // otherwise hold this coroutine until the run ended, contributing one
+    // failure where it should contribute a stream of them.
+    const handshake_bound_ns: u64 = if (p.timeout_ns != 0) p.timeout_ns else handshake_deadline_ns;
+
+    // And the same question for a connection that *did* handshake and then
+    // stopped hearing anything.
+    //
+    // TCP answers this for the serial path: a wire timeout shuts the socket
+    // down, and the request and the connection die together. QUIC has no such
+    // coupling — a request is a stream, `expire` resets that one stream, and a
+    // connection whose peer has gone away silently is a connection this loop
+    // will happily keep paying `--timeout` on, one request at a time, until the
+    // run ends. Stopping the target mid-run and starting it again is what
+    // showed it: the server came back after three seconds and the run did not,
+    // spending its remaining eight seconds timing out against a connection that
+    // could never answer.
+    //
+    // Progress is anything from the peer, not a completed response: a server
+    // that is merely slow is still there, and retiring a live connection would
+    // throw away the streams already on it.
+    const progress_bound_ns: u64 = if (p.timeout_ns != 0)
+        progress_bound_multiple * p.timeout_ns
+    else
+        handshake_deadline_ns;
+    var progress_ns: u64 = 0;
+
+    while (true) {
+        if (p.stop.load(.monotonic)) return;
+        const t = conn.now(io);
+        if (t.nanoseconds >= p.end.nanoseconds) return;
+        const now_ns: u64 = @intCast(t.nanoseconds - origin.nanoseconds);
+
+        if (!pumpCrypto(p, state)) return;
+
+        if (state.connection.state == .handshaking and now_ns > handshake_bound_ns) {
+            conn.noteError(p, .connect);
+            return;
+        }
+        // Requests whose own bound already fired were counted and freed by
+        // `expire`, so they are not busy any more and `abandonAll` cannot
+        // charge them twice. What it does charge is the requests that were
+        // still inside their timeout when the connection was given up, and
+        // those are real failures: they were on the wire and no answer is
+        // coming.
+        if (state.connection.state == .established and now_ns - progress_ns > progress_bound_ns) {
+            abandonAll(p, state, .read);
+            return;
+        }
+
+        // Poll before draining, not after. `poll` is what says a stream has
+        // data; draining first would read the streams the *previous* datagram
+        // announced and leave this one's until something else woke the loop —
+        // an acknowledgement timer, usually, which turns a response that has
+        // fully arrived into one that lands a max-ack-delay late. Every
+        // latency this tool reports would carry that.
+        if (!pollTransport(p, state)) return;
+        if (!drain(p, state)) return;
+
+        if (state.connection.state == .established) {
+            if (!state.http3_started and !startHttp3(p, state)) return;
+            issue(p, state, anchor, send_index);
+        }
+
+        expire(p, state);
+
+        if (!flush(p, state, &socket, now_ns)) return;
+
+        // A CONNECTION_CLOSE from the peer ends the attempt. Requests still in
+        // flight are the peer's answer to them, so they count as read errors —
+        // the same judgement the TCP path makes when a server hangs up mid
+        // response.
+        switch (state.connection.state) {
+            .draining, .closing => {
+                abandonAll(p, state, .read);
+                return;
+            },
+            else => {},
+        }
+
+        const wait_ns = waitFor(p, state, anchor, send_index.*, origin);
+        const timeout: Io.Timeout = .{ .duration = .{
+            .raw = Io.Duration.fromNanoseconds(wait_ns),
+            .clock = .awake,
+        } };
+        const message = socket.receiveTimeout(io, &state.incoming, timeout) catch |err| switch (err) {
+            error.Timeout => {
+                state.connection.onTimeout(elapsed(io, origin));
+                continue;
+            },
+            else => {
+                abandonAll(p, state, .read);
+                conn.noteError(p, .read);
+                return;
+            },
+        };
+        progress_ns = elapsed(io, origin);
+        state.connection.receive(message.data, elapsed(io, origin)) catch {
+            // A datagram that does not parse or does not authenticate is
+            // discarded inside the connection; what reaches here is a protocol
+            // error, and RFC 9000 §10.2 says close rather than ignore.
+            abandonAll(p, state, .read);
+            conn.noteError(p, .read);
+            return;
+        };
+    }
+}
+
+/// Draw this attempt's identifiers and entropy, build the connection and the
+/// TLS client, and put the ClientHello on the Initial crypto stream. False on
+/// anything that makes the attempt impossible; the failure is already counted.
+fn begin(p: *conn.Params, state: *State) bool {
+    const io = p.io;
+
+    var seed: [64]u8 = undefined;
+    io.randomSecure(&seed) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+    var identifiers: [2 * connection_id_octets]u8 = undefined;
+    io.randomSecure(&identifiers) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+
+    const destination = quic.ConnectionId.init(identifiers[0..connection_id_octets]) catch unreachable;
+    const source = quic.ConnectionId.init(identifiers[connection_id_octets..]) catch unreachable;
+
+    state.connection = .init(.{
+        .side = .client,
+        .original_destination = destination,
+        .source = source,
+    });
+    // The same numbers the transport parameters below carry. Without this the
+    // stream layer enforces the *table's* size instead, which is larger than
+    // what was offered — so a peer opening past the advertised limit would be
+    // admitted, and RFC 9000 §3.2's implicit creation would then spend table
+    // slots this endpoint had promised to nobody.
+    state.connection.streams.setAdvertisedStreamLimits(requests_max, unidirectional_max);
+    state.http3 = .init(.client);
+    state.http3_started = false;
+    state.slots = @splat(.{});
+    state.readable_len = 0;
+    state.next_stream = 0;
+
+    // What this endpoint advertises: its comptime limits, not a policy. A
+    // `Connection` enforces what it was built with, so advertising anything
+    // else would be advertising a window it will not honour.
+    var parameters: [512]u8 = undefined;
+    const parameters_len = quic.transport_parameters.encode(&parameters, &.{
+        .initial_max_data = 1 << 20,
+        .initial_max_stream_data_bidi_local = stream_receive_octets,
+        .initial_max_stream_data_bidi_remote = stream_receive_octets,
+        .initial_max_stream_data_uni = stream_receive_octets,
+        .initial_max_streams_bidi = requests_max,
+        // Zero here refuses the peer's control stream, which is how an HTTP/3
+        // run fails before it starts: a server that cannot open one cannot send
+        // SETTINGS, and a client that never sees SETTINGS is talking to nobody.
+        .initial_max_streams_uni = unidirectional_max,
+        .max_udp_payload_size = Connection.datagram_octets,
+        .active_connection_id_limit = 2,
+        .initial_source_connection_id = source,
+    }) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+
+    state.client = .init(.{
+        .server_name = p.host,
+        .alpn = "h3",
+        .transport_parameters = parameters[0..parameters_len],
+        .offer = &offered_suites,
+        .random = seed[0..32].*,
+        .key_seed = seed[32..64].*,
+    });
+
+    var hello: [2048]u8 = undefined;
+    const client_hello = state.client.clientHello(&hello) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+    state.connection.cryptoIn(.initial, client_hello) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+    return true;
+}
+
+/// Move handshake octets between the connection and the TLS client in both
+/// directions, and install whatever the key schedule produced.
+fn pumpCrypto(p: *conn.Params, state: *State) bool {
+    for ([_]quic.crypto.Level{ .initial, .handshake, .one_rtt }) |level| {
+        const available = state.connection.cryptoOut(level);
+        if (available.len == 0) continue;
+        const consumed = state.client.read(level, available) catch {
+            // A handshake this endpoint could not follow. Before the connection
+            // is established that is a connect failure; after it, a
+            // post-handshake message we could not read, which kills the
+            // connection and every request on it.
+            failHandshakeOrRead(p, state);
+            return false;
+        };
+        state.connection.cryptoConsumed(level, consumed);
+    }
+
+    for (state.client.drainInstalls()) |one| {
+        var secret = quic.crypto.Secret.init(&one.secret) catch {
+            failHandshakeOrRead(p, state);
+            return false;
+        };
+        // Switched rather than forwarded: `installSecret`'s direction is an
+        // anonymous enum declared in its own signature, so the two types are
+        // distinct even though the tags are the same.
+        const installed = switch (one.direction) {
+            .send => state.connection.installSecret(one.level, .send, &secret, one.suite),
+            .receive => state.connection.installSecret(one.level, .receive, &secret, one.suite),
+        };
+        installed catch {
+            failHandshakeOrRead(p, state);
+            return false;
+        };
+    }
+
+    if (state.client.drainTransportParameters()) |octets| {
+        state.connection.transportParametersIn(octets) catch {
+            failHandshakeOrRead(p, state);
+            return false;
+        };
+    }
+
+    const finished = state.client.drainFinished();
+    if (finished.len > 0) {
+        state.connection.cryptoIn(.handshake, finished) catch {
+            failHandshakeOrRead(p, state);
+            return false;
+        };
+    }
+    return true;
+}
+
+/// A TLS or key-schedule failure, charged to whichever phase it happened in.
+fn failHandshakeOrRead(p: *conn.Params, state: *State) void {
+    if (state.connection.state == .handshaking) {
+        conn.noteError(p, .connect);
+    } else {
+        abandonAll(p, state, .read);
+        conn.noteError(p, .read);
+    }
+}
+
+/// RFC 9114 §6.2: this endpoint's three unidirectional streams, sent as soon as
+/// there are 1-RTT keys to send them under.
+///
+/// The QPACK streams carry their type octet and nothing else, ever. This
+/// endpoint advertises `SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0`, so it will never
+/// encode a dynamic table instruction — but RFC 9204 §4.2 still expects the
+/// streams to exist, and a server that waits for them before answering is a
+/// server this client would otherwise hang on.
+fn startHttp3(p: *conn.Params, state: *State) bool {
+    var buffer: [256]u8 = undefined;
+    const control = state.http3.writeControl(&buffer) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+    const written = state.connection.write(control_stream, buffer[0..control], false) catch {
+        conn.noteError(p, .connect);
+        return false;
+    };
+    if (written != control) {
+        conn.noteError(p, .connect);
+        return false;
+    }
+    inline for (.{
+        .{ qpack_encoder_stream, h3.stream.Type.qpack_encoder },
+        .{ qpack_decoder_stream, h3.stream.Type.qpack_decoder },
+    }) |pair| {
+        const octets = h3.stream.write(&buffer, pair[1]) catch {
+            conn.noteError(p, .connect);
+            return false;
+        };
+        _ = state.connection.write(pair[0], buffer[0..octets], false) catch {
+            conn.noteError(p, .connect);
+            return false;
+        };
+    }
+    state.http3_started = true;
+    return true;
+}
+
+/// Open as many requests as the schedule, the slot table and the peer's stream
+/// limit allow — and no more.
+///
+/// Structurally `connection.zig`'s serial request loop with the blocking
+/// exchange taken out of the middle. Every step it shares with that loop means
+/// what it means there; a send that is not due yet simply returns, and the
+/// wait `waitFor` computes is what brings the loop back at the right moment.
+fn issue(
+    p: *conn.Params,
+    state: *State,
+    anchor: *?Io.Timestamp,
+    send_index: *u64,
+) void {
+    const io = p.io;
+    const depth = @min(p.streams, requests_max);
+
+    // Bounded by the slot table: every pass either sends (consuming a slot),
+    // sheds (consuming an index and continuing), or returns.
+    for (0..requests_max) |_| {
+        if (busySlots(state) >= depth) return;
+        const slot = freeSlot(state) orelse return;
+        // The peer decides how many identifiers this endpoint may use; writing
+        // to one it has not permitted is a connection error at the far end
+        // rather than a short write here.
+        if (!state.connection.streams.peerPermits(state.next_stream)) return;
+
+        const t = conn.now(io);
+        if (t.nanoseconds >= p.end.nanoseconds) return;
+
+        // Closed loop has no schedule to solve: the send is intended for
+        // whenever a stream frees, which degenerately zeroes the pacing wait,
+        // the deadline check and the coordinated-omission correction, leaving
+        // genuine round-trip latency.
+        if (anchor.* == null) anchor.* = t;
+        const scheduled = if (p.schedule == .closed) t else blk: {
+            const offset = p.schedule.offsetNs(send_index.*, p.phase);
+            break :blk anchor.*.?.addDuration(Io.Duration.fromNanoseconds(@intCast(offset)));
+        };
+
+        // Not due yet. Nothing to shed and nothing to send; the loop sleeps.
+        if (scheduled.nanoseconds > t.nanoseconds) return;
+
+        const behind_ns: i128 = t.nanoseconds - scheduled.nanoseconds;
+        if (behind_ns > 0) p.counters.noteBehind(@intCast(behind_ns));
+
+        // Deadline shedding: a request already staler than the deadline can
+        // never meet it, so fail it now — without touching the wire — and move
+        // on. This is what lets the connection drain a backlog and keep
+        // measuring near-live latency instead of serializing through an
+        // ever-staler queue.
+        if (p.deadline_ns != 0 and behind_ns > p.deadline_ns) {
+            conn.noteDeadline(p);
+            send_index.* += 1;
+            continue;
+        }
+
+        const id = state.next_stream;
+        const written = state.connection.write(id, p.h3_request, true) catch |err| switch (err) {
+            // Backpressure, not a failure. The stream table is full of streams
+            // that have finished and are waiting their turn to retire (see
+            // `streams_max`), or the peer's connection-level window is spent.
+            // Neither is the target answering wrongly, and neither is
+            // permanent: `send_index` is deliberately *not* advanced, so this
+            // request goes out on a later pass and its coordinated-omission
+            // latency carries the wait — which is exactly what a client-side
+            // queue should do to the numbers.
+            error.TooManyStreams, error.FlowControl => return,
+            else => {
+                conn.noteError(p, .write);
+                return;
+            },
+        };
+        if (written != p.h3_request.len) {
+            // The stream send buffer could not take the whole request. A fresh
+            // stream's buffer is empty and `cli.zig` bounds `--body` against
+            // it, so this is unreachable for a well-formed run — and a
+            // half-written request is not one this file can resume, so the
+            // stream is abandoned rather than left for the peer to parse.
+            state.connection.resetStream(id, h3_request_cancelled) catch {};
+            state.next_stream += 4;
+            conn.noteError(p, .write);
+            return;
+        }
+
+        // RFC 9000 §2.1: client-initiated bidirectional streams are 0, 4, 8 —
+        // the two least significant bits are the type, and this assertion is
+        // what keeps that a fact rather than a comment.
+        std.debug.assert(state.next_stream % 4 == 0);
+        state.next_stream += 4;
+        send_index.* += 1;
+
+        // Both bounds are absolute timestamps — the wire timeout from the
+        // actual send, the coordinated-omission abort from `scheduled` — so the
+        // earlier one binds and the two collapse into a single deadline.
+        const wire_deadline_ns: u64 = if (p.timeout_ns != 0)
+            @intCast(t.nanoseconds + @as(i128, p.timeout_ns))
+        else
+            0;
+        const co_deadline_ns: u64 = if (p.deadline_abort and p.deadline_ns != 0)
+            @intCast(scheduled.nanoseconds + @as(i128, p.deadline_ns))
+        else
+            0;
+        const co_binds = co_deadline_ns != 0 and
+            (wire_deadline_ns == 0 or co_deadline_ns <= wire_deadline_ns);
+
+        slot.* = .{
+            .busy = true,
+            .stream = id,
+            .scheduled = scheduled,
+            .deadline_ns = if (co_binds) co_deadline_ns else wire_deadline_ns,
+            .deadline_co = co_binds,
+        };
+    }
+}
+
+/// Drive `Http3` over every stream the connection has reported data on, and
+/// fold what comes out into the slot it belongs to.
+fn drain(p: *conn.Params, state: *State) bool {
+    var index: usize = 0;
+    // Bounded by `readable_len`, which is bounded by the stream table.
+    while (index < state.readable_len) : (index += 1) {
+        const id = state.readable[index];
+
+        // A request stream whose slot is gone is one this connection has
+        // finished with: the response was recorded, or the request's bound
+        // expired and the stream was reset. It must not be handed to `Http3`
+        // again.
+        //
+        // Not a tidiness rule. A stream stays live in the transport after its
+        // response is complete — our own send side is not retired until it is
+        // acknowledged — so `fin` stays true and `receive` reports `finished`
+        // again on every pass. The second report finds no slot and is dropped,
+        // but `receive` allocates a request-table entry for whatever identifier
+        // it is given *before* deciding what to say about it, and that entry is
+        // only ever freed by `release`, which the dropped event never reaches.
+        // The table fills, and a load generator that is working perfectly
+        // starts answering `H3_EXCESSIVE_LOAD` to itself: 1.9% of requests on
+        // the run that found this.
+        //
+        // RFC 9000 §2.1: a client-initiated bidirectional stream is `id % 4 ==
+        // 0`, which is every stream this endpoint opens for a request. The
+        // peer's unidirectional streams are not filtered — the control stream
+        // has no slot and never will, and it is where SETTINGS and GOAWAY come
+        // from.
+        if (id % 4 == 0 and slotFor(state, id) == null) continue;
+
+        // A stream the connection has already given up is handled by the sweep
+        // at the end of this function, not here — see it for why the sweep and
+        // not this branch is the one that has to be right.
+        const stream = state.connection.findStream(id) orelse continue;
+        if (stream.receive_state == .reset) {
+            if (slotFor(state, id)) |slot| {
+                release(state, slot);
+                conn.noteError(p, .read);
+            }
+            continue;
+        }
+
+        const data = state.connection.readable(id);
+        // Whether the FIN sits at the end of what is readable now. A
+        // half-arrived frame followed by a FIN is a truncated message, and
+        // `Http3` has to be told which it is looking at.
+        const fin = if (stream.received.final_size) |size|
+            size == stream.consumed + data.len
+        else
+            false;
+        if (data.len == 0 and !fin) continue;
+
+        var events: [events_per_stream_max]h3.http3.Event = undefined;
+        const result = state.http3.receive(id, data, fin, &events) catch {
+            // A malformed HTTP/3 message. RFC 9114 §8 makes most of these
+            // connection errors, and this endpoint has no reason to be lenient
+            // about a response it is measuring.
+            abandonAll(p, state, .read);
+            conn.noteError(p, .read);
+            return false;
+        };
+        for (events[0..result.events]) |event| apply(p, state, event);
+        if (result.consumed > 0) {
+            state.connection.consume(id, result.consumed) catch {
+                abandonAll(p, state, .read);
+                conn.noteError(p, .read);
+                return false;
+            };
+        }
+    }
+
+    // A stream the transport has retired is one both halves have finished
+    // with: every octet delivered, the FIN consumed, nothing more coming. That
+    // is a complete response, and it is *only* visible as an absence — the
+    // last octets of a body and the end of the stream can land in the same
+    // pass, in which case the stream is gone before any code here reads a
+    // `Http3` event off it, and there is no `finished` to wait for.
+    //
+    // A sweep over the slots rather than a branch inside the loop above,
+    // because a stream can be retired without ever having been announced as
+    // readable, and a request whose slot was only freed by its own `--timeout`
+    // is a response this tool measured as a failure and the peer sent
+    // correctly. This was the whole of the first prototype's stall: a 17-octet
+    // response completed and a 4 KiB one hung, because only the small one
+    // arrived whole enough to produce a `finished` before the retire.
+    //
+    // Ordered after the drain so that a response finishing in *this* pass has
+    // already had its HEADERS and DATA folded into the slot.
+    for (&state.slots) |*slot| {
+        if (!slot.busy) continue;
+        if (state.connection.findStream(slot.stream) != null) continue;
+        complete(p, state, slot);
+    }
+
+    compactReadable(state);
+    return true;
+}
+
+/// One HTTP/3 event, applied to the request it belongs to.
+fn apply(p: *conn.Params, state: *State, event: h3.http3.Event) void {
+    switch (event) {
+        // The peer's SETTINGS and its GOAWAY are both connection-level facts
+        // this prototype has nothing to do with: it opens one stream per
+        // request and never more than `--streams` of them, and a run that is
+        // told to go away simply reconnects when the peer closes.
+        .settings, .goaway => {},
+        .headers => |value| {
+            const slot = slotFor(state, value.stream) orelse return;
+            slot.bytes += value.section.len;
+            if (value.trailers) return;
+            slot.status = statusOf(state, value.section);
+        },
+        .data => |value| {
+            const slot = slotFor(state, value.stream) orelse return;
+            slot.bytes += value.payload.len;
+        },
+        .finished => |id| {
+            const slot = slotFor(state, id) orelse return;
+            complete(p, state, slot);
+        },
+    }
+}
+
+/// `:status` out of a QPACK field section, or null if it is not there.
+///
+/// Decoded rather than trusted: `Http3` hands the section over encoded because
+/// the buffer a decode needs is many times the section's size and belongs to
+/// the caller. Only `:status` is kept — zrk deliberately retains no header
+/// content, on any transport.
+fn statusOf(state: *State, section: []const u8) ?u16 {
+    var iterator = h3.qpack.field_line.iterate(
+        section,
+        &state.fields,
+        field_section_octets_max,
+    ) catch return null;
+    // Bounded by the section, which `Http3` bounded by the advertised maximum.
+    while (iterator.next() catch return null) |field| {
+        if (!std.mem.eql(u8, field.name, ":status")) continue;
+        return std.fmt.parseInt(u16, field.value, 10) catch null;
+    }
+    return null;
+}
+
+/// A response that arrived whole: record it exactly as the serial path does.
+fn complete(p: *conn.Params, state: *State, slot: *Slot) void {
+    const io = p.io;
+
+    // Coordinated-omission-corrected latency: measured from the time the
+    // request *should* have been sent, not from when it actually went out.
+    const done = conn.now(io);
+    const latency_ns = done.nanoseconds - slot.scheduled.nanoseconds;
+    const latency_us: u64 = if (latency_ns > 0)
+        @intCast(@divTrunc(latency_ns, std.time.ns_per_us))
+    else
+        0;
+    p.histogram.record(latency_us);
+
+    p.counters.completed += 1;
+    p.counters.bytes += slot.bytes;
+    // A response whose HEADERS never carried a readable `:status` is not a
+    // response this tool can classify. `Http3` and `fields.MessageValidator`
+    // between them make that unreachable for a conforming peer; 0 lands in the
+    // "non-2xx/3xx" bucket, which is the honest answer if it ever happens.
+    p.counters.recordStatus(slot.status orelse 0);
+
+    conn.maybePublish(p, done.nanoseconds);
+    release(state, slot);
+}
+
+/// Give a slot and its stream back to both layers.
+fn release(state: *State, slot: *Slot) void {
+    state.http3.release(slot.stream);
+    slot.* = .{};
+}
+
+/// Abandon a request that outlived its bound, and *only* that request.
+///
+/// This is the whole difference from the serial TCP path. There a timeout is a
+/// socket shutdown — abandoning the request and the connection in one act,
+/// which is exact when they hold one request between them. Here the same act
+/// would take every other in-flight sample with it, so the bound is spent on
+/// RESET_STREAM and STOP_SENDING and the other responses go on arriving.
+fn expire(p: *conn.Params, state: *State) void {
+    const io = p.io;
+    const nanoseconds = conn.now(io).nanoseconds;
+
+    for (&state.slots) |*slot| {
+        if (!slot.busy or slot.deadline_ns == 0) continue;
+        if (nanoseconds < slot.deadline_ns) continue;
+
+        // Best effort: a peer that will not take the frames is a peer this
+        // request was already lost to.
+        state.connection.resetStream(slot.stream, h3_request_cancelled) catch {};
+        state.connection.stopSending(slot.stream, h3_request_cancelled) catch {};
+
+        if (slot.deadline_co) {
+            conn.noteDeadline(p);
+        } else {
+            conn.noteTimeout(p, io, slot.scheduled);
+        }
+        release(state, slot);
+    }
+}
+
+/// Every in-flight request, charged to one error kind. The connection is going
+/// away and these responses are never arriving.
+fn abandonAll(p: *conn.Params, state: *State, kind: conn.ErrorKind) void {
+    for (&state.slots) |*slot| {
+        if (!slot.busy) continue;
+        conn.noteError(p, kind);
+        release(state, slot);
+    }
+}
+
+/// Empty the transport's event queue. The one event this loop must act on is
+/// `stream_readable`; the rest are recorded by the connection itself.
+fn pollTransport(p: *conn.Params, state: *State) bool {
+    // Bounded rather than "until null": a queue that refills as fast as it is
+    // drained is a bug this loop should not turn into a hang.
+    for (0..events_per_poll_max) |_| {
+        const event = state.connection.poll() orelse return true;
+        switch (event) {
+            .stream_readable => |id| noteReadable(state, id),
+            .stream_reset => |value| {
+                if (slotFor(state, value.stream)) |slot| {
+                    release(state, slot);
+                    conn.noteError(p, .read);
+                }
+            },
+            .stream_stopped => |value| {
+                if (slotFor(state, value.stream)) |slot| {
+                    release(state, slot);
+                    conn.noteError(p, .write);
+                }
+            },
+            .closed => {
+                abandonAll(p, state, .read);
+                conn.noteError(p, .read);
+                return false;
+            },
+            // `overflowed` means events were produced faster than this loop
+            // polled, which cannot happen while the queue is drained every
+            // pass. A dropped `stream_readable` would strand a response, so
+            // the connection is retired rather than left to time out one
+            // request at a time.
+            .overflowed => {
+                abandonAll(p, state, .read);
+                conn.noteError(p, .read);
+                return false;
+            },
+            .handshake_confirmed, .stream_delivered, .key_updated, .packets_lost => {},
+        }
+    }
+    return true;
+}
+
+/// Build and send datagrams until the connection has nothing more.
+fn flush(p: *conn.Params, state: *State, socket: *net.Socket, now_ns: u64) bool {
+    for (0..flush_datagrams_max) |_| {
+        const octets = state.connection.send(&state.datagram, now_ns) catch {
+            abandonAll(p, state, .write);
+            conn.noteError(p, .write);
+            return false;
+        };
+        if (octets == 0) return true;
+        socket.send(p.io, &p.address, state.datagram[0..octets]) catch {
+            // A datagram the kernel would not take — a full socket buffer under
+            // load, most often — is a lost packet, which is the one failure
+            // QUIC is built to absorb: `Recovery` will declare it lost and send
+            // it again. Killing the connection over it would turn a moment of
+            // local backpressure into every in-flight request failing, and
+            // counting it as a write error would report the target as failing
+            // when the send never left this machine.
+            return true;
+        };
+    }
+    return true;
+}
+
+/// How long the loop may sleep: the earliest of the next scheduled send, the
+/// transport's own timer, the earliest in-flight bound, the run's end, and the
+/// idle slice that keeps `stop` responsive.
+fn waitFor(
+    p: *conn.Params,
+    state: *State,
+    anchor: *?Io.Timestamp,
+    send_index: u64,
+    origin: Io.Timestamp,
+) u64 {
+    const io = p.io;
+    const t = conn.now(io);
+
+    var wake: i128 = t.nanoseconds + idle_slice_ns;
+    if (p.end.nanoseconds < wake) wake = p.end.nanoseconds;
+
+    if (state.connection.timeout()) |at| {
+        const absolute = origin.nanoseconds + @as(i128, at);
+        if (absolute < wake) wake = absolute;
+    }
+
+    // The next send, but only if there is somewhere to put it. A schedule that
+    // has run ahead of the slot table is not a reason to spin: the wake that
+    // matters then is the one that frees a slot, which is a response or a
+    // deadline, both of which are below.
+    const depth = @min(p.streams, requests_max);
+    if (state.connection.state == .established and
+        busySlots(state) < depth and
+        p.schedule != .closed)
+    {
+        if (anchor.*) |base| {
+            const offset = p.schedule.offsetNs(send_index, p.phase);
+            const scheduled = base.nanoseconds + @as(i128, @intCast(offset));
+            if (scheduled < wake) wake = scheduled;
+        } else {
+            // Nothing has been anchored yet, so the first send is due the
+            // moment the connection is usable.
+            wake = t.nanoseconds;
+        }
+    }
+
+    for (&state.slots) |*slot| {
+        if (!slot.busy or slot.deadline_ns == 0) continue;
+        if (@as(i128, slot.deadline_ns) < wake) wake = slot.deadline_ns;
+    }
+
+    if (wake <= t.nanoseconds) return 0;
+    return @intCast(wake - t.nanoseconds);
+}
+
+// ------------------------------------------------------------- slot plumbing
+
+fn freeSlot(state: *State) ?*Slot {
+    for (&state.slots) |*slot| {
+        if (!slot.busy) return slot;
+    }
+    return null;
+}
+
+fn busySlots(state: *State) u32 {
+    var count: u32 = 0;
+    for (&state.slots) |*slot| {
+        if (slot.busy) count += 1;
+    }
+    return count;
+}
+
+fn slotFor(state: *State, id: u64) ?*Slot {
+    for (&state.slots) |*slot| {
+        if (slot.busy and slot.stream == id) return slot;
+    }
+    return null;
+}
+
+/// Remember a stream the transport says has data, without letting the list
+/// grow past the table it indexes.
+fn noteReadable(state: *State, id: u64) void {
+    for (state.readable[0..state.readable_len]) |seen| {
+        if (seen == id) return;
+    }
+    if (state.readable_len == state.readable.len) return;
+    state.readable[state.readable_len] = id;
+    state.readable_len += 1;
+}
+
+/// Drop the identifiers whose streams are gone, so the list does not fill up
+/// and start refusing new ones.
+fn compactReadable(state: *State) void {
+    var kept: usize = 0;
+    // Bounded by `readable_len`.
+    for (state.readable[0..state.readable_len]) |id| {
+        if (state.connection.findStream(id) == null) continue;
+        state.readable[kept] = id;
+        kept += 1;
+    }
+    state.readable_len = kept;
+}
+
+fn elapsed(io: Io, origin: Io.Timestamp) u64 {
+    const t = conn.now(io);
+    const delta = t.nanoseconds - origin.nanoseconds;
+    return if (delta > 0) @intCast(delta) else 0;
+}
+
+const testing = std.testing;
+
+test "a connection's transport state is a bounded, allocation-free block" {
+    // The whole point of `h3` being comptime-sized: `-c 100` costs exactly a
+    // hundred of these and nothing else, so a run's memory is knowable before
+    // it starts. The bound is generous — this is a guard against a limit above
+    // being raised without anyone noticing what it multiplies by.
+    try testing.expect(footprint_octets < 4 * 1024 * 1024);
+}
+
+test "the request frame is a HEADERS frame that fits one stream write" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+
+    const parsed = try cli.parse(arena.allocator(), &[_][]const u8{
+        "--http3", "--insecure", "https://example.com/hello",
+    });
+    const frame = try buildRequest(arena.allocator(), &parsed.config);
+
+    try testing.expect(frame.len <= request_octets_max);
+    // RFC 9114 §7.2.2: a HEADERS frame's type is 0x01, and it is the first
+    // octet here because the frame's own header comes first.
+    try testing.expectEqual(@as(u8, 0x01), frame[0]);
+}
+
+test "a request body rides in a DATA frame after the header block" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+
+    const parsed = try cli.parse(arena.allocator(), &[_][]const u8{
+        "--http3", "--insecure", "-m", "POST", "-b", "hello", "https://example.com/",
+    });
+    const frame = try buildRequest(arena.allocator(), &parsed.config);
+
+    // The body's octets are on the wire verbatim, after a DATA header the
+    // frame layer wrote; finding them is enough to say the two frames were
+    // concatenated rather than one overwriting the other.
+    try testing.expect(std.mem.indexOf(u8, frame, "hello") != null);
+}

--- a/src/h3conn.zig
+++ b/src/h3conn.zig
@@ -38,12 +38,18 @@
 //!
 //! * **No certificate verification.** `quic_tls.zig` says why, and `cli.zig`
 //!   makes `--http3` require `--insecure` so no run can believe otherwise.
-//! * **One datagram per syscall.** The issue that asked for HTTP/3
-//!   (zoxy-io/zrk#74) names GSO/GRO batching as the thing that decides whether
-//!   a load generator can saturate a link. `std.Io.net.Socket` has `sendMany`
-//!   and `receiveManyTimeout` and zio implements both, so the seam is there;
-//!   this file does not use it yet, and that is the first optimisation to
-//!   measure rather than assume.
+//!   Accepted rather than outstanding: a load generator is pointed at a target
+//!   its operator chose, and the other two transports keep verification on by
+//!   default for the case where that is not enough.
+//! * **One datagram per syscall** — `flush` calls `socket.send` once per
+//!   datagram and the loop below receives one per `receiveTimeout`.
+//!   zoxy-io/zrk#76 is the work, and it is larger than the API surface
+//!   suggests: `std.Io.net.Socket` has `sendMany` and `receiveManyTimeout`,
+//!   but zio implements the first as a `for` loop over `sendmsg` and the
+//!   second one `recvmsg` at a time, and nothing in the stack exposes
+//!   `UDP_SEGMENT` or `UDP_GRO`. So the batched *API* is here and the batching
+//!   is not, and closing that is plumbing in a dependency rather than a
+//!   call-site change in this file.
 //! * **No connection migration, no 0-RTT, no session resumption.** A run that
 //!   reconnects pays a full handshake every time.
 //!

--- a/src/http.zig
+++ b/src/http.zig
@@ -74,6 +74,77 @@ pub fn buildRequest(allocator: std.mem.Allocator, cfg: *const cli.Config) ![]u8 
     return alloc_writer.toOwnedSlice();
 }
 
+/// One request field, in the form both HPACK and QPACK take it.
+///
+/// A local type rather than either encoder's. h2 vendors its own HPACK and h3
+/// depends on zoxy-io/hpack, so `h2.hpack.Field` and `h3.qpack.Field` are
+/// distinct nominal types of identical shape — and the rules that decide
+/// *which* fields zrk's request carries are not rules to write twice. They are
+/// written once, here, and each transport maps this list into its own encoder's
+/// type at the last moment.
+pub const Field = struct {
+    name: []const u8,
+    value: []const u8,
+};
+
+/// The field list zrk's request is, for either of the two transports that take
+/// one. Every string it points at is allocated in `scratch`, which the caller
+/// owns; the encoders copy the octets in, so the list dies with the encode.
+///
+/// Validated here rather than by each caller: a malformed request would be
+/// answered with a stream error on every single stream, and the run would
+/// report the target failing when it was us.
+pub fn buildRequestFields(scratch: std.mem.Allocator, cfg: *const cli.Config) ![]const Field {
+    var fields: std.ArrayList(Field) = .empty;
+
+    // RFC 9113 §8.3 and RFC 9114 §4.3.1 name the same four, and they come first.
+    try fields.append(scratch, .{ .name = ":method", .value = cfg.method });
+    try fields.append(scratch, .{ .name = ":scheme", .value = if (cfg.url.isTls()) "https" else "http" });
+    try fields.append(scratch, .{ .name = ":path", .value = cfg.url.target });
+
+    // §8.3.1: `:authority` replaces `Host`, and carries the port only when it
+    // is not the scheme's default — the same rule `buildRequest` applies to
+    // `Host`, so every transport addresses the same origin.
+    const default_port: u16 = if (cfg.url.isTls()) 443 else 80;
+    const authority = if (cfg.url.port == default_port)
+        try scratch.dupe(u8, cfg.url.host)
+    else
+        try std.fmt.allocPrint(scratch, "{s}:{d}", .{ cfg.url.host, cfg.url.port });
+    try fields.append(scratch, .{ .name = ":authority", .value = authority });
+
+    var has_ua = false;
+    var has_cl = false;
+    for (cfg.headers) |h| {
+        if (std.ascii.eqlIgnoreCase(h.name, "user-agent")) has_ua = true;
+        if (std.ascii.eqlIgnoreCase(h.name, "content-length")) has_cl = true;
+        // §8.2.1 requires field names to be lowercase on the wire. `-H` takes
+        // them in whatever case the user typed, exactly as HTTP/1.1 does, so
+        // the case is folded here rather than refused — the user asked for a
+        // header, not for a lesson.
+        try fields.append(scratch, .{
+            .name = try lowerName(scratch, h.name),
+            .value = h.value,
+        });
+    }
+    if (!has_ua) try fields.append(scratch, .{ .name = "user-agent", .value = "zrk" });
+
+    // No `Connection: keep-alive`: §8.2.2 makes connection-specific header
+    // fields malformed above HTTP/1.1, and `buildRequest` adds one.
+    if (!has_cl) {
+        if (cfg.body.len > 0) {
+            try fields.append(scratch, .{
+                .name = "content-length",
+                .value = try std.fmt.allocPrint(scratch, "{d}", .{cfg.body.len}),
+            });
+        } else if (methodAnticipatesBody(cfg.method)) {
+            try fields.append(scratch, .{ .name = "content-length", .value = "0" });
+        }
+    }
+
+    try validateRequestFields(fields.items);
+    return fields.items;
+}
+
 /// The HTTP/2 request as one HPACK-encoded header block, built once.
 ///
 /// Encoded with `Encoder.Mode.static_only`, which is an API guarantee in
@@ -92,59 +163,13 @@ pub fn buildRequestBlock(allocator: std.mem.Allocator, cfg: *const cli.Config) !
     defer scratch.deinit();
     const tmp = scratch.allocator();
 
-    var fields: std.ArrayList(h2.hpack.Field) = .empty;
+    const fields = try buildRequestFields(tmp, cfg);
 
-    // RFC 9113 §8.3: the pseudo-header fields, and they come first.
-    try fields.append(tmp, .{ .name = ":method", .value = cfg.method });
-    try fields.append(tmp, .{ .name = ":scheme", .value = if (cfg.url.isTls()) "https" else "http" });
-    try fields.append(tmp, .{ .name = ":path", .value = cfg.url.target });
+    // Into h2's own field type at the last moment; see `Field`.
+    const hpack_fields = try tmp.alloc(h2.hpack.Field, fields.len);
+    for (hpack_fields, fields) |*out, in| out.* = .{ .name = in.name, .value = in.value };
 
-    // §8.3.1: `:authority` replaces `Host`, and carries the port only when it
-    // is not the scheme's default — the same rule `buildRequest` applies to
-    // `Host`, so the two transports address the same origin.
-    const default_port: u16 = if (cfg.url.isTls()) 443 else 80;
-    const authority = if (cfg.url.port == default_port)
-        try tmp.dupe(u8, cfg.url.host)
-    else
-        try std.fmt.allocPrint(tmp, "{s}:{d}", .{ cfg.url.host, cfg.url.port });
-    try fields.append(tmp, .{ .name = ":authority", .value = authority });
-
-    var has_ua = false;
-    var has_cl = false;
-    for (cfg.headers) |h| {
-        if (std.ascii.eqlIgnoreCase(h.name, "user-agent")) has_ua = true;
-        if (std.ascii.eqlIgnoreCase(h.name, "content-length")) has_cl = true;
-        // §8.2.1 requires field names to be lowercase on the wire. `-H` takes
-        // them in whatever case the user typed, exactly as HTTP/1.1 does, so
-        // the case is folded here rather than refused — the user asked for a
-        // header, not for a lesson.
-        try fields.append(tmp, .{
-            .name = try lowerName(tmp, h.name),
-            .value = h.value,
-        });
-    }
-    if (!has_ua) try fields.append(tmp, .{ .name = "user-agent", .value = "zrk" });
-
-    // No `Connection: keep-alive`: §8.2.2 makes connection-specific header
-    // fields malformed in HTTP/2, and `buildRequest` adds one.
-    if (!has_cl) {
-        if (cfg.body.len > 0) {
-            try fields.append(tmp, .{
-                .name = "content-length",
-                .value = try std.fmt.allocPrint(tmp, "{d}", .{cfg.body.len}),
-            });
-        } else if (methodAnticipatesBody(cfg.method)) {
-            try fields.append(tmp, .{ .name = "content-length", .value = "0" });
-        }
-    }
-
-    // Checked before it goes on the wire, once, for the block that will be sent
-    // for the whole run. A malformed request would be answered with a stream
-    // error on every single stream, and the run would report the target
-    // failing when it was us.
-    try validateRequestFields(fields.items);
-
-    return encodeBlock(allocator, fields.items);
+    return encodeBlock(allocator, hpack_fields);
 }
 
 /// Encode into a buffer sized from the fields themselves.
@@ -181,7 +206,7 @@ fn lowerName(allocator: std.mem.Allocator, name: []const u8) ![]u8 {
 
 /// The request has to be a well-formed HTTP/2 request before it is sent a
 /// million times.
-fn validateRequestFields(fields: []const h2.hpack.Field) !void {
+fn validateRequestFields(fields: []const Field) !void {
     var validator: h2.fields.MessageValidator = .init(.{
         .kind = .request,
         // The stricter reading for what *we* send. zrk is lenient about what a
@@ -189,8 +214,13 @@ fn validateRequestFields(fields: []const h2.hpack.Field) !void {
         // request it generates itself has no excuse for being questionable.
         .rules = .strict,
     });
+    // h2's validator for the HTTP/3 request too. RFC 9114 §4.3 restates RFC
+    // 9113 §8.3's rules for the same four pseudo-headers, so one validator
+    // answers for both — and it is the request *this program builds*, not
+    // anything a peer sent, so the two readings cannot diverge on real input.
     for (fields) |field| {
-        validator.field(&field) catch return error.InvalidRequestHeader;
+        const one: h2.hpack.Field = .{ .name = field.name, .value = field.value };
+        validator.field(&one) catch return error.InvalidRequestHeader;
     }
     validator.finish() catch return error.InvalidRequestHeader;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -424,8 +424,12 @@ fn printUsageError(io: Io, err: cli.ParseError) !void {
         error.ClosedWithDeadline => "zrk: --closed is incompatible with --deadline\n\n",
         error.KeepaliveWithHttp2 => "zrk: --disable-keepalive is incompatible with --http2\n\n",
         error.ZeroStreams => "zrk: streams (-s) must be greater than 0\n\n",
-        error.StreamsWithoutHttp2 => "zrk: streams (-s) requires --http2; HTTP/1.1 has no second stream to open\n\n",
+        error.StreamsWithoutHttp2 => "zrk: streams (-s) requires --http2 or --http3; HTTP/1.1 has no second stream to open\n\n",
         error.TooManyStreams => "zrk: streams (-s) exceeds the per-connection maximum\n\n",
+        error.Http3WithHttp2 => "zrk: --http3 and --http2 are different transports; run them separately\n\n",
+        error.Http3WithoutTls => "zrk: --http3 needs an https:// URL; QUIC has no cleartext mode\n\n",
+        error.Http3WithoutInsecure => "zrk: --http3 is a prototype and does not verify certificates yet, so it requires -k/--insecure\n\n",
+        error.Http3BodyTooLarge => "zrk: --body is too large for --http3; the request must fit one QUIC stream write\n\n",
         error.OutOfMemory => "zrk: out of memory\n\n",
     };
     try writeAll(io, .stderr(), msg);

--- a/src/quic_tls.zig
+++ b/src/quic_tls.zig
@@ -1,0 +1,969 @@
+//! A TLS 1.3 client handshake in QUIC mode, for `h3conn.zig` and nothing else.
+//!
+//! ## Why this file exists at all
+//!
+//! zrk terminates TLS through zssl everywhere else, and zssl is the right
+//! engine: it is audited Zig over a constant-time libcrypto, and `src/tls.zig`
+//! adds the two things it declines — the `std.Io` adapter and X.509 chain and
+//! hostname verification. **zssl does not do QUIC** (its README: "Out, for
+//! now: ... and QUIC"), and QUIC does not want a TLS *record* layer at all.
+//! RFC 9001 §4 replaces it: handshake messages cross as CRYPTO frames, and
+//! what the engine hands back is a traffic secret per encryption level rather
+//! than a sealed record. There is no way to drive that through an API whose
+//! unit is a record.
+//!
+//! So this is a second, much smaller TLS client, vendored from h3's
+//! `interop/tls.zig` — the file that completed real handshakes against
+//! quic-go, ngtcp2 and aioquic in the QUIC Interop Runner. It is here rather
+//! than in h3 because h3's `paths` ships `src/` only: `interop/` is that
+//! package's test harness, deliberately not part of its library.
+//!
+//! ## What it does not do, and what that costs
+//!
+//! **It does not verify certificates.** It parses `Certificate` and
+//! `CertificateVerify` far enough to keep the transcript hash correct and then
+//! ignores both. In the interop runner that was the test bed's contract — a
+//! throwaway CA per run, every client configured to trust anything. Here it is
+//! a gap, and `cli.zig` names it: `--http3` requires `--insecure`, so a run
+//! cannot silently believe it authenticated a peer it did not.
+//!
+//! Closing it is a known, bounded piece of work rather than a research
+//! problem. `Client.read` already walks the `Certificate` message's DER
+//! entries to hash them; `src/tls.zig`'s `verifyChain` already builds a chain
+//! to a system anchor and matches the hostname over `std.crypto.Certificate`.
+//! What is missing is the wiring between them, plus checking the
+//! `CertificateVerify` signature over RFC 8446 §4.4.3's context string. Until
+//! that lands, this engine proves the peer speaks QUIC, not who it is.
+//!
+//! **It offers only SHA-256 suites** — `TLS_AES_128_GCM_SHA256` and
+//! `TLS_CHACHA20_POLY1305_SHA256` — because the key schedule below is written
+//! against one hash rather than parameterised over two. `h3`'s packet
+//! protection supports AES-256-GCM regardless of whether this file can
+//! negotiate it.
+//!
+//! **It offers one group**, X25519, and refuses a HelloRetryRequest rather
+//! than answering one. **No 0-RTT, no session tickets, no post-handshake
+//! authentication**; a `NewSessionTicket` is read off the 1-RTT crypto stream
+//! and discarded, which is what keeps a server that sends two of them from
+//! stalling the connection.
+//!
+//! ## The transcript, which is where this goes wrong
+//!
+//! Three derivations read the transcript hash at three different points, and
+//! the boundaries are not interchangeable:
+//!
+//! - the handshake traffic secrets, at `ClientHello .. ServerHello`;
+//! - the server's `Finished`, verified at `ClientHello .. CertificateVerify`,
+//!   which is to say *before* that `Finished` is added;
+//! - the application traffic secrets and the client's own `Finished`, at
+//!   `ClientHello .. server Finished`, which is to say after.
+//!
+//! `message` is arranged so each of the three happens at its own boundary and
+//! the reader can see which. A transcript off by one message produces secrets
+//! that are wrong in a way nothing local can detect: the failure surfaces as
+//! the peer discarding packets it cannot authenticate.
+
+const std = @import("std");
+
+const h3 = @import("h3");
+
+const Hash = std.crypto.hash.sha2.Sha256;
+const Hkdf = std.crypto.kdf.hkdf.HkdfSha256;
+const Hmac = std.crypto.auth.hmac.sha2.HmacSha256;
+const X25519 = std.crypto.dh.X25519;
+
+const Level = h3.quic.crypto.Level;
+const Suite = h3.quic.crypto.Suite;
+
+/// SHA-256's output, which is a traffic secret's length for every suite this
+/// file offers.
+pub const secret_octets: usize = Hash.digest_length;
+/// X25519's public key and its shared secret are both this.
+const share_octets: usize = 32;
+
+/// TLS 1.3's cipher suite code points, restricted to the two whose hash is
+/// SHA-256. `aes_256_gcm_sha384` is deliberately absent; see the module
+/// comment.
+pub const CipherSuite = enum(u16) {
+    aes_128_gcm_sha256 = 0x1301,
+    chacha20_poly1305_sha256 = 0x1303,
+
+    fn quic(self: CipherSuite) Suite {
+        return switch (self) {
+            .aes_128_gcm_sha256 => .aes_128_gcm_sha256,
+            .chacha20_poly1305_sha256 => .chacha20_poly1305_sha256,
+        };
+    }
+};
+
+/// RFC 8446 section 4: the handshake message types this file acts on. Anything
+/// else is a protocol error rather than something to skip, because a message
+/// this client did not expect is a handshake it did not understand.
+const MessageType = enum(u8) {
+    client_hello = 1,
+    server_hello = 2,
+    new_session_ticket = 4,
+    encrypted_extensions = 8,
+    certificate = 11,
+    certificate_request = 13,
+    certificate_verify = 15,
+    finished = 20,
+    _,
+};
+
+const Extension = enum(u16) {
+    server_name = 0,
+    supported_groups = 10,
+    signature_algorithms = 13,
+    alpn = 16,
+    supported_versions = 43,
+    key_share = 51,
+    /// RFC 9001 section 8.2.
+    quic_transport_parameters = 57,
+    _,
+};
+
+/// X25519's code point in TLS's named group registry.
+const group_x25519: u16 = 0x001d;
+
+/// RFC 8446 section 4.1.3: the `Random` a server sends to mean
+/// HelloRetryRequest. Recognised so that the failure names itself.
+const hello_retry_request_random: [32]u8 = .{
+    0xcf, 0x21, 0xad, 0x74, 0xe5, 0x9a, 0x61, 0x11, 0xbe, 0x1d, 0x8c, 0x02,
+    0x1e, 0x65, 0xb8, 0x91,
+} ++ .{0} ** 16;
+
+pub const Error = error{
+    /// A message, extension or length field that does not parse, or a length
+    /// that runs past the octets it was given.
+    Malformed,
+    /// A handshake this client cannot complete: a HelloRetryRequest, a suite
+    /// or group it did not offer, a TLS version below 1.3, a message arriving
+    /// at the wrong encryption level or in the wrong order.
+    Unsupported,
+    /// The server's `Finished` did not match the transcript. Either the
+    /// handshake was tampered with, or — far likelier while this file is being
+    /// written — a secret or a transcript boundary here is wrong.
+    BadFinished,
+    /// Something exceeded a fixed bound: the peer's transport parameters, or
+    /// the ClientHello's own buffer.
+    TooLarge,
+    /// RFC 9001 section 8.1: the client offered no protocol this endpoint
+    /// speaks. Its own error because the alert has its own number, and h3spec
+    /// asserts on it — a handshake that failed for this reason and said
+    /// `unexpected_message` is a handshake whose peer learns nothing.
+    NoApplicationProtocol,
+    /// RFC 9001 section 8.2: no `quic_transport_parameters` extension. Likewise
+    /// its own alert.
+    MissingExtension,
+};
+
+/// A traffic secret to hand to `Connection.installSecret`, held until the
+/// caller drains it. An array rather than an event queue with slices in it:
+/// the caller drives both sides of the seam in one loop, and a secret that
+/// borrows from a parse buffer is a use-after-free waiting for the next
+/// datagram.
+pub const Install = struct {
+    level: Level,
+    direction: enum { send, receive },
+    secret: [secret_octets]u8,
+    suite: Suite,
+    /// The NSS key log label for this secret, so `SSLKEYLOGFILE` can be
+    /// written without the caller re-deriving which secret it just received.
+    label: []const u8,
+};
+
+pub const Options = struct {
+    /// The name to put in SNI, and the one this client does not check the
+    /// certificate against.
+    server_name: []const u8,
+    /// The single protocol to offer. `hq-interop` for the HTTP/0.9 test cases,
+    /// `h3` for the HTTP/3 ones.
+    alpn: []const u8,
+    /// The QUIC transport parameters extension's *body*: the encoding
+    /// `transport_parameters.encode` produces. RFC 9001 section 8.2 carries it
+    /// in the ClientHello, which is on this side of the seam.
+    transport_parameters: []const u8,
+    /// The suites to offer, in preference order.
+    offer: []const CipherSuite,
+    /// 32 octets of entropy for the ClientHello's `Random`, and 32 for the
+    /// X25519 private key. Parameters rather than draws, for the same reason
+    /// `now_ns` is a parameter in `src/`: a handshake this file cannot replay
+    /// is a handshake nothing can debug.
+    random: [32]u8,
+    key_seed: [32]u8,
+};
+
+pub const Client = struct {
+    /// Where the handshake is. The order is RFC 8446 section 4.4.2's, and a
+    /// message arriving out of it is `error.Unsupported` rather than something
+    /// to buffer: a client that tolerates reordering here is a client that
+    /// hashes the transcript in an order the server did not.
+    state: enum {
+        wait_server_hello,
+        wait_encrypted_extensions,
+        wait_certificate,
+        wait_certificate_verify,
+        wait_finished,
+        established,
+    } = .wait_server_hello,
+
+    random: [32]u8,
+    key_pair: X25519.KeyPair,
+    server_name: []const u8,
+    alpn: []const u8,
+    transport_parameters: []const u8,
+    offer: []const CipherSuite,
+
+    transcript: Hash = Hash.init(.{}),
+    /// The ECDHE output, held between parsing the ServerHello and deriving
+    /// from it. A field rather than a local because the transcript update sits
+    /// between the two and has to happen first.
+    shared: [share_octets]u8 = @splat(0),
+    suite: CipherSuite = .aes_128_gcm_sha256,
+
+    /// RFC 8446 section 7.1's schedule, kept because each stage is the salt of
+    /// the next and the next arrives a round trip later.
+    handshake_secret: [secret_octets]u8 = @splat(0),
+    client_handshake_traffic: [secret_octets]u8 = @splat(0),
+    server_handshake_traffic: [secret_octets]u8 = @splat(0),
+
+    /// Secrets produced and not yet installed. Four is the whole handshake:
+    /// two at Handshake and two at 1-RTT, and the two halves of a level are
+    /// always produced together.
+    installs: [4]Install = undefined,
+    installs_len: u8 = 0,
+
+    /// The client's `Finished`, waiting to be handed to `cryptoIn`. Sized for
+    /// a handshake header and SHA-256's output and asserted against both.
+    finished: [4 + secret_octets]u8 = @splat(0),
+    finished_len: u8 = 0,
+
+    /// The server's QUIC transport parameters, as the extension's octets.
+    /// 1024 matches `Connection.Config.transport_parameters_octets`; a server
+    /// sending more is refused here rather than at `transportParametersIn`, so
+    /// the error names the side that was too large.
+    peer_parameters: [1024]u8 = @splat(0),
+    peer_parameters_len: u16 = 0,
+    peer_parameters_seen: bool = false,
+
+    pub fn init(options: Options) Client {
+        return .{
+            .random = options.random,
+            // X25519 accepts any 32 octets as a private key: it clamps, and
+            // the only failure `generateDeterministic` reports is an identity
+            // element, which a seed cannot produce.
+            .key_pair = X25519.KeyPair.generateDeterministic(options.key_seed) catch unreachable,
+            .server_name = options.server_name,
+            .alpn = options.alpn,
+            .transport_parameters = options.transport_parameters,
+            .offer = options.offer,
+        };
+    }
+
+    // -------------------------------------------------------------- outbound
+
+    /// Write the ClientHello into `buffer` and fold it into the transcript.
+    /// The caller hands the result to `cryptoIn(.initial, ...)`.
+    pub fn clientHello(self: *Client, buffer: []u8) Error![]const u8 {
+        var out: Writer = .{ .buffer = buffer };
+
+        try out.byte(@intFromEnum(MessageType.client_hello));
+        const body = try out.beginLength(3);
+        {
+            // `legacy_version` is 1.2 on the wire for every TLS 1.3 hello; the
+            // real version is in `supported_versions`.
+            try out.int(u16, 0x0303);
+            try out.bytes(&self.random);
+            // RFC 9001 section 8.4: over QUIC the session ID is empty, because
+            // there is no middlebox to fool and no compatibility mode to enter.
+            try out.byte(0);
+
+            const suites = try out.beginLength(2);
+            for (self.offer) |one| try out.int(u16, @intFromEnum(one));
+            try out.endLength(suites);
+
+            // One compression method, `null`. TLS 1.3 permits nothing else.
+            try out.byte(1);
+            try out.byte(0);
+
+            const extensions = try out.beginLength(2);
+            try self.writeExtensions(&out);
+            try out.endLength(extensions);
+        }
+        try out.endLength(body);
+
+        const written = out.written();
+        self.transcript.update(written);
+        return written;
+    }
+
+    fn writeExtensions(self: *Client, out: *Writer) Error!void {
+        // server_name: a list of one, of type `host_name`.
+        try out.int(u16, @intFromEnum(Extension.server_name));
+        var extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(2);
+            try out.byte(0);
+            const name = try out.beginLength(2);
+            try out.bytes(self.server_name);
+            try out.endLength(name);
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // supported_groups: X25519 alone. See the module comment on HRR.
+        try out.int(u16, @intFromEnum(Extension.supported_groups));
+        extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(2);
+            try out.int(u16, group_x25519);
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // signature_algorithms. Required to be present and, since nothing here
+        // verifies a signature, its contents only have to be wide enough that
+        // no server refuses for lack of an algorithm it holds a certificate
+        // for. These are the five the runner's servers use between them.
+        try out.int(u16, @intFromEnum(Extension.signature_algorithms));
+        extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(2);
+            try out.int(u16, 0x0403); // ecdsa_secp256r1_sha256
+            try out.int(u16, 0x0503); // ecdsa_secp384r1_sha384
+            try out.int(u16, 0x0804); // rsa_pss_rsae_sha256
+            try out.int(u16, 0x0805); // rsa_pss_rsae_sha384
+            try out.int(u16, 0x0806); // rsa_pss_rsae_sha512
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // ALPN. RFC 9001 section 8.1 requires one over QUIC, and the runner
+        // decides which by test case.
+        try out.int(u16, @intFromEnum(Extension.alpn));
+        extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(2);
+            const protocol = try out.beginLength(1);
+            try out.bytes(self.alpn);
+            try out.endLength(protocol);
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // supported_versions: 1.3 alone.
+        try out.int(u16, @intFromEnum(Extension.supported_versions));
+        extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(1);
+            try out.int(u16, 0x0304);
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // key_share, so the handshake finishes in one round trip.
+        try out.int(u16, @intFromEnum(Extension.key_share));
+        extension = try out.beginLength(2);
+        {
+            const list = try out.beginLength(2);
+            try out.int(u16, group_x25519);
+            const key = try out.beginLength(2);
+            try out.bytes(&self.key_pair.public_key);
+            try out.endLength(key);
+            try out.endLength(list);
+        }
+        try out.endLength(extension);
+
+        // quic_transport_parameters, whose body the caller built with
+        // `transport_parameters.encode`. This is the extension docs/DESIGN.md
+        // section 4 says is assembled on this side of the seam.
+        try out.int(u16, @intFromEnum(Extension.quic_transport_parameters));
+        extension = try out.beginLength(2);
+        try out.bytes(self.transport_parameters);
+        try out.endLength(extension);
+    }
+
+    // --------------------------------------------------------------- inbound
+
+    /// Consume whole handshake messages from the front of `source`, returning
+    /// how many octets were taken. A partial message at the end is left for
+    /// the next call, which is why the caller passes `cryptoOut`'s slice and
+    /// then `cryptoConsumed`s exactly the return value.
+    pub fn read(self: *Client, level: Level, source: []const u8) Error!usize {
+        var offset: usize = 0;
+        // Bounded by `source`: every iteration consumes at least the four
+        // octets of a header, and the loop stops when fewer remain.
+        while (source.len - offset >= 4) {
+            const length = readInt(u24, source[offset + 1 ..][0..3]);
+            const total = 4 + @as(usize, length);
+            if (source.len - offset < total) break;
+            try self.message(level, source[offset..][0..total]);
+            offset += total;
+        }
+        return offset;
+    }
+
+    /// One message, header included. `body` below is the message without it.
+    fn message(self: *Client, level: Level, whole: []const u8) Error!void {
+        std.debug.assert(whole.len >= 4);
+        const kind: MessageType = @enumFromInt(whole[0]);
+        const body = whole[4..];
+
+        switch (kind) {
+            .server_hello => {
+                if (level != .initial) return error.Unsupported;
+                if (self.state != .wait_server_hello) return error.Unsupported;
+                try self.serverHello(body);
+                // The handshake traffic secrets read the transcript at
+                // `ClientHello .. ServerHello`, so the ServerHello goes in
+                // before they are derived and after it is parsed — the shared
+                // secret it carries is an input to the same derivation.
+                self.transcript.update(whole);
+                self.deriveHandshake();
+                self.state = .wait_encrypted_extensions;
+            },
+            .encrypted_extensions => {
+                if (level != .handshake) return error.Unsupported;
+                if (self.state != .wait_encrypted_extensions) return error.Unsupported;
+                self.transcript.update(whole);
+                try self.encryptedExtensions(body);
+                self.state = .wait_certificate;
+            },
+            .certificate_request => {
+                // RFC 9001 section 4.4 forbids post-handshake client
+                // authentication, and this client holds no certificate to
+                // answer one during the handshake either.
+                return error.Unsupported;
+            },
+            .certificate => {
+                if (level != .handshake) return error.Unsupported;
+                if (self.state != .wait_certificate) return error.Unsupported;
+                // Hashed and not read. See the module comment: the runner's CA
+                // is generated per run and every client in it trusts anything.
+                self.transcript.update(whole);
+                self.state = .wait_certificate_verify;
+            },
+            .certificate_verify => {
+                if (level != .handshake) return error.Unsupported;
+                if (self.state != .wait_certificate_verify) return error.Unsupported;
+                self.transcript.update(whole);
+                self.state = .wait_finished;
+            },
+            .finished => {
+                if (level != .handshake) return error.Unsupported;
+                if (self.state != .wait_finished) return error.Unsupported;
+                // Verified against `ClientHello .. CertificateVerify`, which is
+                // the transcript as it stands *before* this message joins it.
+                try self.verifyFinished(body);
+                self.transcript.update(whole);
+                // And everything after reads `ClientHello .. server Finished`.
+                self.deriveApplication();
+                self.writeFinished();
+                self.state = .established;
+            },
+            .new_session_ticket => {
+                // Post-handshake, at 1-RTT, and of no use to a client that
+                // does not resume. Discarded rather than refused: a server
+                // that sends two would otherwise fail a connection that is
+                // working.
+                if (level != .one_rtt) return error.Unsupported;
+                if (self.state != .established) return error.Unsupported;
+            },
+            else => return error.Unsupported,
+        }
+    }
+
+    fn serverHello(self: *Client, body: []const u8) Error!void {
+        var in: Reader = .{ .buffer = body };
+
+        if (try in.int(u16) != 0x0303) return error.Unsupported;
+        const random = try in.take(32);
+        if (std.mem.eql(u8, random, &hello_retry_request_random)) return error.Unsupported;
+        // RFC 9001 section 8.4: an empty session ID went out, so an empty one
+        // comes back.
+        if (try in.byte() != 0) return error.Unsupported;
+
+        const suite = try in.int(u16);
+        self.suite = for (self.offer) |one| {
+            if (@intFromEnum(one) == suite) break one;
+        } else return error.Unsupported;
+
+        if (try in.byte() != 0) return error.Unsupported; // compression
+
+        var version_seen = false;
+        var share: ?[]const u8 = null;
+        var extensions: Reader = .{ .buffer = try in.lengthPrefixed(2) };
+        // Bounded by the extensions block: `extension` consumes its own length
+        // every iteration.
+        while (!extensions.done()) {
+            const id: Extension = @enumFromInt(try extensions.int(u16));
+            const value = try extensions.lengthPrefixed(2);
+            switch (id) {
+                .supported_versions => {
+                    if (value.len != 2 or readInt(u16, value[0..2]) != 0x0304) return error.Unsupported;
+                    version_seen = true;
+                },
+                .key_share => {
+                    var one: Reader = .{ .buffer = value };
+                    if (try one.int(u16) != group_x25519) return error.Unsupported;
+                    share = try one.lengthPrefixed(2);
+                },
+                else => {},
+            }
+        }
+        // A ServerHello without `supported_versions` is a TLS 1.2 server, and
+        // RFC 9001 section 4.2 makes that fatal rather than a downgrade.
+        if (!version_seen) return error.Unsupported;
+
+        const public = share orelse return error.Unsupported;
+        if (public.len != share_octets) return error.Malformed;
+        const shared = X25519.scalarmult(self.key_pair.secret_key, public[0..share_octets].*) catch
+            return error.Unsupported; // An identity element: no shared secret exists.
+        self.shared = shared;
+    }
+
+    fn encryptedExtensions(self: *Client, body: []const u8) Error!void {
+        var extensions: Reader = .{ .buffer = try (Reader{ .buffer = body }).lengthPrefixedOf(2) };
+        // Bounded by the block, as in `serverHello`.
+        while (!extensions.done()) {
+            const id: Extension = @enumFromInt(try extensions.int(u16));
+            const value = try extensions.lengthPrefixed(2);
+            if (id != .quic_transport_parameters) continue;
+            if (value.len > self.peer_parameters.len) return error.TooLarge;
+            @memcpy(self.peer_parameters[0..value.len], value);
+            self.peer_parameters_len = @intCast(value.len);
+            self.peer_parameters_seen = true;
+        }
+        // RFC 9001 section 8.2 makes the extension mandatory in both
+        // directions, and a server that omits it has told this client nothing
+        // about its limits — including the ones it will enforce.
+        if (!self.peer_parameters_seen) return error.Unsupported;
+    }
+
+    fn verifyFinished(self: *Client, body: []const u8) Error!void {
+        var expected: [Hmac.mac_length]u8 = undefined;
+        self.finishedData(&self.server_handshake_traffic, &expected);
+        if (body.len != expected.len) return error.BadFinished;
+        // Constant-time, because this is a MAC comparison and the timing of a
+        // byte-by-byte one is the classic way to forge one.
+        if (!std.crypto.timing_safe.eql([Hmac.mac_length]u8, expected, body[0..Hmac.mac_length].*)) {
+            return error.BadFinished;
+        }
+    }
+
+    fn writeFinished(self: *Client) void {
+        var verify: [Hmac.mac_length]u8 = undefined;
+        self.finishedData(&self.client_handshake_traffic, &verify);
+        self.finished[0] = @intFromEnum(MessageType.finished);
+        writeInt(u24, self.finished[1..4], @intCast(verify.len));
+        @memcpy(self.finished[4..][0..verify.len], &verify);
+        self.finished_len = @intCast(4 + verify.len);
+        std.debug.assert(self.finished_len == self.finished.len);
+    }
+
+    /// RFC 8446 section 4.4.4's `verify_data`, over the transcript as it
+    /// stands.
+    fn finishedData(self: *Client, traffic: *const [secret_octets]u8, out: *[Hmac.mac_length]u8) void {
+        var key: [secret_octets]u8 = undefined;
+        expandLabel(&key, traffic, "finished", "");
+        var digest: [Hash.digest_length]u8 = undefined;
+        var copy = self.transcript;
+        copy.final(&digest);
+        Hmac.create(out, &digest, &key);
+    }
+
+    // -------------------------------------------------------- the schedule
+
+    /// RFC 8446 section 7.1, as far as the handshake traffic secrets.
+    fn deriveHandshake(self: *Client) void {
+        const zero: [secret_octets]u8 = @splat(0);
+        const early = Hkdf.extract(&.{}, &zero);
+        var derived: [secret_octets]u8 = undefined;
+        self.deriveSecretEmpty(&derived, &early, "derived");
+
+        self.handshake_secret = Hkdf.extract(&derived, &self.shared);
+        self.deriveSecret(&self.client_handshake_traffic, &self.handshake_secret, "c hs traffic");
+        self.deriveSecret(&self.server_handshake_traffic, &self.handshake_secret, "s hs traffic");
+
+        self.install(.handshake, .send, &self.client_handshake_traffic, "CLIENT_HANDSHAKE_TRAFFIC_SECRET");
+        self.install(.handshake, .receive, &self.server_handshake_traffic, "SERVER_HANDSHAKE_TRAFFIC_SECRET");
+    }
+
+    /// The rest of section 7.1: the master secret, and the two 1-RTT secrets
+    /// that QUIC turns into packet protection keys.
+    fn deriveApplication(self: *Client) void {
+        const zero: [secret_octets]u8 = @splat(0);
+        var derived: [secret_octets]u8 = undefined;
+        self.deriveSecretEmpty(&derived, &self.handshake_secret, "derived");
+        const master = Hkdf.extract(&derived, &zero);
+
+        var client_traffic: [secret_octets]u8 = undefined;
+        var server_traffic: [secret_octets]u8 = undefined;
+        self.deriveSecret(&client_traffic, &master, "c ap traffic");
+        self.deriveSecret(&server_traffic, &master, "s ap traffic");
+
+        self.install(.one_rtt, .send, &client_traffic, "CLIENT_TRAFFIC_SECRET_0");
+        self.install(.one_rtt, .receive, &server_traffic, "SERVER_TRAFFIC_SECRET_0");
+    }
+
+    /// `Derive-Secret(secret, label, Messages)` with `Messages` the transcript
+    /// so far.
+    fn deriveSecret(self: *Client, out: *[secret_octets]u8, secret: *const [secret_octets]u8, label: []const u8) void {
+        var digest: [Hash.digest_length]u8 = undefined;
+        var copy = self.transcript;
+        copy.final(&digest);
+        expandLabel(out, secret, label, &digest);
+    }
+
+    /// The same, with `Messages` empty — which is a different value from the
+    /// transcript being empty only because `Derive-Secret` hashes it either
+    /// way. Separate so the two cannot be confused at a call site.
+    fn deriveSecretEmpty(self: *Client, out: *[secret_octets]u8, secret: *const [secret_octets]u8, label: []const u8) void {
+        _ = self;
+        var digest: [Hash.digest_length]u8 = undefined;
+        Hash.hash("", &digest, .{});
+        expandLabel(out, secret, label, &digest);
+    }
+
+    fn install(self: *Client, level: Level, direction: @FieldType(Install, "direction"), secret: *const [secret_octets]u8, label: []const u8) void {
+        // Four is the whole handshake; a fifth would mean a state machine that
+        // derived a level twice.
+        std.debug.assert(self.installs_len < self.installs.len);
+        self.installs[self.installs_len] = .{
+            .level = level,
+            .direction = direction,
+            .secret = secret.*,
+            .suite = self.suite.quic(),
+            .label = label,
+        };
+        self.installs_len += 1;
+    }
+
+    /// Secrets produced since the last call, and none of them again.
+    pub fn drainInstalls(self: *Client) []const Install {
+        const out = self.installs[0..self.installs_len];
+        self.installs_len = 0;
+        return out;
+    }
+
+    /// The client's `Finished`, once, or an empty slice.
+    pub fn drainFinished(self: *Client) []const u8 {
+        const out = self.finished[0..self.finished_len];
+        self.finished_len = 0;
+        return out;
+    }
+
+    /// The server's transport parameters, once, or null.
+    pub fn drainTransportParameters(self: *Client) ?[]const u8 {
+        if (!self.peer_parameters_seen) return null;
+        self.peer_parameters_seen = false;
+        return self.peer_parameters[0..self.peer_parameters_len];
+    }
+};
+
+/// `HKDF-Expand-Label` from RFC 8446 section 7.1, with the "tls13 " prefix.
+/// QUIC's own labels go through `src/quic/crypto/secrets.zig` instead; this one
+/// is only ever used on the TLS side of the schedule.
+fn expandLabel(out: []u8, secret: *const [secret_octets]u8, label: []const u8, context: []const u8) void {
+    const prefix = "tls13 ";
+    // The longest label here is "s hs traffic" at twelve, and the longest
+    // context is a SHA-256 digest.
+    var info: [2 + 1 + prefix.len + 16 + 1 + Hash.digest_length]u8 = undefined;
+    std.debug.assert(label.len <= 16);
+    std.debug.assert(context.len <= Hash.digest_length);
+
+    var offset: usize = 0;
+    writeInt(u16, info[offset..][0..2], @intCast(out.len));
+    offset += 2;
+    info[offset] = @intCast(prefix.len + label.len);
+    offset += 1;
+    @memcpy(info[offset..][0..prefix.len], prefix);
+    offset += prefix.len;
+    @memcpy(info[offset..][0..label.len], label);
+    offset += label.len;
+    info[offset] = @intCast(context.len);
+    offset += 1;
+    @memcpy(info[offset..][0..context.len], context);
+    offset += context.len;
+
+    Hkdf.expand(out, info[0..offset], secret.*);
+}
+
+fn readInt(comptime T: type, source: *const [@divExact(@typeInfo(T).int.bits, 8)]u8) T {
+    return std.mem.readInt(T, source, .big);
+}
+
+fn writeInt(comptime T: type, target: *[@divExact(@typeInfo(T).int.bits, 8)]u8, value: T) void {
+    std.mem.writeInt(T, target, value, .big);
+}
+
+/// A cursor over a caller-owned buffer, with the length-prefix patching TLS
+/// needs: every structure in a hello is preceded by its own length, and the
+/// length is only known once the structure is written.
+const Writer = struct {
+    buffer: []u8,
+    offset: usize = 0,
+
+    const Pending = struct { at: usize, octets: u8 };
+
+    fn byte(self: *Writer, value: u8) Error!void {
+        if (self.offset + 1 > self.buffer.len) return error.TooLarge;
+        self.buffer[self.offset] = value;
+        self.offset += 1;
+    }
+
+    fn int(self: *Writer, comptime T: type, value: T) Error!void {
+        const octets = @divExact(@typeInfo(T).int.bits, 8);
+        if (self.offset + octets > self.buffer.len) return error.TooLarge;
+        writeInt(T, self.buffer[self.offset..][0..octets], value);
+        self.offset += octets;
+    }
+
+    fn bytes(self: *Writer, value: []const u8) Error!void {
+        if (self.offset + value.len > self.buffer.len) return error.TooLarge;
+        @memcpy(self.buffer[self.offset..][0..value.len], value);
+        self.offset += value.len;
+    }
+
+    /// Reserve `octets` for a length, to be filled in by `endLength`.
+    fn beginLength(self: *Writer, octets: u8) Error!Pending {
+        std.debug.assert(octets == 1 or octets == 2 or octets == 3);
+        if (self.offset + octets > self.buffer.len) return error.TooLarge;
+        const at = self.offset;
+        @memset(self.buffer[at..][0..octets], 0);
+        self.offset += octets;
+        return .{ .at = at, .octets = octets };
+    }
+
+    fn endLength(self: *Writer, pending: Pending) Error!void {
+        const length = self.offset - pending.at - pending.octets;
+        switch (pending.octets) {
+            1 => {
+                if (length > std.math.maxInt(u8)) return error.TooLarge;
+                self.buffer[pending.at] = @intCast(length);
+            },
+            2 => {
+                if (length > std.math.maxInt(u16)) return error.TooLarge;
+                writeInt(u16, self.buffer[pending.at..][0..2], @intCast(length));
+            },
+            3 => {
+                if (length > std.math.maxInt(u24)) return error.TooLarge;
+                writeInt(u24, self.buffer[pending.at..][0..3], @intCast(length));
+            },
+            else => unreachable, // `beginLength` asserts the width.
+        }
+    }
+
+    fn written(self: *const Writer) []const u8 {
+        return self.buffer[0..self.offset];
+    }
+};
+
+/// The reading half. Every accessor is bounds-checked against the buffer it was
+/// given, because a hello is peer-supplied and this file is the first thing in
+/// the tree to parse one.
+const Reader = struct {
+    buffer: []const u8,
+    offset: usize = 0,
+
+    fn done(self: *const Reader) bool {
+        return self.offset >= self.buffer.len;
+    }
+
+    fn byte(self: *Reader) Error!u8 {
+        if (self.offset + 1 > self.buffer.len) return error.Malformed;
+        defer self.offset += 1;
+        return self.buffer[self.offset];
+    }
+
+    fn int(self: *Reader, comptime T: type) Error!T {
+        const octets = @divExact(@typeInfo(T).int.bits, 8);
+        if (self.offset + octets > self.buffer.len) return error.Malformed;
+        defer self.offset += octets;
+        return readInt(T, self.buffer[self.offset..][0..octets]);
+    }
+
+    fn take(self: *Reader, count: usize) Error![]const u8 {
+        if (self.offset + count > self.buffer.len) return error.Malformed;
+        defer self.offset += count;
+        return self.buffer[self.offset..][0..count];
+    }
+
+    fn lengthPrefixed(self: *Reader, octets: u8) Error![]const u8 {
+        const length: usize = switch (octets) {
+            1 => try self.byte(),
+            2 => try self.int(u16),
+            3 => try self.int(u24),
+            else => unreachable, // Only these three widths appear in TLS.
+        };
+        return self.take(length);
+    }
+
+    /// `lengthPrefixed` on a temporary, for the one call site that reads a
+    /// prefix off the front of a message body and keeps only the contents.
+    fn lengthPrefixedOf(self: Reader, octets: u8) Error![]const u8 {
+        var copy = self;
+        return copy.lengthPrefixed(octets);
+    }
+};
+
+const testing = std.testing;
+
+test "the ClientHello parses as one handshake message of the length it declares" {
+    var buffer: [1024]u8 = undefined;
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &.{ 0x01, 0x02, 0x67, 0x10 },
+        .offer = &.{ .aes_128_gcm_sha256, .chacha20_poly1305_sha256 },
+        .random = @splat(0xa5),
+        .key_seed = @splat(0x5a),
+    });
+    const hello = try client.clientHello(&buffer);
+
+    try testing.expectEqual(@as(u8, @intFromEnum(MessageType.client_hello)), hello[0]);
+    try testing.expectEqual(hello.len - 4, readInt(u24, hello[1..4]));
+    try testing.expectEqual(@as(u16, 0x0303), readInt(u16, hello[4..6]));
+    // The session ID is empty, which RFC 9001 section 8.4 requires over QUIC.
+    try testing.expectEqual(@as(u8, 0), hello[38]);
+}
+
+test "the ClientHello carries the transport parameters it was given" {
+    var buffer: [1024]u8 = undefined;
+    const parameters = [_]u8{ 0x0f, 0x04, 0xde, 0xad, 0xbe, 0xef };
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &parameters,
+        .offer = &.{.aes_128_gcm_sha256},
+        .random = @splat(0),
+        .key_seed = @splat(1),
+    });
+    const hello = try client.clientHello(&buffer);
+    // Extension 57, its length, and then the body verbatim.
+    const wanted = [_]u8{ 0x00, 0x39, 0x00, parameters.len } ++ parameters;
+    try testing.expect(std.mem.indexOf(u8, hello, &wanted) != null);
+}
+
+test "a buffer too small for the ClientHello is refused rather than truncated" {
+    var buffer: [16]u8 = undefined;
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &.{},
+        .offer = &.{.aes_128_gcm_sha256},
+        .random = @splat(0),
+        .key_seed = @splat(1),
+    });
+    try testing.expectError(error.TooLarge, client.clientHello(&buffer));
+}
+
+test "a partial handshake message is left for the next call" {
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &.{},
+        .offer = &.{.aes_128_gcm_sha256},
+        .random = @splat(0),
+        .key_seed = @splat(1),
+    });
+    // A ServerHello header claiming 64 octets, with two of them present.
+    const partial = [_]u8{ 0x02, 0x00, 0x00, 0x40, 0x03, 0x03 };
+    try testing.expectEqual(@as(usize, 0), try client.read(.initial, &partial));
+    // And a header that is itself incomplete.
+    try testing.expectEqual(@as(usize, 0), try client.read(.initial, partial[0..3]));
+}
+
+test "a HelloRetryRequest is refused by name rather than parsed as a ServerHello" {
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &.{},
+        .offer = &.{.aes_128_gcm_sha256},
+        .random = @splat(0),
+        .key_seed = @splat(1),
+    });
+    var message: [4 + 2 + 32 + 1]u8 = @splat(0);
+    message[0] = @intFromEnum(MessageType.server_hello);
+    writeInt(u24, message[1..4], message.len - 4);
+    writeInt(u16, message[4..6], 0x0303);
+    @memcpy(message[6..38], &hello_retry_request_random);
+    try testing.expectError(error.Unsupported, client.read(.initial, &message));
+}
+
+test "a message arriving at the wrong encryption level is refused" {
+    var client: Client = .init(.{
+        .server_name = "server4",
+        .alpn = "hq-interop",
+        .transport_parameters = &.{},
+        .offer = &.{.aes_128_gcm_sha256},
+        .random = @splat(0),
+        .key_seed = @splat(1),
+    });
+    // EncryptedExtensions belongs at Handshake; RFC 8446 puts nothing but the
+    // ServerHello at Initial.
+    const message = [_]u8{ 0x08, 0x00, 0x00, 0x02, 0x00, 0x00 };
+    try testing.expectError(error.Unsupported, client.read(.initial, &message));
+}
+
+test "expandLabel reproduces RFC 8448's derived secret" {
+    // RFC 8448 section 3, the "derived" secret of the early stage: the input
+    // is the early secret of a zero PSK and the context is the hash of the
+    // empty string. Both are constants of TLS 1.3 rather than of a session,
+    // which is what makes them a usable vector for a handshake with no peer.
+    const zero: [secret_octets]u8 = @splat(0);
+    const early = Hkdf.extract(&.{}, &zero);
+    const early_expected = [_]u8{
+        0x33, 0xad, 0x0a, 0x1c, 0x60, 0x7e, 0xc0, 0x3b, 0x09, 0xe6, 0xcd, 0x98,
+        0x93, 0x68, 0x0c, 0xe2, 0x10, 0xad, 0xf3, 0x00, 0xaa, 0x1f, 0x26, 0x60,
+        0xe1, 0xb2, 0x2e, 0x10, 0xf1, 0x70, 0xf9, 0x2a,
+    };
+    try testing.expectEqualSlices(u8, &early_expected, &early);
+
+    var digest: [Hash.digest_length]u8 = undefined;
+    Hash.hash("", &digest, .{});
+    var derived: [secret_octets]u8 = undefined;
+    expandLabel(&derived, &early, "derived", &digest);
+    const derived_expected = [_]u8{
+        0x6f, 0x26, 0x15, 0xa1, 0x08, 0xc7, 0x02, 0xc5, 0x67, 0x8f, 0x54, 0xfc,
+        0x9d, 0xba, 0xb6, 0x97, 0x16, 0xc0, 0x76, 0x18, 0x9c, 0x48, 0x25, 0x0c,
+        0xeb, 0xea, 0xc3, 0x57, 0x6c, 0x36, 0x11, 0xba,
+    };
+    try testing.expectEqualSlices(u8, &derived_expected, &derived);
+}
+
+/// `Derive-Secret(secret, label, Messages)` over a transcript, shared by both
+/// roles. A free function rather than a method, because `Client` and `Server`
+/// hold the same schedule and only differ in which secret goes which way.
+fn deriveSecret(
+    transcript: *const Hash,
+    out: *[secret_octets]u8,
+    secret: *const [secret_octets]u8,
+    label: []const u8,
+) void {
+    var digest: [Hash.digest_length]u8 = undefined;
+    var copy = transcript.*;
+    copy.final(&digest);
+    expandLabel(out, secret, label, &digest);
+}
+
+fn deriveSecretEmpty(out: *[secret_octets]u8, secret: *const [secret_octets]u8, label: []const u8) void {
+    var digest: [Hash.digest_length]u8 = undefined;
+    Hash.hash("", &digest, .{});
+    expandLabel(out, secret, label, &digest);
+}
+
+/// RFC 8446 section 4.4.4's `verify_data`, over a transcript.
+fn finishedData(
+    transcript: *const Hash,
+    traffic: *const [secret_octets]u8,
+    out: *[Hmac.mac_length]u8,
+) void {
+    var key: [secret_octets]u8 = undefined;
+    expandLabel(&key, traffic, "finished", "");
+    var digest: [Hash.digest_length]u8 = undefined;
+    var copy = transcript.*;
+    copy.final(&digest);
+    Hmac.create(out, &digest, &key);
+}

--- a/src/runner.zig
+++ b/src/runner.zig
@@ -10,6 +10,7 @@ const net = std.Io.net;
 
 const cli = @import("cli.zig");
 const connection = @import("connection.zig");
+const h3conn = @import("h3conn.zig");
 const httpmod = @import("http.zig");
 const pace = @import("pace.zig");
 const stats = @import("stats.zig");
@@ -106,12 +107,21 @@ pub fn run(
     // no encoder state, so replaying the same octets on every stream of every
     // connection is byte-identical to encoding it each time.
     const request_block = if (cfg.http2) try httpmod.buildRequestBlock(arena, cfg) else &[_]u8{};
+    // The HTTP/3 half of the same trade: one QPACK HEADERS frame (and a DATA
+    // frame when there is a body), built once and replayed byte-identically on
+    // every stream of every connection. See `h3conn.buildRequest`.
+    const h3_request = if (cfg.http3) try h3conn.buildRequest(arena, cfg) else &[_]u8{};
     const address = try resolveAddress(io, cfg.url.host, cfg.url.port);
 
     // Load the system trust store once (shared, read-mostly) for HTTPS
     // with verification enabled.
+    //
+    // Not for `--http3`: that path terminates TLS through `quic_tls.zig`,
+    // which does not verify certificates at all — which is why `cli.zig`
+    // requires `--insecure` for it, so this branch is unreachable there rather
+    // than merely unused.
     var ca_store: ?tlsmod.CaStore = null;
-    if (cfg.url.isTls() and !cfg.insecure) {
+    if (cfg.url.isTls() and !cfg.insecure and !cfg.http3) {
         ca_store = try tlsmod.CaStore.load(arena, io);
     }
     const ca_ptr: ?*tlsmod.CaStore = if (ca_store) |*c| c else null;
@@ -123,7 +133,15 @@ pub fn run(
     // repaints every frame but the numbers behind it are only as fresh as the
     // last publish.
     const publish_ns = if (frame_interval_ns > 0) @min(frame_interval_ns, cfg.interval_ns) else cfg.interval_ns;
-    var fleet = try stats.Fleet.init(arena, cfg.connections, publish_ns, cfg.url.isTls());
+    // `enable_tls` is zssl's per-connection block, which the HTTP/3 path does
+    // not use: QUIC's handshake state lives inside `h3conn.State` instead.
+    var fleet = try stats.Fleet.init(
+        arena,
+        cfg.connections,
+        publish_ns,
+        cfg.url.isTls() and !cfg.http3,
+        cfg.http3,
+    );
     defer fleet.deinit();
 
     // Merging the fleet's per-connection histograms is O(connections) and does
@@ -158,6 +176,8 @@ pub fn run(
         .request_block = request_block,
         .body = cfg.body,
         .http2 = cfg.http2,
+        .http3 = cfg.http3,
+        .h3_request = h3_request,
         .streams = cfg.streams,
         .method = .of(cfg.method),
         .is_tls = cfg.url.isTls(),

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -15,6 +15,7 @@ const Allocator = std.mem.Allocator;
 
 const hdr = @import("hdr.zig");
 const connection = @import("connection.zig");
+const h3conn = @import("h3conn.zig");
 const tlsmod = @import("tls.zig");
 
 /// Latency histogram configuration: 1µs .. 60s at 3 significant figures.
@@ -61,8 +62,19 @@ pub const Fleet = struct {
     params: []connection.Params,
     /// Per-connection TLS state, allocated only for HTTPS targets.
     tls_state: ?[]tlsmod.State,
+    /// Per-connection QUIC/HTTP-3 transport state, allocated only for
+    /// `--http3`. Megabytes apiece rather than kilobytes — see
+    /// `h3conn.footprint_octets` — which is exactly why it is allocated here,
+    /// once for the run, and not on a coroutine's frame per reconnect.
+    h3_state: ?[]h3conn.State,
 
-    pub fn init(allocator: Allocator, n: u32, publish_interval_ns: u64, enable_tls: bool) !Fleet {
+    pub fn init(
+        allocator: Allocator,
+        n: u32,
+        publish_interval_ns: u64,
+        enable_tls: bool,
+        enable_h3: bool,
+    ) !Fleet {
         const live_hist = try allocator.alloc(hdr.Histogram, n);
         errdefer allocator.free(live_hist);
         const live_counters = try allocator.alloc(connection.Counters, n);
@@ -79,6 +91,11 @@ pub const Fleet = struct {
         // decide whether a previous session needs tearing down, so nothing may
         // touch one before this runs.
         if (tls_state) |ts| for (ts) |*state| state.init();
+        const h3_state: ?[]h3conn.State = if (enable_h3) try allocator.alloc(h3conn.State, n) else null;
+        errdefer if (h3_state) |hs| allocator.free(hs);
+        // Same contract as `tls_state` above: the block arrives undefined and
+        // nothing may read a field before this runs.
+        if (h3_state) |hs| for (hs) |*state| state.init();
 
         var live_inited: usize = 0;
         errdefer for (live_hist[0..live_inited]) |*h| h.deinit();
@@ -106,6 +123,7 @@ pub const Fleet = struct {
             .publish = publish,
             .params = params,
             .tls_state = tls_state,
+            .h3_state = h3_state,
         };
     }
 
@@ -126,6 +144,7 @@ pub const Fleet = struct {
             p.publish = &self.publish[i];
             p.phase = @as(f64, @floatFromInt(i)) / n;
             if (self.tls_state) |ts| p.tls_state = &ts[i];
+            if (self.h3_state) |hs| p.h3_state = &hs[i];
         }
         return self.params;
     }
@@ -170,6 +189,9 @@ pub const Fleet = struct {
             for (ts) |*state| state.deinit();
             self.allocator.free(ts);
         }
+        // Nothing to tear down per state: `h3conn.State` owns no handle and no
+        // allocation — the transport's whole memory is the block itself.
+        if (self.h3_state) |hs| self.allocator.free(hs);
     }
 };
 
@@ -312,7 +334,7 @@ test "the default histogram's footprint stays within budget" {
 }
 
 test "fleet aggregates live counters and histograms" {
-    var fleet = try Fleet.init(testing.allocator, 3, std.time.ns_per_s, false);
+    var fleet = try Fleet.init(testing.allocator, 3, std.time.ns_per_s, false, false);
     defer fleet.deinit();
 
     // Simulate each connection having done some work.
@@ -334,7 +356,7 @@ test "fleet aggregates live counters and histograms" {
 test "Fleet.init leaks nothing when any allocation fails" {
     try testing.checkAllAllocationFailures(testing.allocator, struct {
         fn initAndDeinit(allocator: Allocator) !void {
-            var fleet = try Fleet.init(allocator, 3, std.time.ns_per_s, true);
+            var fleet = try Fleet.init(allocator, 3, std.time.ns_per_s, true, false);
             fleet.deinit();
         }
     }.initAndDeinit, .{});
@@ -345,7 +367,7 @@ test "readSnapshot reflects published state" {
     defer rt.deinit();
     const io = rt.io();
 
-    var fleet = try Fleet.init(testing.allocator, 2, std.time.ns_per_s, false);
+    var fleet = try Fleet.init(testing.allocator, 2, std.time.ns_per_s, false, false);
     defer fleet.deinit();
 
     // Publish some values into each connection's snapshot slot directly.
@@ -367,7 +389,7 @@ test "Sweeper returns the same aggregate as an inline readSnapshot" {
     defer rt.deinit();
     const io = rt.io();
 
-    var fleet = try Fleet.init(testing.allocator, 8, std.time.ns_per_s, false);
+    var fleet = try Fleet.init(testing.allocator, 8, std.time.ns_per_s, false, false);
     defer fleet.deinit();
     for (fleet.publish, 0..) |*p, i| {
         p.hist.record(1000 * (@as(u64, @intCast(i)) + 1));
@@ -403,7 +425,7 @@ test "each Sweeper.snapshot waits for a merge newer than the request" {
     defer rt.deinit();
     const io = rt.io();
 
-    var fleet = try Fleet.init(testing.allocator, 4, std.time.ns_per_s, false);
+    var fleet = try Fleet.init(testing.allocator, 4, std.time.ns_per_s, false, false);
     defer fleet.deinit();
 
     var sweeper = try Sweeper.init(testing.allocator, &fleet, io);
@@ -432,7 +454,7 @@ test "Sweeper stops cleanly when no snapshot was ever taken" {
     var rt = try zio.Runtime.init(testing.allocator, .{});
     defer rt.deinit();
 
-    var fleet = try Fleet.init(testing.allocator, 2, std.time.ns_per_s, false);
+    var fleet = try Fleet.init(testing.allocator, 2, std.time.ns_per_s, false, false);
     defer fleet.deinit();
 
     var sweeper = try Sweeper.init(testing.allocator, &fleet, rt.io());


### PR DESCRIPTION
`zrk --http3 -k https://host/path` runs a load test over HTTP/3 through zoxy-io/h3. `-c`, the pacing and every latency number keep the meaning they have on the other two transports: the anchoring, the closed-form schedule offset, the lag gauge, `--deadline` shedding and the coordinated-omission correction are the same steps in the same order as `connection.zig`, reading the same clock.

HTTP/3 is not a codec swap, so this is not one. Both existing transports block on a read while some other layer runs the transport; here QUIC *is* the transport, and a connection with nothing to receive still has to send — acknowledgements, probes, retransmissions — so a blocked read is a stalled congestion controller. `h3conn.zig` inverts the loop: it computes the earliest of the next scheduled send, the QUIC loss timer, the earliest in-flight request's bound and the run's end, and sleeps in `receiveTimeout` until then. One coroutine per connection and no locks, because the socket read and the pacing wait are the same wait.

`quic_tls.zig` is a TLS 1.3 client in QUIC mode, vendored from h3's interop shim. zssl declines QUIC, and QUIC does not want a TLS record layer at all — RFC 9001 section 4 replaces it, so there was nothing to drive zssl through. It does not verify certificates, which is why `--http3` requires `-k/--insecure`: the gap is stated rather than left for a run to discover. Closing it is bounded work and the file says what is missing.

`http.zig` grows a transport-neutral `Field` and `buildRequestFields`. h2 vendors its own HPACK and h3 depends on zoxy-io/hpack, so the two encoders' field types are distinct nominal types of identical shape — and the rules deciding *which* fields a request carries are not rules to write twice.

Two defects found while soaking it, both this file's:

  * A completed response is visible only as an absence. The transport retires a stream once its FIN and last octets are consumed, sometimes before any `finished` event is produced, so a 17-octet response completed and a 4 KiB one hung. A sweep over the slots answers it.
  * A finished request stream must not go back to `Http3`: it re-announces the FIN every pass, and `receive` allocates a request-table entry for whatever identifier it is given before deciding what to say about it. The table filled and the connection answered `H3_EXCESSIVE_LOAD` to itself on 1.9% of requests.

And a third that was not ours, recorded in `h3conn.zig` because the symptom looked like it was: h3 truncated the acknowledged packets' contexts at thirty-two while `Recovery` tracked `sent_max` of them, so once the congestion window grew past that, the streams named by the dropped contexts were never settled, never retired, and — retirement walking a contiguous watermark — pinned every stream above them. A multiplexed connection ran at full rate for about a second and then went to zero req/s reporting no errors. Fixed in zoxy-io/h3#1, and `build.zig.zon` pins the commit that fixes it: below that commit `--streams` above 1 does not work, so the pin is what makes multiplexed HTTP/3 work rather than a version bump.

Verified against quic-go's interop server, and against the *fetched* h3 package rather than the working tree: paced and closed-loop, bodies and bodiless, multiplexed depth, the JSON summary, and target restarts mid-run — a three-second outage costs one connect, one read and one timeout error per connection and the run catches its backlog up. A `-c 16 -s 16 --closed` soak runs 210,772 requests at 14.1k req/s and 55.9 MiB/s with no errors, where before the upstream fix it managed 1,642 before stalling.

Two things are still worth knowing before quoting a number from this, and the README says both.

**It does not verify certificates**, so `--http3` requires `-k/--insecure`. Deliberate rather than pending: a load generator is pointed at a target its operator chose, and HTTP/1.1 and HTTP/2 still verify by default with `-k` opt-in, so the case where that is not enough is covered on the transports that can cover it.

**It is one datagram per syscall**, which bounds throughput per core and nothing else. #76 carries that work. It is larger than the API surface suggests, and the PR's first draft said the opposite: `std.Io.net.Socket` has `sendMany` and `receiveManyTimeout`, but zio implements the first as a `for` loop over `sendmsg` and the second one `recvmsg` at a time, and nothing in the stack exposes `UDP_SEGMENT` or `UDP_GRO`. The batched API is there; the batching is not, and closing that is plumbing in a dependency rather than a call-site change here.

The first CI run on this branch is red, and honestly so: `eff4bd1` still named h3 by local path, which builds nowhere but the machine it was written on. `da6776d` replaces it with the pin.

Closes #74. The batching half of that issue moves to #76, where it can be measured on its own terms rather than holding open an issue whose main ask — HTTP/3 in zrk at all — this delivers.
