### PR TITLE
release: prereleases are marked, and stay off the tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,15 @@ name: Release
 # packages, gathers and checksums exactly as a real release does, then stops
 # before publishing anything or touching the tap. Use it after editing this
 # file.
+#
+# A tag whose version carries a semver prerelease — `v3.0.0-alpha.1`, anything
+# with a `-` after the version — is published as a GitHub prerelease and does
+# **not** touch the Homebrew tap. The tap holds one formula and `brew upgrade`
+# reads it, so publishing an alpha there hands it to every stable user; and
+# `livecheck`'s `:github_latest` strategy skips prereleases, so a stable
+# formula left alone keeps pointing at the last stable release. Prereleases
+# ship as downloadable archives and nothing else, which is what a prerelease
+# is for.
 on:
   push:
     tags: ['v*']
@@ -37,14 +46,27 @@ jobs:
       tag: ${{ steps.ver.outputs.tag }}
       version: ${{ steps.ver.outputs.version }}
       dry: ${{ steps.ver.outputs.dry }}
+      prerelease: ${{ steps.ver.outputs.prerelease }}
     steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
       - name: Resolve version
         id: ver
         run: |
           set -euo pipefail
           ref="${{ github.event.inputs.tag || github.ref_name }}"
+          version="${ref#v}"
           echo "tag=$ref" >> "$GITHUB_OUTPUT"
-          echo "version=${ref#v}" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Semver: everything after the first `-` is the prerelease
+          # identifier. `3.0.0` has none, `3.0.0-alpha.1` does.
+          case "$version" in
+            *-*) echo "prerelease=true"  >> "$GITHUB_OUTPUT"
+                 echo "::notice::$ref is a prerelease — GitHub prerelease, no tap" ;;
+            *)   echo "prerelease=false" >> "$GITHUB_OUTPUT" ;;
+          esac
           # On `push` there are no inputs at all, so this is empty and the
           # release is real. Only an explicit dispatch can ask for a dry run.
           # The publish steps gate on `dry == 'false'` rather than
@@ -57,6 +79,27 @@ jobs:
           else
             echo "dry=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # The tag names the artifacts; build.zig.zon is what `zrk --version`
+      # prints. Nothing made the two agree, and until now one thing caught it
+      # late: the Homebrew formula's `assert_match version.to_s` against
+      # `zrk --version`, on install. A prerelease does not go to the tap, so
+      # that backstop is gone for exactly the releases most likely to be cut in
+      # a hurry — which is why the check moves here, before anything is built.
+      - name: Tag and manifest agree
+        run: |
+          set -euo pipefail
+          version="${{ steps.ver.outputs.version }}"
+          # The only `.version` in the file: a dependency entry carries a `.url`
+          # and a `.hash`, never a version.
+          manifest=$(sed -n 's/^[[:space:]]*\.version = "\(.*\)",$/\1/p' build.zig.zon | head -1)
+          [ -n "$manifest" ] || { echo "no .version in build.zig.zon"; exit 1; }
+          if [ "$manifest" != "$version" ]; then
+            echo "tag says $version, build.zig.zon says $manifest" >&2
+            echo "bump .version in build.zig.zon to match the tag" >&2
+            exit 1
+          fi
+          echo "tag and manifest agree on $version"
 
   # Zig cross-compiles any target from any host, so these could all run on one
   # runner — and did, serially, for 15 minutes. Each leg builds BoringSSL from
@@ -168,9 +211,18 @@ jobs:
           files: dist/*
           body_path: ${{ steps.notes.outputs.path }}
           generate_release_notes: ${{ steps.notes.outputs.generate }}
+          # GitHub declines to call a prerelease "Latest" on its own, so this
+          # one flag is also what keeps the README's "latest release binary"
+          # link, and the stable formula's `:github_latest` livecheck, pointing
+          # at the last stable release.
+          prerelease: ${{ needs.version.outputs.prerelease }}
 
+      # Not for a prerelease: the tap holds one formula, `brew upgrade` reads
+      # it, and an alpha written there is an alpha handed to every stable user.
+      # `zrk-alpha` as a second formula is the shape that would let both exist,
+      # and it is not built here — a prerelease ships as archives.
       - name: Update Homebrew formula
-        if: needs.version.outputs.dry == 'false'
+        if: needs.version.outputs.dry == 'false' && needs.version.outputs.prerelease == 'false'
         env:
           HOMEBREW_TAP_DEPLOY_KEY: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
         run: |
@@ -258,7 +310,17 @@ jobs:
           count=$(grep -c '\.tar\.gz$' assets.txt)
           [ "$count" -eq 4 ] || { echo "expected 4 archives on $tag, found $count"; exit 1; }
           grep -qx 'SHA256SUMS.txt' assets.txt || { echo "no SHA256SUMS.txt on $tag"; exit 1; }
-          echo "$tag published with 4 archives and checksums"
+
+          # The same reasoning as the comment above, applied to the flag that
+          # decides who gets this build. `prerelease` is passed to an action
+          # rather than acted on here, so nothing else would notice it being
+          # dropped — and a prerelease published as a normal release is one
+          # `brew upgrade` away from being everyone's problem.
+          want="${{ needs.version.outputs.prerelease }}"
+          got=$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease')
+          [ "$got" = "$want" ] || { echo "$tag: isPrerelease is $got, expected $want"; exit 1; }
+
+          echo "$tag published with 4 archives and checksums, prerelease=$got"
 
       - name: Dry run summary
         if: needs.version.outputs.dry == 'true'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ A constant-throughput HTTP load generator — a Zig 0.16 rewrite of
 brew install zoxy-io/tap/zrk
 ```
 
+The tap follows stable releases only. A prerelease — `v3.0.0-alpha.1` and
+anything else with a `-` in its version — is published to
+[Releases](https://github.com/zoxy-io/zrk/releases) as archives and is
+deliberately not written to the tap, because the tap holds one formula and
+`brew upgrade` reads it. Take a prerelease from the download below.
+
 ### Pre-built binary
 
 Download the latest release binary from the [Releases page](https://github.com/zoxy-io/zrk/releases).

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zrk,
-    .version = "2.5.0",
+    .version = "3.0.0-alpha.1",
     .fingerprint = 0x614e97303b45a75a, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{


### PR DESCRIPTION
Two changes to `release.yml`, and a version bump so the first prerelease can be cut.

**A prerelease is marked as one, and stays off the tap.** A tag whose version carries a semver prerelease identifier — anything with a `-` after the version — is published as a GitHub prerelease, and the Homebrew step is skipped.

The tap is the reason. It holds a single `Formula/zrk.rb`, the release job overwrites it unconditionally, and `brew upgrade` reads it — so an alpha written there is an alpha handed to every stable user. Leaving it alone also keeps the stable formula's `livecheck` correct for free: `:github_latest` reads the endpoint that skips prereleases, so it goes on pointing at the last stable release without needing to know this rule exists. And GitHub will not call a prerelease "Latest" on its own, so the one `prerelease` flag is also what keeps the README's "latest release binary" link honest.

The skip is written `prerelease == 'false'` rather than `!= 'true'`, so an output that went missing skips the tap rather than writing to it — the direction the existing `dry` guard already errs in, and for the same reason. The published release is then checked for the flag it was meant to get, because `prerelease` is handed to an action rather than acted on in the job, and nothing else would notice it being dropped.

**The tag and the manifest have to agree.** `zrk --version` comes from `build.zig.zon`; the artifact names come from the tag. Nothing made them agree, and the one thing that caught a mismatch caught it late and elsewhere — the Homebrew formula's `assert_match version.to_s, shell_output("#{bin}/zrk --version")`, on install. That is precisely the backstop a prerelease no longer has, so the check moves into the `version` job, before anything is built.

**`build.zig.zon` goes to `3.0.0-alpha.1`**, which the new guard now requires before the matching tag can be cut. Zig accepts a semver prerelease there; `zrk --version` prints `3.0.0-alpha.1`.

Why 3.0.0 rather than 2.6.0, since `--http3` is additive at the CLI: `stats.Fleet.init` gained two parameters in #75 and `stats` is exported from `root.zig`, so an embedder calling it breaks. `docs/library.md` only documents `runner.run`, whose signature is unchanged, so this is a judgement call rather than a forced one.

Verified: `actionlint` clean (the two shellcheck infos it reports are pre-existing, in the Checksum step), the manifest-extraction `sed` checked against the real file, and the guard rehearsed in both directions — matching tag passes, mismatched tag fails.

Not rehearsable before merge: the prerelease branch itself, which needs a prerelease tag to exist, which is the thing it gates. Failing safe is what covers that — a missing output skips the tap. The plan is a `dry_run` dispatch against `v2.5.0` after this merges, to confirm the stable path and the new guard, and then the real tag.
