### PR TITLE
docs: release notes for v3.0.0-alpha.1

### DIFF
--- a/docs/releases/v3.0.0-alpha.1.md
+++ b/docs/releases/v3.0.0-alpha.1.md
@@ -1,0 +1,86 @@
+The first alpha of v3.0.0, and the first zrk that speaks HTTP/3.
+
+**This is a prerelease.** It is not on the Homebrew tap and `brew upgrade` will
+not offer it — the tap holds one formula and stable users read it. Take an
+archive from the assets below.
+
+## `--http3`
+
+```sh
+zrk --http3 -k -c 10 -R 2000 -d 30s https://127.0.0.1:4433/
+```
+
+HTTP/3 over QUIC, through [h3](https://github.com/zoxy-io/h3). Every number it
+reports means what it means on the other two transports: the anchoring, the
+closed-form schedule offset, the backlog gauge, `--deadline` shedding and the
+coordinated-omission correction are the same code reading the same clock. `-c`
+is still the number to compare across runs, `-s` works as it does under
+`--http2`, and `--closed`, ramps, `--timeseries`, the JSON summary and the CI
+gates all carry over unchanged.
+
+What is *not* shared is the loop underneath. The HTTP/1.1 and HTTP/2 paths
+block on a read while the kernel and zssl run the transport between them. Here
+QUIC is the transport, and a connection with nothing to receive still has to
+send — acknowledgements, probes, retransmissions — so a blocked read is a
+stalled congestion controller. The HTTP/3 connection instead computes the
+earliest of the next scheduled send, the QUIC loss timer, the earliest
+in-flight request's bound and the run's end, and sleeps until then. One
+coroutine per connection, no locks, because the socket read and the pacing wait
+are the same wait.
+
+## Why it is an alpha
+
+Two things, and the README says both.
+
+**It does not verify certificates**, so `--http3` requires `-k/--insecure`
+rather than letting a run believe otherwise. QUIC needs a TLS engine that
+speaks RFC 9001 §4's handshake rather than a record layer, and zssl declines
+QUIC, so this path carries its own small client. That is a deliberate trade for
+a tool pointed at a target its operator chose — HTTP/1.1 and HTTP/2 still
+verify by default — and [#77](https://github.com/zoxy-io/zrk/issues/77) is the
+work to close it.
+
+**It is one datagram per syscall**, which bounds throughput per core and
+nothing else. [#76](https://github.com/zoxy-io/zrk/issues/76) is that work, and
+it is larger than the API surface suggests: `std.Io.net.Socket` has `sendMany`
+and `receiveManyTimeout`, but zio implements the first as a loop over `sendmsg`
+and the second one `recvmsg` at a time, and nothing in the stack exposes
+`UDP_SEGMENT` or `UDP_GRO`. The batched API is there; the batching is not.
+
+Neither affects whether a measurement is *correct* — they affect what it costs
+and what it proves about the peer's identity.
+
+## A defect this found in h3
+
+Worth reading if you use `-s` above 1 on any transport, because the symptom is
+one to recognise: a multiplexed connection running at full rate for about a
+second and then going to **zero** requests a second, with no error reported on
+either side, for the rest of the run.
+
+h3 handed its loss detector a fixed 32-entry array for the contexts of
+acknowledged packets while the detector tracked `sent_max` of them, and clamped
+its writes to whatever slice it was given. An acknowledgement retiring more
+than thirty-two packets — routine once the congestion window has grown —
+reported a prefix. The streams named by the dropped contexts were never
+settled, never retired, and because retirement walks a contiguous watermark,
+one stranded stream pinned every stream above it until the table was full.
+
+Fixed in [zoxy-io/h3#1](https://github.com/zoxy-io/h3/pull/1), and this release
+pins the commit that fixes it. A `-c 16 -s 16 --closed` soak now runs 296,866
+requests at 14.8k req/s and 59 MiB/s with no errors, where before it managed
+1,642 before stalling.
+
+## Why 3.0.0
+
+At the CLI this is additive: a new flag, and nothing that changed meaning. The
+break is in the library surface — `stats.Fleet.init` gained two parameters, and
+`stats` is exported from the root module, so an embedder calling it directly
+needs a change. `runner.run`, which is what `docs/library.md` documents, is
+unchanged.
+
+## Verified against
+
+quic-go's interop server: paced and closed-loop, with and without request
+bodies, multiplexed depth, the JSON summary, and target restarts mid-run — a
+three-second outage costs one connect, one read and one timeout error per
+connection, and the run catches its backlog up.


### PR DESCRIPTION
Curated notes for the tag, which `release.yml` picks up in place of a generated commit list. Covers what `--http3` is, the two reasons it is an alpha with their tracking issues, the h3 defect this found and the soak numbers, why the major bump, and — where someone will actually read it — that a prerelease is not on the Homebrew tap.